### PR TITLE
docs: add rules API route docstrings

### DIFF
--- a/backend/api/rules_api.py
+++ b/backend/api/rules_api.py
@@ -12,6 +12,18 @@ rules_bp = Blueprint("rules_api", __name__, url_prefix="/api/rules")
 
 @rules_bp.route("", methods=["GET"])
 def get_rules():
+    """List rules, optionally filtered by project, type, or active status.
+
+    Query parameters:
+        project_id: Optional project id used to return rules linked to that project.
+        type: Optional rule type filter, such as COMMAND_RULE.
+        is_active: Optional boolean-like active-state filter.
+        page: Optional page number, defaulting to 1.
+        per_page: Optional page size capped at 100, defaulting to 50.
+
+    Returns:
+        A JSON array of rule objects ordered by most recent update.
+    """
     try:
         project_id_filter = request.args.get("project_id", type=int)
         query = db.session.query(Rule)
@@ -46,6 +58,15 @@ def get_rules():
 
 @rules_bp.route("/<int:rule_id>", methods=["GET"])
 def get_rule(rule_id):
+    """Return one rule by id.
+
+    Path parameters:
+        rule_id: Database id of the rule to retrieve.
+
+    Returns:
+        A standard success envelope containing the serialized rule, or a
+        NOT_FOUND error when the rule does not exist.
+    """
     rule = db.session.get(Rule, rule_id)
     if not rule:
         return error_response("Rule not found", 404, "NOT_FOUND")
@@ -54,6 +75,19 @@ def get_rule(rule_id):
 
 @rules_bp.route("", methods=["POST"])
 def create_rule():
+    """Create a new rule from a JSON request body.
+
+    Expected JSON fields:
+        name: Required rule name.
+        rule_text: Required rule body.
+        level: Optional rule level, defaulting to PROMPT.
+        type, command_label, reference_id, description, target_models,
+        is_active, project_id: Optional rule metadata.
+
+    Returns:
+        A standard success envelope containing the created rule id, or a
+        validation/database error envelope.
+    """
     # Input validation
     if not request.is_json:
         return error_response("Request must be JSON", 400, "INVALID_REQUEST")
@@ -122,6 +156,21 @@ def create_rule():
 
 @rules_bp.route("/<int:rule_id>", methods=["PUT"])
 def update_rule(rule_id):
+    """Update an existing rule with fields from a JSON request body.
+
+    Path parameters:
+        rule_id: Database id of the rule to update.
+
+    Expected JSON fields:
+        Any editable rule field, including name, level, type, command_label,
+        reference_id, rule_text, description, target_models, is_active, or
+        project_id.
+
+    Returns:
+        A standard success envelope when the update is committed, or an error
+        envelope for missing rules, duplicate command labels, or database
+        failures.
+    """
     data = request.get_json()
     rule = db.session.get(Rule, rule_id)
     if not rule:
@@ -167,6 +216,15 @@ def update_rule(rule_id):
 
 @rules_bp.route("/<int:rule_id>", methods=["DELETE"])
 def delete_rule(rule_id):
+    """Delete one rule by id.
+
+    Path parameters:
+        rule_id: Database id of the rule to delete.
+
+    Returns:
+        A standard success envelope after deletion, or an error envelope when
+        the rule is missing or the database delete fails.
+    """
     rule = db.session.get(Rule, rule_id)
     if not rule:
         return error_response("Rule not found", 404)


### PR DESCRIPTION
Fixes #12.

Summary:
- add endpoint docstrings to `backend/api/rules_api.py`
- document query/path/body inputs and response shapes for the rules routes
- keep the PR scoped to one API module with no logic or import changes

Verification:
- ast.parse on `backend/api/rules_api.py`
- git diff --check
- python run_tests.py (timed out locally after 3 minutes)