### PR TITLE
feat(chat): hover copy button on user messages (#4)

### DIFF
--- a/frontend/src/components/chat/MessageItem.jsx
+++ b/frontend/src/components/chat/MessageItem.jsx
@@ -272,8 +272,30 @@ const MessageItem = ({ message, sessionId: sessionIdProp }) => {
         flexDirection: "row",
         alignItems: "flex-start",
         gap: 1,
+        // Reveal the user-message copy affordance on hover (AI messages keep
+        // their always-visible action row below).
+        "&:hover .msg-user-copy": { opacity: 1 },
       }}
     >
+      {/* User messages get a hover-revealed copy button beside the bubble.
+          AI messages already carry copy in their action row. */}
+      {isUser && (
+        <Tooltip title={copied ? "Copied" : "Copy"}>
+          <IconButton
+            className="msg-user-copy"
+            size="small"
+            onClick={handleCopy}
+            aria-label="Copy message"
+            sx={{ p: 0.25, alignSelf: "center", opacity: 0, transition: "opacity 0.15s" }}
+          >
+            {copied ? (
+              <CheckIcon sx={{ fontSize: 14, color: "success.main" }} />
+            ) : (
+              <ContentCopyIcon sx={{ fontSize: 14, opacity: 0.6 }} />
+            )}
+          </IconButton>
+        </Tooltip>
+      )}
       {!isUser && (
         <Avatar
           src={logoUrl}


### PR DESCRIPTION
## Summary

Closes #4. On inspection, AI messages **already** had a copy button (in their action row alongside the feedback thumbs), so the only gap against the acceptance criteria was **user messages**, which had no copy affordance.

This adds a **hover-revealed copy button beside user-message bubbles**, reusing the existing `handleCopy` + `copied` state (including the non-HTTPS `execCommand` fallback). The AI action row is deliberately **left untouched** to avoid regressing the chat UI.

## Acceptance criteria
- [x] Copy button appears on hover over (user) chat messages
- [x] Clicking copies the message text to clipboard
- [x] Brief "Copied" tooltip feedback
- [x] Works for both user and AI messages

## Verification
- `eslint` on the changed file → clean
- `npm run build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)