### PR TITLE
ci: bump actions to Node 24 majors + build on Node 22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Why

Every CI run was emitting Node 20 deprecation annotations. GitHub **forces JS actions onto Node 24 on 2026-06-02** and removes Node 20 from runners on 2026-09-16. The current pins run on the deprecated Node 20.

## Changes

| action | before | after |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| frontend build `node-version` | 20 | **22** (Active LTS) |

All three action majors run on Node 24, clearing the deprecation. The build `node-version` also moves off Node 20 (EOL April 2026) to 22 LTS — verified the frontend builds green on Node 22 locally.

This PR's own CI run exercises every bumped action, so green here = the new versions work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)