### PR TITLE
feat(api): add /api/health/frontend endpoint (#3)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1469,6 +1469,41 @@ def health_db():
     return jsonify(status), 200
 
 
+@app.route("/api/health/frontend")
+def health_frontend():
+    """Report the built frontend's version and build timestamp.
+
+    Version is the shared repo-root VERSION (frontend and backend ship from one
+    tree). Build time is derived from the mtime of the Vite build's index.html.
+    Returns 503 if no build output exists (e.g. running the dev server only).
+    """
+    from datetime import datetime, timezone
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    index_path = os.path.join(repo_root, "frontend", "dist", "index.html")
+    if not os.path.exists(index_path):
+        return (
+            jsonify(
+                {
+                    "status": "unavailable",
+                    "error": "no frontend build found (frontend/dist/index.html missing)",
+                }
+            ),
+            503,
+        )
+    build_dt = datetime.fromtimestamp(os.path.getmtime(index_path), tz=timezone.utc)
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "version": __version__,
+                "build_timestamp": build_dt.isoformat().replace("+00:00", "Z"),
+            }
+        ),
+        200,
+    )
+
+
 _celery_health_cache = {"data": None, "timestamp": 0}
 _HEALTH_CACHE_DURATION = 30
 


### PR DESCRIPTION
## Summary

Closes #3. Adds `/api/health/frontend`, sitting alongside the existing `/api/health`, `/api/health/db`, `/api/health/celery`, etc.

```json
// 200 when a build exists
{ "status": "ok", "version": "2.5.4", "build_timestamp": "2026-05-29T03:29:41Z" }

// 503 when frontend/dist/index.html is missing
{ "status": "unavailable", "error": "no frontend build found (frontend/dist/index.html missing)" }
```

- **Version** is the shared repo-root `VERSION` (frontend and backend ship from one tree — single source of truth, per #11/#26).
- **Build timestamp** is derived from the mtime of the Vite build's `frontend/dist/index.html`, resolved via a repo-root-relative path.

## Acceptance criteria
- [x] Returns frontend version and build timestamp
- [x] Returns appropriate error (503) if no build exists
- [x] Dashboard can optionally display this info (endpoint is ready to consume)

## Verification
- `python -m py_compile backend/app.py` → OK
- endpoint logic exercised in isolation → returns `2.5.4` + ISO-8601 `Z` timestamp; 503 path confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)