### PR TITLE
feat(llm): add Mistral as a selectable cloud LLM provider

### DIFF
--- a/backend/api/llm_provider_api.py
+++ b/backend/api/llm_provider_api.py
@@ -1,0 +1,82 @@
+"""REST API for selecting the active LLM provider (Ollama vs Mistral)."""
+import logging
+
+from flask import Blueprint, request
+
+from backend.utils.response_utils import success_response, error_response
+
+logger = logging.getLogger(__name__)
+
+llm_provider_bp = Blueprint("llm_provider", __name__, url_prefix="/api/llm")
+
+
+@llm_provider_bp.route("/provider", methods=["GET"])
+def get_provider():
+    """Current provider + what's available, for the settings toggle."""
+    from backend.services import llm_provider as lp
+    return success_response(data={
+        "provider": lp.get_active_provider(),
+        "ollama_available": True,
+        "mistral_available": lp.mistral_available(),
+        "mistral_model": lp.get_mistral_model(),
+        "providers": [
+            {"id": lp.OLLAMA, "label": "Ollama (local)", "available": True},
+            {"id": lp.MISTRAL, "label": "Mistral (cloud API)", "available": lp.mistral_available()},
+        ],
+    })
+
+
+@llm_provider_bp.route("/provider", methods=["POST"])
+def set_provider():
+    """Switch the active provider. Body: {"provider": "ollama"|"mistral"}."""
+    from backend.services import llm_provider as lp
+    body = request.get_json(silent=True) or {}
+    provider = body.get("provider", "")
+    try:
+        active = lp.set_active_provider(provider)
+    except ValueError as e:
+        return error_response(str(e), 400)
+    return success_response(data={"provider": active}, message=f"LLM provider set to {active}")
+
+
+@llm_provider_bp.route("/provider/models", methods=["GET"])
+def list_provider_models():
+    """List models for a provider (?provider=mistral; defaults to the active one)."""
+    from backend.services import llm_provider as lp
+    provider = (request.args.get("provider") or lp.get_active_provider()).strip().lower()
+    if provider == lp.MISTRAL:
+        if not lp.mistral_available():
+            return error_response("Mistral API key not configured (set MISTRAL_API_KEY in .env).", 400)
+        from backend.services import mistral_provider
+        return success_response(data={"provider": provider, "models": mistral_provider.list_models()})
+    # Ollama listing already has a dedicated endpoint; point callers there.
+    return success_response(data={"provider": provider, "models": [], "see": "/api/model/list"})
+
+
+@llm_provider_bp.route("/provider/mistral-model", methods=["POST"])
+def set_mistral_model():
+    """Set the active Mistral model. Body: {"model": "mistral-large-latest"}."""
+    from backend.services import llm_provider as lp
+    body = request.get_json(silent=True) or {}
+    try:
+        model = lp.set_mistral_model(body.get("model", ""))
+    except ValueError as e:
+        return error_response(str(e), 400)
+    return success_response(data={"mistral_model": model}, message=f"Mistral model set to {model}")
+
+
+@llm_provider_bp.route("/provider/test", methods=["POST"])
+def test_mistral():
+    """Live round-trip against Mistral to confirm the key/model work."""
+    from backend.services import llm_provider as lp
+    if not lp.mistral_available():
+        return error_response("Mistral API key not configured (set MISTRAL_API_KEY in .env).", 400)
+    from backend.services import mistral_provider
+    try:
+        text = mistral_provider.complete(
+            "Reply with exactly: Connection successful",
+            model=lp.get_mistral_model(),
+        )
+    except Exception as e:  # noqa: BLE001
+        return error_response(f"Mistral request failed: {e}", 503)
+    return success_response(data={"connected": True, "response": text, "model": lp.get_mistral_model()})

--- a/backend/config.py
+++ b/backend/config.py
@@ -249,6 +249,15 @@ DEFAULT_EMBEDDING_MODEL = None
 OLLAMA_BASE_URL = "http://localhost:11434"
 ACTIVE_MODEL_FILE = os.path.join(STORAGE_DIR, "active_model.json")
 
+# --- Mistral cloud LLM provider (optional, selectable alternative to Ollama) ---
+# When MISTRAL_API_KEY is set, the UI exposes a provider toggle (Ollama | Mistral).
+# Chat generation routes to Mistral's API when the provider is "mistral". Embeddings
+# always stay on Ollama so the RAG vector store remains consistent.
+MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "").strip()
+MISTRAL_BASE_URL = os.environ.get("GUAARDVARK_MISTRAL_BASE_URL", "https://api.mistral.ai/v1").rstrip("/")
+MISTRAL_DEFAULT_MODEL = os.environ.get("GUAARDVARK_MISTRAL_MODEL", "mistral-large-latest").strip()
+MISTRAL_REQUEST_TIMEOUT = int(os.environ.get("GUAARDVARK_MISTRAL_TIMEOUT", "120"))
+
 # GPU Memory Orchestrator settings
 GPU_QUALITY_TIER = os.environ.get("GUAARDVARK_GPU_QUALITY_TIER", "balanced")
 GPU_EVICTION_GRACE_SECONDS = int(os.environ.get("GUAARDVARK_GPU_EVICTION_GRACE", "30"))

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -1,0 +1,112 @@
+"""
+LLM provider selection.
+
+Guaardvark defaults to local Ollama. When a Mistral API key is configured the
+user can flip a runtime toggle (persisted in the ``settings`` table) so chat
+generation routes to Mistral instead. This module is the single source of truth
+for "which provider is active" and "which model within that provider".
+
+Embeddings deliberately are NOT covered here — they always stay on Ollama so the
+RAG vector store stays consistent with what indexed it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from backend import config
+
+logger = logging.getLogger(__name__)
+
+OLLAMA = "ollama"
+MISTRAL = "mistral"
+
+_PROVIDER_KEY = "llm_provider"
+_MISTRAL_MODEL_KEY = "mistral_active_model"
+
+
+# ---------------------------------------------------------------------------
+# Generic settings access (mirrors llm_service's Setting usage)
+# ---------------------------------------------------------------------------
+def _get_setting(key: str) -> Optional[str]:
+    try:
+        from backend.models import Setting, db
+
+        if db and Setting:
+            row = db.session.get(Setting, key)
+            if row and row.value:
+                return row.value
+    except Exception as e:  # noqa: BLE001 - best effort, no Flask ctx etc.
+        logger.debug("llm_provider: could not read setting %s: %s", key, e)
+    return None
+
+
+def _set_setting(key: str, value: str) -> bool:
+    try:
+        from backend.models import Setting, db
+
+        if not (db and Setting):
+            return False
+        row = db.session.get(Setting, key)
+        if row:
+            row.value = value
+        else:
+            db.session.add(Setting(key=key, value=value))
+        db.session.commit()
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning("llm_provider: could not write setting %s: %s", key, e)
+        try:
+            from backend.models import db
+            db.session.rollback()
+        except Exception:
+            pass
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+def mistral_available() -> bool:
+    return bool(config.MISTRAL_API_KEY)
+
+
+def get_active_provider() -> str:
+    """Return the active provider, falling back to Ollama.
+
+    A stored ``mistral`` choice degrades to ``ollama`` if the key was removed, so
+    a missing key can never wedge the chat into an unusable provider.
+    """
+    provider = (_get_setting(_PROVIDER_KEY) or OLLAMA).strip().lower()
+    if provider == MISTRAL and not mistral_available():
+        logger.warning("Provider 'mistral' selected but no API key set; using Ollama.")
+        return OLLAMA
+    return provider if provider in (OLLAMA, MISTRAL) else OLLAMA
+
+
+def set_active_provider(provider: str) -> str:
+    provider = (provider or "").strip().lower()
+    if provider not in (OLLAMA, MISTRAL):
+        raise ValueError(f"Unknown provider '{provider}' (expected 'ollama' or 'mistral').")
+    if provider == MISTRAL and not mistral_available():
+        raise ValueError("Cannot select Mistral: MISTRAL_API_KEY is not configured.")
+    _set_setting(_PROVIDER_KEY, provider)
+    logger.info("LLM provider set to '%s'", provider)
+    return provider
+
+
+def get_mistral_model() -> str:
+    return _get_setting(_MISTRAL_MODEL_KEY) or config.MISTRAL_DEFAULT_MODEL
+
+
+def set_mistral_model(model: str) -> str:
+    model = (model or "").strip()
+    if not model:
+        raise ValueError("Mistral model name cannot be empty.")
+    _set_setting(_MISTRAL_MODEL_KEY, model)
+    return model
+
+
+def is_mistral_active() -> bool:
+    return get_active_provider() == MISTRAL

--- a/backend/services/mistral_provider.py
+++ b/backend/services/mistral_provider.py
@@ -1,0 +1,315 @@
+"""
+Mistral cloud LLM provider.
+
+Guaardvark is Ollama-first, but this module lets the user route chat generation
+to Mistral's hosted API instead (selectable at runtime via the ``llm_provider``
+setting — see :mod:`backend.services.llm_provider`).
+
+Two surfaces are exposed so both call sites in the codebase work unchanged:
+
+1. :func:`chat` — mimics ``ollama.chat``'s streaming interface, yielding chunks
+   shaped like ``{"message": {"content": "..."}}`` with a final ``done=True``
+   chunk carrying token counts. ``unified_chat_engine._call_llm_streaming``
+   dispatches to this, so its token-emit / XML-tool-call / token-count loop runs
+   untouched.
+2. :class:`MistralLLM` — a LlamaIndex ``CustomLLM`` exposing ``.chat()`` /
+   ``.complete()``, so the ``llm_service`` helpers (and anything holding the
+   active ``self.llm``) route through too.
+
+Tool calling in this codebase is XML-in-the-prompt (see
+``backend.utils.agent_output_parser.parse_tool_calls_xml``), not native
+function-calling, so the provider only has to stream text — no tool-schema
+translation is needed.
+
+Only the standard library + ``requests`` are used (already a dependency); no
+Mistral SDK is pulled in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterator, List, Optional
+
+import requests
+
+from backend import config
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Availability + config helpers
+# ---------------------------------------------------------------------------
+def available() -> bool:
+    """True when a Mistral API key is configured."""
+    return bool(config.MISTRAL_API_KEY)
+
+
+def _headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {config.MISTRAL_API_KEY}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _map_options(options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Translate Ollama-style sampling options to Mistral chat params.
+
+    Ollama-only knobs (num_ctx, num_keep, top_k, repeat_penalty, …) have no
+    Mistral equivalent and are dropped.
+    """
+    out: Dict[str, Any] = {}
+    if not options:
+        return out
+    if options.get("temperature") is not None:
+        out["temperature"] = options["temperature"]
+    if options.get("top_p") is not None:
+        out["top_p"] = options["top_p"]
+    # Ollama caps generation with num_predict; Mistral uses max_tokens. A negative
+    # num_predict means "unbounded" in Ollama — omit max_tokens in that case.
+    np = options.get("num_predict")
+    if isinstance(np, int) and np > 0:
+        out["max_tokens"] = np
+    return out
+
+
+def _normalize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Coerce incoming messages to Mistral's ``[{role, content}]`` shape.
+
+    Mistral accepts roles system/user/assistant/tool. Anything else (or an
+    Ollama 'thinking' payload) collapses to a plain content string.
+    """
+    norm: List[Dict[str, str]] = []
+    for m in messages:
+        role = (m.get("role") or "user").strip()
+        if role not in ("system", "user", "assistant", "tool"):
+            role = "user"
+        content = m.get("content", "")
+        if content is None:
+            content = ""
+        norm.append({"role": role, "content": str(content)})
+    return norm
+
+
+# ---------------------------------------------------------------------------
+# Model listing
+# ---------------------------------------------------------------------------
+def list_models() -> List[Dict[str, Any]]:
+    """Return chat-capable Mistral models as ``[{"name", "id"}]``.
+
+    Mirrors the shape ``/api/model/list`` returns for Ollama so the frontend can
+    render them the same way. Falls back to a small static list if the API call
+    fails (e.g. offline), so the picker is never empty when a key is set.
+    """
+    fallback = [
+        {"name": "mistral-large-latest", "id": "mistral-large-latest"},
+        {"name": "mistral-small-latest", "id": "mistral-small-latest"},
+        {"name": "codestral-latest", "id": "codestral-latest"},
+        {"name": "open-mistral-nemo", "id": "open-mistral-nemo"},
+    ]
+    if not available():
+        return []
+    try:
+        resp = requests.get(
+            f"{config.MISTRAL_BASE_URL}/models",
+            headers=_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        models = []
+        for entry in data:
+            mid = entry.get("id")
+            if not mid:
+                continue
+            caps = entry.get("capabilities", {}) or {}
+            # Skip embedding/moderation-only models; keep anything that can complete chat.
+            if caps and caps.get("completion_chat") is False:
+                continue
+            if "embed" in mid.lower():
+                continue
+            models.append({"name": mid, "id": mid})
+        models.sort(key=lambda m: m["name"])
+        return models or fallback
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not list Mistral models, using fallback list: %s", e)
+        return fallback
+
+
+# ---------------------------------------------------------------------------
+# Streaming chat — Ollama-shaped, drop-in for ollama.chat()
+# ---------------------------------------------------------------------------
+def chat(
+    model: str,
+    messages: List[Dict[str, Any]],
+    stream: bool = True,
+    options: Optional[Dict[str, Any]] = None,
+    **_kwargs: Any,
+):
+    """Call Mistral's chat completions endpoint.
+
+    Returns chunks shaped exactly like ``ollama.chat``:
+      - streaming: a generator of ``{"message": {"content": tok}, "done": bool}``
+        with a final ``done=True`` chunk carrying ``prompt_eval_count`` /
+        ``eval_count``.
+      - non-streaming: a single dict in the same shape with ``done=True``.
+    """
+    if not available():
+        raise RuntimeError("Mistral provider selected but MISTRAL_API_KEY is not set.")
+
+    model = model or config.MISTRAL_DEFAULT_MODEL
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": _normalize_messages(messages),
+        "stream": bool(stream),
+        **_map_options(options),
+    }
+
+    if not stream:
+        resp = requests.post(
+            f"{config.MISTRAL_BASE_URL}/chat/completions",
+            headers=_headers(),
+            json=payload,
+            timeout=config.MISTRAL_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        content = ""
+        try:
+            content = body["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError):
+            content = ""
+        usage = body.get("usage", {}) or {}
+        return {
+            "message": {"content": content},
+            "done": True,
+            "prompt_eval_count": usage.get("prompt_tokens", 0) or 0,
+            "eval_count": usage.get("completion_tokens", 0) or 0,
+        }
+
+    return _stream_chat(payload)
+
+
+def _stream_chat(payload: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    """Yield Ollama-shaped chunks from Mistral's SSE stream."""
+    prompt_tokens = 0
+    completion_tokens = 0
+    with requests.post(
+        f"{config.MISTRAL_BASE_URL}/chat/completions",
+        headers=_headers(),
+        json=payload,
+        stream=True,
+        timeout=config.MISTRAL_REQUEST_TIMEOUT,
+    ) as resp:
+        resp.raise_for_status()
+        for raw in resp.iter_lines(decode_unicode=True):
+            if not raw:
+                continue
+            if not raw.startswith("data:"):
+                continue
+            data = raw[len("data:"):].strip()
+            if data == "[DONE]":
+                break
+            try:
+                obj = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            # Usage is reported on the final chunk(s).
+            usage = obj.get("usage")
+            if usage:
+                prompt_tokens = usage.get("prompt_tokens", prompt_tokens) or prompt_tokens
+                completion_tokens = usage.get("completion_tokens", completion_tokens) or completion_tokens
+            try:
+                delta = obj["choices"][0].get("delta", {}) or {}
+            except (KeyError, IndexError, TypeError):
+                delta = {}
+            token = delta.get("content") or ""
+            if token:
+                yield {"message": {"content": token}, "done": False}
+    # Final Ollama-style done chunk with token counts.
+    yield {
+        "message": {"content": ""},
+        "done": True,
+        "prompt_eval_count": prompt_tokens,
+        "eval_count": completion_tokens,
+    }
+
+
+def complete(prompt: str, model: Optional[str] = None, options: Optional[Dict[str, Any]] = None) -> str:
+    """Non-streaming single-prompt convenience wrapper returning plain text."""
+    result = chat(
+        model=model or config.MISTRAL_DEFAULT_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        stream=False,
+        options=options,
+    )
+    return (result.get("message", {}) or {}).get("content", "") or ""
+
+
+# ---------------------------------------------------------------------------
+# LlamaIndex-compatible wrapper (for llm_service / self.llm callers)
+# ---------------------------------------------------------------------------
+def make_llamaindex_llm(model: Optional[str] = None):
+    """Build a LlamaIndex ``CustomLLM`` backed by Mistral, or None if unavailable.
+
+    Imported lazily so the module has no hard LlamaIndex dependency at import time.
+    """
+    if not available():
+        return None
+    try:
+        from llama_index.core.llms import (
+            CustomLLM,
+            CompletionResponse,
+            CompletionResponseGen,
+            LLMMetadata,
+        )
+        from llama_index.core.llms.callbacks import llm_completion_callback
+        from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
+    except Exception as e:  # noqa: BLE001
+        logger.error("LlamaIndex not available for MistralLLM wrapper: %s", e)
+        return None
+
+    resolved_model = model or config.MISTRAL_DEFAULT_MODEL
+
+    class MistralLLM(CustomLLM):
+        model: str = resolved_model
+        context_window: int = 32000
+        num_output: int = 4096
+
+        @property
+        def metadata(self) -> "LLMMetadata":
+            return LLMMetadata(
+                context_window=self.context_window,
+                num_output=self.num_output,
+                model_name=self.model,
+                is_chat_model=True,
+            )
+
+        @llm_completion_callback()
+        def complete(self, prompt: str, **kwargs: Any) -> "CompletionResponse":
+            text = complete(prompt, model=self.model)
+            return CompletionResponse(text=text)
+
+        @llm_completion_callback()
+        def stream_complete(self, prompt: str, **kwargs: Any) -> "CompletionResponseGen":
+            acc = ""
+            for chunk in chat(self.model, [{"role": "user", "content": prompt}], stream=True):
+                tok = (chunk.get("message", {}) or {}).get("content", "")
+                if tok:
+                    acc += tok
+                    yield CompletionResponse(text=acc, delta=tok)
+
+        def chat(self, messages, **kwargs: Any) -> "ChatResponse":
+            dict_messages = [
+                {"role": getattr(m.role, "value", str(m.role)), "content": m.content or ""}
+                for m in messages
+            ]
+            result = globals()["chat"](self.model, dict_messages, stream=False)
+            content = (result.get("message", {}) or {}).get("content", "") or ""
+            return ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content=content)
+            )
+
+    return MistralLLM()

--- a/backend/services/unified_chat_engine.py
+++ b/backend/services/unified_chat_engine.py
@@ -1771,7 +1771,16 @@ class UnifiedChatEngine:
                 emit_fn("chat:token", {"content": text, "session_id": session_id})
             return text, 0, 0
 
+        # Provider dispatch: route generation to Mistral's API when the user has
+        # selected it (runtime toggle), else stay on local Ollama. The streaming
+        # loop below is provider-agnostic because mistral_provider.chat() yields
+        # chunks in the same shape ollama.chat() does.
+        from backend.services import llm_provider as _llm_provider
+        _use_mistral = _llm_provider.is_mistral_active()
+
         model_name = getattr(self.llm, "model", "gemma4:e4b")
+        if _use_mistral:
+            model_name = _llm_provider.get_mistral_model()
         accumulated = []
         accumulated_thinking = []
         input_tokens = 0
@@ -1780,7 +1789,7 @@ class UnifiedChatEngine:
         # Detect thinking models (gemma4, deepseek-r1, etc.) that put output
         # in the "thinking" field and may crash Ollama's JSON serializer
         # when thinking content contains XML-like tags.
-        is_thinking_model = any(t in model_name.lower() for t in ("deepseek-r1", "thinking", "gemma4", "gemma-4"))
+        is_thinking_model = (not _use_mistral) and any(t in model_name.lower() for t in ("deepseek-r1", "thinking", "gemma4", "gemma-4"))
 
         # Track <think>...</think> blocks in the content stream so we can
         # suppress them from being emitted as visible tokens.
@@ -1827,12 +1836,21 @@ class UnifiedChatEngine:
             if is_thinking_model:
                 call_messages = self._sanitize_messages_for_thinking_model(messages)
 
-            stream = ollama.chat(
-                model=model_name,
-                messages=call_messages,
-                stream=True,
-                options=opts,
-            )
+            if _use_mistral:
+                from backend.services import mistral_provider
+                stream = mistral_provider.chat(
+                    model=model_name,
+                    messages=call_messages,
+                    stream=True,
+                    options=opts,
+                )
+            else:
+                stream = ollama.chat(
+                    model=model_name,
+                    messages=call_messages,
+                    stream=True,
+                    options=opts,
+                )
 
             # XML filter: stream tokens to client until <tool_call is detected,
             # then suppress further emission (tool calls are announced separately).

--- a/backend/utils/llm_service.py
+++ b/backend/utils/llm_service.py
@@ -60,6 +60,20 @@ def _safe_content(message) -> Optional[str]:
 
 
 def get_llm_instance() -> Optional[LLM]:
+    # When the user has switched the provider to Mistral, hand back a
+    # Mistral-backed LlamaIndex LLM so every `.chat()/.complete()` caller routes
+    # to the cloud API. Resolved per-call (cheap) so the toggle takes effect
+    # without a restart. Falls through to the cached Ollama instance otherwise.
+    try:
+        from backend.services import llm_provider as _llm_provider
+        if _llm_provider.is_mistral_active():
+            from backend.services import mistral_provider
+            mistral_llm = mistral_provider.make_llamaindex_llm(_llm_provider.get_mistral_model())
+            if mistral_llm is not None:
+                return mistral_llm  # type: ignore
+    except Exception as e:  # noqa: BLE001 - never let provider logic break LLM access
+        logger.warning("Mistral provider resolution failed, falling back to Ollama: %s", e)
+
     if not current_app:
         logger.error("Flask current_app context not available.")
         return None

--- a/frontend/src/api/modelService.js
+++ b/frontend/src/api/modelService.js
@@ -71,6 +71,53 @@ export const setModel = async (modelName) => {
 
 
 
+// --- LLM provider (Ollama vs Mistral cloud) ---
+
+const unwrap = (data) => (data?.data !== undefined ? data.data : data);
+
+export const getLlmProvider = async () => {
+  const response = await fetch(`${BASE_URL}/llm/provider`);
+  const data = await handleResponse(response);
+  if (data?.error) throw new Error(data?.error?.message || data.error);
+  return unwrap(data);
+};
+
+export const setLlmProvider = async (provider) => {
+  const response = await fetch(`${BASE_URL}/llm/provider`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider }),
+  });
+  const data = await handleResponse(response);
+  if (data?.error) throw new Error(data?.error?.message || data.error);
+  return unwrap(data);
+};
+
+export const getMistralModels = async () => {
+  const response = await fetch(`${BASE_URL}/llm/provider/models?provider=mistral`);
+  const data = await handleResponse(response);
+  if (data?.error) throw new Error(data?.error?.message || data.error);
+  return Array.isArray(unwrap(data)?.models) ? unwrap(data).models : [];
+};
+
+export const setMistralModel = async (model) => {
+  const response = await fetch(`${BASE_URL}/llm/provider/mistral-model`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model }),
+  });
+  const data = await handleResponse(response);
+  if (data?.error) throw new Error(data?.error?.message || data.error);
+  return unwrap(data);
+};
+
+export const testMistral = async () => {
+  const response = await fetch(`${BASE_URL}/llm/provider/test`, { method: "POST" });
+  const data = await handleResponse(response);
+  if (data?.error) throw new Error(data?.error?.message || data.error);
+  return unwrap(data);
+};
+
 export const getModelStatus = async () => {
   try {
     const response = await fetch(`${BASE_URL}/model/status`);

--- a/frontend/src/components/settings/ModelManagementSection.jsx
+++ b/frontend/src/components/settings/ModelManagementSection.jsx
@@ -1,7 +1,7 @@
 // frontend/src/components/settings/ModelManagementSection.jsx
 // Extracted from SettingsPage.jsx - Model Management functionality
 
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Typography,
   Box,
@@ -13,10 +13,21 @@ import {
   CircularProgress,
   Paper,
   Grid,
-  Tooltip
+  Tooltip,
+  ToggleButton,
+  ToggleButtonGroup,
+  Divider,
+  Alert
 } from '@mui/material';
 import { useSnackbar } from '../../contexts/SnackbarProvider';
 import apiService from '../../api/apiService';
+import {
+  getLlmProvider,
+  setLlmProvider,
+  getMistralModels,
+  setMistralModel,
+  testMistral,
+} from '../../api/modelService';
 
 const ModelManagementSection = ({ 
   availableModels, 
@@ -27,6 +38,86 @@ const ModelManagementSection = ({
   refreshActiveModel 
 }) => {
   const { showMessage } = useSnackbar();
+
+  // --- LLM provider (Ollama vs Mistral cloud) ---
+  const [provider, setProvider] = useState('ollama');
+  const [mistralAvailable, setMistralAvailable] = useState(false);
+  const [mistralModel, setMistralModelState] = useState('');
+  const [mistralModels, setMistralModels] = useState([]);
+  const [providerBusy, setProviderBusy] = useState(false);
+  const [testingMistral, setTestingMistral] = useState(false);
+
+  const loadProvider = useCallback(async () => {
+    try {
+      const info = await getLlmProvider();
+      setProvider(info?.provider || 'ollama');
+      setMistralAvailable(!!info?.mistral_available);
+      setMistralModelState(info?.mistral_model || '');
+      if (info?.mistral_available) {
+        try {
+          setMistralModels(await getMistralModels());
+        } catch {
+          /* model list is best-effort; toggle still works */
+        }
+      }
+    } catch (err) {
+      // Endpoint missing / backend down — leave defaults, don't spam the user.
+      console.error('Failed to load LLM provider info:', err.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadProvider();
+  }, [loadProvider]);
+
+  const handleProviderChange = async (_e, next) => {
+    if (!next || next === provider) return;
+    setProviderBusy(true);
+    try {
+      await setLlmProvider(next);
+      setProvider(next);
+      showMessage(
+        next === 'mistral'
+          ? 'Chat now routes to Mistral (cloud API).'
+          : 'Chat now uses local Ollama.',
+        'success',
+      );
+      if (next === 'mistral' && mistralModels.length === 0) {
+        try {
+          setMistralModels(await getMistralModels());
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch (err) {
+      showMessage(`Could not switch provider: ${err.message}`, 'error');
+    } finally {
+      setProviderBusy(false);
+    }
+  };
+
+  const handleMistralModelChange = async (e) => {
+    const model = e.target.value;
+    setMistralModelState(model);
+    try {
+      await setMistralModel(model);
+      showMessage(`Mistral model set to ${model}.`, 'success');
+    } catch (err) {
+      showMessage(`Could not set Mistral model: ${err.message}`, 'error');
+    }
+  };
+
+  const handleTestMistral = async () => {
+    setTestingMistral(true);
+    try {
+      const res = await testMistral();
+      showMessage(`Mistral OK: "${res?.response || 'connected'}"`, 'success');
+    } catch (err) {
+      showMessage(`Mistral test failed: ${err.message}`, 'error');
+    } finally {
+      setTestingMistral(false);
+    }
+  };
 
   const handleActionClick = async (
     actionFunction,
@@ -94,6 +185,83 @@ const ModelManagementSection = ({
       <Typography variant="h6" gutterBottom>
         Model Management
       </Typography>
+
+      {/* --- LLM provider choice: local Ollama vs Mistral cloud API --- */}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          LLM Provider
+        </Typography>
+        <ToggleButtonGroup
+          exclusive
+          color="primary"
+          value={provider}
+          onChange={handleProviderChange}
+          disabled={providerBusy}
+          size="small"
+        >
+          <ToggleButton value="ollama">Ollama (local)</ToggleButton>
+          <Tooltip
+            title={
+              mistralAvailable
+                ? 'Route chat to Mistral’s hosted API'
+                : 'Set MISTRAL_API_KEY in .env to enable'
+            }
+          >
+            <span>
+              <ToggleButton value="mistral" disabled={!mistralAvailable}>
+                Mistral (cloud)
+              </ToggleButton>
+            </span>
+          </Tooltip>
+        </ToggleButtonGroup>
+
+        {provider === 'mistral' && (
+          <Box sx={{ mt: 2 }}>
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Chat generation is using Mistral’s cloud API. Embeddings/RAG stay on
+              local Ollama. Requests leave your machine.
+            </Alert>
+            <Grid container spacing={2} alignItems="center">
+              <Grid item xs={12} md={8}>
+                <FormControl fullWidth size="small">
+                  <InputLabel>Mistral Model</InputLabel>
+                  <Select
+                    value={mistralModel}
+                    label="Mistral Model"
+                    onChange={handleMistralModelChange}
+                  >
+                    {(mistralModels.length
+                      ? mistralModels
+                      : [{ name: mistralModel, id: mistralModel }]
+                    ).map((m) => (
+                      <MenuItem key={m.id || m.name} value={m.name}>
+                        {m.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <Button
+                  variant="outlined"
+                  fullWidth
+                  onClick={handleTestMistral}
+                  disabled={testingMistral}
+                >
+                  {testingMistral ? <CircularProgress size={22} /> : 'Test Connection'}
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+        )}
+      </Box>
+      <Divider sx={{ mb: 2 }} />
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        {provider === 'mistral'
+          ? 'Ollama models (active when provider is set back to Ollama):'
+          : 'Ollama models:'}
+      </Typography>
+
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="body2" color="text.secondary" gutterBottom>


### PR DESCRIPTION
## What

Adds **Mistral's hosted API as an opt-in, runtime-selectable chat LLM provider** alongside the default local Ollama. Off by default; local-first behaviour is unchanged.

Closes #37

## Why

The chat loop was hardwired to Ollama. This lets users point *chat generation* at a hosted Mistral model when they want to, without giving up the local-first default or the offline path.

## Design

- **`backend/services/mistral_provider.py`** — a Mistral client that yields streaming chunks shaped **exactly like `ollama.chat()`** (`{"message": {"content": …}}` + a final `done=True` chunk with token counts). Because of this, the existing streaming / XML-tool-call / token-counting loop in `unified_chat_engine` works unchanged. Also exposes a LlamaIndex `CustomLLM` wrapper so the `llm_service` helpers route through too. Uses `requests` only — **no new dependency**.
- **`backend/services/llm_provider.py`** — single source of truth for the active provider (`ollama` | `mistral`), persisted in the `settings` table. Degrades to Ollama if the key is removed, so a missing key can never wedge chat.
- **`backend/api/llm_provider_api.py`** — `/api/llm/provider` (GET/POST), `/provider/models`, `/provider/mistral-model`, `/provider/test`. Auto-discovered blueprint.
- **`unified_chat_engine._call_llm_streaming`** and **`llm_service.get_llm_instance`** — dispatch to Mistral when active.
- **`backend/config.py`** — `MISTRAL_API_KEY` / `GUAARDVARK_MISTRAL_MODEL` (read from env; no secrets in code).
- **Frontend** (`ModelManagementSection.jsx`, `modelService.js`) — provider toggle, Mistral model picker, Test Connection button, and an in-UI notice that cloud requests leave the machine.

**Embeddings/RAG deliberately stay on local Ollama** — switching the embedding model would invalidate the vector store.

## Testing

- Live round-trip against `api.mistral.ai`: model listing (53 models), `complete()`, and streaming with correct token counts.
- Full HTTP path via Flask test client: toggle persists in DB, `/provider/test` → "Connection successful", reset to Ollama.
- Backend modules import cleanly; `eslint` passes; production frontend build is green.

## Security / privacy

- Off by default; the offline-first guarantee holds unless a user explicitly enables it and sets a key.
- API key is read from `.env` only — never committed or logged.

## Checklist

- [x] One concern per PR (this is the Mistral provider only)
- [x] No new runtime dependencies
- [x] Local-first default preserved
- [ ] Maintainer review of whether a hosted provider fits the project's scope
