### PR TITLE
fix(ci): green up main — pytest 9 dep conflict + frontend lint

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -100,7 +100,7 @@ soundfile>=0.12.1  # WAV/FLAC IO for voice_api + audio_foundry backends
 # Testing Dependencies
 pytest==9.0.3
 pytest-timeout==2.3.1
-pytest-playwright==0.7.0
+pytest-playwright==0.8.0  # 0.7.0 caps pytest<9.0.0; 0.8.0 supports pytest 9.x
 playwright==1.52.0
 
 # Desktop Automation Dependencies

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -23,6 +23,10 @@
     {
       "files": ["*.config.js", "vite.config.js"],
       "env": { "node": true }
+    },
+    {
+      "files": ["**/*.test.{js,jsx}", "**/*.spec.{js,jsx}"],
+      "env": { "node": true }
     }
   ]
 }

--- a/frontend/src/components/dashboard/DashboardCardWrapper.jsx
+++ b/frontend/src/components/dashboard/DashboardCardWrapper.jsx
@@ -35,7 +35,7 @@ const DashboardCardWrapper = React.forwardRef(
       _maxW,
       _minH,
       _maxH, // Size constraints
-      isDraggable,
+      _isDraggable,
       _isResizable,
       _isBounded,
       static: _staticProp, // Interaction props

--- a/frontend/src/components/filmcrew/CastingPanel.jsx
+++ b/frontend/src/components/filmcrew/CastingPanel.jsx
@@ -22,7 +22,7 @@ import {
 import { listCastLibrary, listProductionSubjects, castSubject } from '../../api/productionService';
 import DragDropImageUpload from './DragDropImageUpload';
 
-const CastingPanel = ({ productionId, shots, onCastingConfirmed }) => {
+const CastingPanel = ({ productionId, _shots, onCastingConfirmed }) => {
   const [castingData, setCastingData] = useState({});
   const [castLibrary, setCastLibrary] = useState([]);
   const [subjectsToCast, setSubjectsToCast] = useState([]);

--- a/frontend/src/components/filmcrew/CharacterPicker.jsx
+++ b/frontend/src/components/filmcrew/CharacterPicker.jsx
@@ -30,7 +30,7 @@ const CharacterPicker = ({
   const theme = useTheme();
   const [subjects, setSubjects] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [, setError] = useState(null);
   const [imgErrors, setImgErrors] = useState({});
 
   useEffect(() => {

--- a/frontend/src/components/filmcrew/DragDropImageUpload.test.jsx
+++ b/frontend/src/components/filmcrew/DragDropImageUpload.test.jsx
@@ -31,7 +31,7 @@ describe("DragDropImageUpload", () => {
       },
     });
 
-    const { container } = render(
+    render(
       <DragDropImageUpload subjectId={7} onUploaded={onUploaded} />,
     );
 
@@ -57,7 +57,7 @@ describe("DragDropImageUpload", () => {
     });
 
     const ref = React.createRef();
-    const { container } = render(<DragDropImageUpload ref={ref} />);
+    render(<DragDropImageUpload ref={ref} />);
 
     const dropzone = screen.getByTestId("drag-drop-zone");
     const file = new File(["fake"], "x.png", { type: "image/png" });

--- a/frontend/src/components/filmcrew/StageProgress.jsx
+++ b/frontend/src/components/filmcrew/StageProgress.jsx
@@ -21,7 +21,7 @@ const StageProgress = ({ currentStage, status, errorBlob }) => {
   return (
     <Box sx={{ width: '100%', my: 4 }}>
       <Stepper activeStep={activeStep === -1 ? 0 : activeStep} alternativeLabel>
-        {STAGES.map((stage, index) => {
+        {STAGES.map((stage) => {
           const isError = isFailed && currentStage === stage.key;
           const isGated = GATED_STAGES.includes(stage.key) && currentStage === stage.key;
           

--- a/frontend/src/components/filmcrew/StoryboardGrid.jsx
+++ b/frontend/src/components/filmcrew/StoryboardGrid.jsx
@@ -20,7 +20,7 @@ import {
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
-const StoryboardGrid = ({ productionId, currentStage, shots, onRegenerate, onApproveAll, isApproving }) => {
+const StoryboardGrid = ({ _productionId, currentStage, shots, onRegenerate, onApproveAll, isApproving }) => {
   const [regenShot, setRegenShot] = useState(null);
   const [promptOverride, setPromptOverride] = useState('');
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/filmcrew/StoryboardGrid.test.jsx
+++ b/frontend/src/components/filmcrew/StoryboardGrid.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import StoryboardGrid from './StoryboardGrid';
 
 describe('StoryboardGrid', () => {

--- a/frontend/src/components/modals/InfographicModelsModal.jsx
+++ b/frontend/src/components/modals/InfographicModelsModal.jsx
@@ -138,9 +138,7 @@ const InfographicModelsModal = ({ open, onClose, showMessage }) => {
     // Poll the backend directly between rounds; relying on the local
     // `dl` ref would capture a stale closure here.
     for (const m of missing) {
-      // eslint-disable-next-line no-await-in-loop
       await handleInstall(m.id);
-      // eslint-disable-next-line no-await-in-loop
       await new Promise((resolve) => {
         const check = setInterval(async () => {
           try {

--- a/frontend/src/components/videoeditor/BinPanel.jsx
+++ b/frontend/src/components/videoeditor/BinPanel.jsx
@@ -3,7 +3,7 @@
 // supported; the bin owns its clips. Remove via the X on each tile.
 
 import React from "react";
-import { Box, Stack, Typography, LinearProgress, Alert, IconButton, Tooltip } from "@mui/material";
+import { Box, Stack, Typography, LinearProgress, Alert } from "@mui/material";
 import { VideoLibrary as VideoIcon, FolderOpen as OpenFolderIcon } from "@mui/icons-material";
 import BinClipTile from "./BinClipTile";
 import { useExternalDrop } from "./useExternalDrop";

--- a/frontend/src/components/videoeditor/DirectorsNotesPanel.jsx
+++ b/frontend/src/components/videoeditor/DirectorsNotesPanel.jsx
@@ -6,7 +6,7 @@
 // will overwrite them. v2 will persist overrides into the plan job so a
 // Re-plan respects them.
 
-import React, { useState, useMemo } from "react";
+import React from "react";
 import {
   Box, Stack, Typography, Chip,
   Button, Divider, Tooltip, CircularProgress,

--- a/frontend/src/components/videoeditor/MediaLibraryPanel.test.jsx
+++ b/frontend/src/components/videoeditor/MediaLibraryPanel.test.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import MediaLibraryPanel from "./MediaLibraryPanel";

--- a/frontend/src/components/videoeditor/OverlayLayer.jsx
+++ b/frontend/src/components/videoeditor/OverlayLayer.jsx
@@ -5,8 +5,7 @@ const OverlayLayer = memo(({
   textElements,
   selectedTextId,
   onSelectText,
-  onMoveText,
-  containerRef
+  onMoveText
 }) => {
   const [dragState, setDragState] = useState(null);
   const dragRef = useRef(null);
@@ -95,5 +94,7 @@ const OverlayLayer = memo(({
     </>
   );
 });
+
+OverlayLayer.displayName = 'OverlayLayer';
 
 export default OverlayLayer;

--- a/frontend/src/components/videoeditor/ScanModeSelector.jsx
+++ b/frontend/src/components/videoeditor/ScanModeSelector.jsx
@@ -4,7 +4,7 @@
 // silent-removal classic.
 
 import React from "react";
-import { Box, ToggleButton, ToggleButtonGroup, Stack, Typography, Tooltip } from "@mui/material";
+import { ToggleButton, ToggleButtonGroup, Stack, Typography, Tooltip } from "@mui/material";
 
 const MODES = [
   { value: "audio", label: "Audio", tip: "Cut silence based on audio loudness." },

--- a/frontend/src/pages/FileGenerationPage.jsx
+++ b/frontend/src/pages/FileGenerationPage.jsx
@@ -28,34 +28,18 @@ import {
   FormControlLabel,
   FormLabel,
   Switch,
-  Card,
-  CardContent,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  IconButton,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import PreviewIcon from "@mui/icons-material/Preview";
-import WarningIcon from "@mui/icons-material/Warning";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 import * as apiService from "../api"; // For fetching Rules & Projects
 // Corrected import: Import generateFileFromChat and alias it as generateSingleFile
 import {
   generateFileFromChat as generateSingleFile,
-  generateBatchCsv,
 } from "../api/filegenService";
 import { getWebsites } from "../api/websiteService"; // For website dropdown
 import { generateBulkXML, generateStructuredCSV } from "../api/bulkGenerationService"; // For XML generation
 import { useStatus } from "../contexts/StatusContext";
 import PageLayout from "../components/layout/PageLayout";
-import { DELIMITER_OPTIONS, BRAND_TONE_OPTIONS, SITE_META_DEFAULTS } from "../config/defaults";
-import { validateGenerationBatch, createValidationReport, formatValidationErrors } from "../utils/validation";
-import { renderStructuredHTML, previewStructuredHTML } from "../utils/htmlRenderer";
-import { arrayToCSV, DELIMITERS } from "../utils/csv";
-import { slugify } from "../utils/slugify";
 
 const FileGenerationPage = () => {
   const theme = useTheme();
@@ -108,15 +92,6 @@ const FileGenerationPage = () => {
   const [isLoadingWebsites, setIsLoadingWebsites] = useState(false);
 
   // New Enhanced Features State
-  const [csvDelimiter, setCsvDelimiter] = useState(DELIMITERS.COMMA);
-  const [structuredHtml, setStructuredHtml] = useState(false);
-  const [includeH1InContent, setIncludeH1InContent] = useState(true);
-  const [siteMeta, setSiteMeta] = useState({ ...SITE_META_DEFAULTS });
-  const [validationReport, setValidationReport] = useState(null);
-  const [showValidationModal, setShowValidationModal] = useState(false);
-  const [showPreviewModal, setShowPreviewModal] = useState(false);
-  const [previewContent, setPreviewContent] = useState("");
-  const [generationId, setGenerationId] = useState(null);
   const [enhancedContext, setEnhancedContext] = useState(false);
 
   // Fetch all required data for dropdowns/autocomplete
@@ -511,76 +486,6 @@ const FileGenerationPage = () => {
       severity: "info",
       open: true,
     });
-  };
-
-  // Enhanced validation and preview handlers
-  const handlePreflightValidation = () => {
-    const items = batchItems.split('\n').filter(item => item.trim());
-    const mockRows = items.map((item, index) => ({
-      title: `${item} - Professional Services`,
-      slug: slugify(item),
-      content: `Comprehensive ${item} services with expert consultation.`,
-      excerpt: `Professional ${item} services for your business needs.`,
-      category: siteMeta.primaryService || 'Services',
-      tags: [siteMeta.primaryService, 'professional', 'expert'].filter(Boolean)
-    }));
-
-    const csvConfig = { delimiter: csvDelimiter, structuredHtml, includeH1: includeH1InContent };
-    const report = createValidationReport(mockRows, siteMeta, csvConfig);
-    setValidationReport(report);
-    setShowValidationModal(true);
-  };
-
-  const handlePreviewStructuredHTML = () => {
-    const sampleContent = `Professional ${siteMeta.primaryService || 'Services'}
-
-About Our Services:
-We provide comprehensive solutions for your business needs.
-
-Our Expertise:
-- Expert consultation and guidance
-- **Proven track record** of success
-- Personalized approach to every project
-
-Why Choose Us:
-Years of experience in the industry
-*Dedicated customer service*
-Competitive pricing and flexible terms
-
-Contact us today for more information.`;
-
-    const preview = previewStructuredHTML(sampleContent, siteMeta, {
-      includeH1: includeH1InContent
-    });
-    setPreviewContent(preview.html);
-    setShowPreviewModal(true);
-  };
-
-  const handleSiteMetaChange = (field, value) => {
-    setSiteMeta(prev => ({ ...prev, [field]: value }));
-  };
-
-  const handleSocialLinkAdd = () => {
-    setSiteMeta(prev => ({
-      ...prev,
-      socialLinks: [...prev.socialLinks, { platform: '', url: '' }]
-    }));
-  };
-
-  const handleSocialLinkChange = (index, field, value) => {
-    setSiteMeta(prev => ({
-      ...prev,
-      socialLinks: prev.socialLinks.map((link, i) =>
-        i === index ? { ...link, [field]: value } : link
-      )
-    }));
-  };
-
-  const handleSocialLinkRemove = (index) => {
-    setSiteMeta(prev => ({
-      ...prev,
-      socialLinks: prev.socialLinks.filter((_, i) => i !== index)
-    }));
   };
 
   // Handle website selection with automatic client and filename setting

--- a/frontend/src/pages/FilmCrewPage.jsx
+++ b/frontend/src/pages/FilmCrewPage.jsx
@@ -31,7 +31,7 @@ const FilmCrewPage = () => {
   const [productions, setProductions] = useState([]);
   const [selectedProdId, setSelectedProdId] = useState(null);
   const [productionDetail, setProductionDetail] = useState(null);
-  const [loadingList, setLoadingList] = useState(false);
+  const [, setLoadingList] = useState(false);
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [approving, setApproving] = useState(false);
   const [error, setError] = useState(null);

--- a/frontend/src/pages/TaskPage.jsx
+++ b/frontend/src/pages/TaskPage.jsx
@@ -12,7 +12,6 @@ import {
   Chip,
   Divider,
   FormControl,
-  IconButton,
   InputLabel,
   ListItemIcon,
   ListItemText,
@@ -22,22 +21,15 @@ import {
   Paper,
   Select,
   Snackbar,
-  Tooltip,
-  Typography,
 } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 import AddIcon from "@mui/icons-material/Add";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import FileCopyIcon from "@mui/icons-material/FileCopy";
-import CloseIcon from "@mui/icons-material/Close";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import CodeIcon from "@mui/icons-material/Code";
 import TableChartIcon from "@mui/icons-material/TableChart";
 import AnalyticsIcon from "@mui/icons-material/Analytics";
-import SmartToyIcon from "@mui/icons-material/SmartToy";
 import ClearAllIcon from "@mui/icons-material/ClearAll";
 import AssignmentOutlined from "@mui/icons-material/AssignmentOutlined";
 import DescriptionIcon from "@mui/icons-material/Description";
@@ -63,39 +55,17 @@ import { ContextualLoader } from "../components/common/LoadingStates";
 
 // Removed TaskStatusChip - now handled in TaskCard component
 
-const formatDate = (dateString) => {
-  if (!dateString) return "-";
-  try {
-    const date = new Date(dateString);
-    // Return timestamp format: YYYY-MM-DD HH:MM:SS
-    return date.toLocaleString("en-US", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-    }).replace(/(\d+)\/(\d+)\/(\d+),?\s*(.+)/, "$3-$1-$2 $4");
-  } catch (error) {
-    return "-";
-  }
-};
-
 // Removed table-related functions and constants - now using card-based layout
 
 const TaskPage = () => {
-  const theme = useTheme();
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { activeModel, isLoadingModel, modelError } = useStatus();
   useUnifiedProgress();
 
   // State management
   const [tasks, setTasks] = useState([]);
   const [availableProjects, setAvailableProjects] = useState([]);
-  const [availableModels, setAvailableModels] = useState([]);
+  const [, setAvailableModels] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -110,10 +80,9 @@ const TaskPage = () => {
   // Task creation state
   const [showTaskForm, setShowTaskForm] = useState(false);
   const [editingTask, setEditingTask] = useState(null);
-  const [viewMode, setViewMode] = useState("cards"); // "cards" or "table"
 
   // Sorting state (simplified for card view)
-  const [sortBy, setSortBy] = useState("created_at");
+  const [sortBy] = useState("created_at");
 
   // New Job menu state
   const [newTaskMenuAnchor, setNewTaskMenuAnchor] = useState(null);
@@ -299,7 +268,7 @@ const TaskPage = () => {
     }
   };
 
-  const handleTaskDeleted = (taskId) => {
+  const handleTaskDeleted = () => {
     setShowTaskForm(false);
     setEditingTask(null);
     setFeedback({

--- a/frontend/src/pages/UpscalingPage.jsx
+++ b/frontend/src/pages/UpscalingPage.jsx
@@ -24,10 +24,6 @@ import {
   ToggleButtonGroup,
   Switch,
   FormControlLabel,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Slider,
 } from "@mui/material";
 import PageLayout from "../components/layout/PageLayout";

--- a/frontend/src/pages/VideoEditorPage.jsx
+++ b/frontend/src/pages/VideoEditorPage.jsx
@@ -11,7 +11,6 @@ import {
   Button,
   IconButton,
   Chip,
-  Divider,
   CircularProgress,
   Alert,
   Tooltip,
@@ -20,9 +19,7 @@ import {
   PlayArrow as PlayIcon,
   Pause as PauseIcon,
   AutoFixHigh as RenderIcon,
-  TextFields as TextIcon,
   MovieFilter as VideoIcon,
-  GraphicEq as AudioIcon,
   AutoAwesome as PlanIcon,
   OpenInNew as ShotcutIcon,
   RocketLaunch as QuickRenderIcon,
@@ -74,13 +71,6 @@ const VE_CARD_TITLES = {
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "/api";
 
-// Track lane colors — keep video / text / audio visually distinct.
-const TRACK_COLORS = {
-  video: "#2196f3",
-  text: "#ff9800",
-  audio: "#9c27b0",
-};
-
 // Initial blank timeline state. Bin holds clips for THIS project; song is
 // the master soundtrack. Text overlays are kept for A2+ — currently they
 // don't flow through the Plan pipeline.
@@ -93,13 +83,13 @@ const _emptyTimeline = () => ({
 });
 
 const VideoEditorPage = () => {
-  const { timeline, commitTimeline, handleUndo, pendingSnapshotRef } = useTimelineHistory(_emptyTimeline());
+  const { timeline, commitTimeline, handleUndo } = useTimelineHistory(_emptyTimeline());
   const videoElRef = useRef(null);
   const [mediaLibrary, setMediaLibrary] = useState([]);
   const [audioLibrary, setAudioLibrary] = useState([]);
   const [imageLibrary, setImageLibrary] = useState([]);
   const [loadingMedia, setLoadingMedia] = useState(false);
-  const [videoDuration, setVideoDuration] = useState(0);  // for visual trim slider
+  const [, setVideoDuration] = useState(0);  // for visual trim slider
   const [selectedItem, setSelectedItem] = useState(null);  // {type, id} for properties panel
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [rendering, setRendering] = useState(false);
@@ -109,7 +99,7 @@ const VideoEditorPage = () => {
   const [styleRecipeName, setStyleRecipeName] = useState("Default");
   const [recipes, setRecipes] = useState([]);
   const planJob = usePlanJob();
-  const [gate, setGate] = useState(null);
+  const [, setGate] = useState(null);
   const [error, setError] = useState(null);
 
   // Director's Notes overrides — keyed by clip_id. Local until next Plan.
@@ -201,7 +191,7 @@ const VideoEditorPage = () => {
       .catch(() => {})
       .finally(() => { if (!cancelled) sessionLoadedRef.current = true; });
     return () => { cancelled = true; };
-  }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);  // deps intentionally limited
 
   useEffect(() => {
     if (!sessionLoadedRef.current) return;
@@ -355,30 +345,6 @@ const VideoEditorPage = () => {
   // Click on the preview to add a text element at that point. Phase 3 of
   // the editor plan adds drag/resize/rotate handles via react-rnd or
   // react-moveable; for now click-to-place + edit-in-properties.
-  const handleAddText = useCallback((x, y) => {
-    const newId = `text_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    commitTimeline((prev) => {
-      return {
-        ...prev,
-        textElements: [
-          ...prev.textElements,
-          {
-            id: newId,
-            text: "Sample text",
-            fontSize: 48,
-            fontColor: "white",
-            x: x ?? 320,
-            y: y ?? 240,
-            rotation: 0,
-            startSeconds: 0,
-            endSeconds: null,
-          },
-        ],
-      };
-    });
-    setSelectedItem({ type: "text", id: newId });
-  }, []);
-
   const handleDeleteText = (textId) => {
     commitTimeline((prev) => {
       return {
@@ -495,7 +461,6 @@ const VideoEditorPage = () => {
     const result = planJob.result;
     if (!result) return;
     const kept = result.kept_ranges_by_clip || {};
-    const songDuration = result.song?.duration_seconds || null;
     commitTimeline((prev) => ({
       ...prev,
       bin: prev.bin.map((c) => ({
@@ -509,7 +474,7 @@ const VideoEditorPage = () => {
           : c.durationSeconds,
       })),
     }));
-  }, [planJob.result]);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, [planJob.result]);  // deps intentionally limited
 
   // Master soundtrack = the flagged audio bin clip. Plan arranges the VIDEO
   // clips against it; audio/image clips aren't part of the auto-edit material.
@@ -628,7 +593,7 @@ const VideoEditorPage = () => {
     } else if (planJob.error) {
       setQuickRenderPending(false);
     }
-  }, [quickRenderPending, planJob.result, planJob.planning, planJob.error, rendering]);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, [quickRenderPending, planJob.result, planJob.planning, planJob.error, rendering]);  // deps intentionally limited
 
   const handleOpenInShotcut = useCallback(async () => {
     if (!renderResult?.mlt_path) return;

--- a/frontend/src/stores/useAppStore.js
+++ b/frontend/src/stores/useAppStore.js
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage, subscribeWithSelector, devtools } from "zustand/middleware";
 
-// eslint-disable-next-line no-unused-vars
 const createUISlice = (set, get) => ({
   themeName: "guaardvark",
   setThemeName: (name) => set({ themeName: name }),


### PR DESCRIPTION
## Why

CI has been red on **every push to `main` since 2026-05-05** — visible to every visitor and PR author. Two independent root causes.

## Backend — dependency resolution failure

A Dependabot security bump set `pytest==9.0.3`, but `pytest-playwright==0.7.0` pins `pytest<9.0.0`. `pip install -r backend/requirements.txt` could not resolve:

```
The conflict is caused by:
    The user requested pytest==9.0.3
    pytest-playwright 0.7.0 depends on pytest<9.0.0 and >=6.2.4
```

**Fix:** bump `pytest-playwright` to `0.8.0`, which supports pytest 9.x. Verified the testing-deps trio resolves cleanly.

## Frontend — 89 lint errors on committed main

`npm run lint` runs `eslint --max-warnings 0`. Committed `main` had 89 errors:

- **78** unused vars / dead imports
- **3** `no-undef` (`global` used in test files, no `node` env override)
- **2** missing `React` in scope for JSX (a test file)
- **1** missing component `display name`
- orphaned `eslint-disable` directives referencing rules not registered in the config (`react-hooks/exhaustive-deps`, `no-await-in-loop`, `no-unused-vars`)

**Fix:** added a test-file eslint override (`node` env), removed dead imports/vars, added the missing `React` import + a `displayName`, and dropped the orphan disable directives. No runtime behavior changed — unused setters whose getters are still read were collapsed to `const [, setX]` rather than deleted.

## Verification (local)

- `npm run lint` → exit 0
- `npm run build` → succeeds
- `python scripts/quality_gate.py --mode static` → OK
- full `py_compile` sweep of `backend/{app,config,models}.py`, `backend/api/*.py`, `backend/services/*.py` → OK
- pip dependency resolution of the testing trio → resolves

Let CI confirm green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)