### PR TITLE
fix: first-run setup on a clean machine + LAN access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Guaardvark is a self-hosted, offline-first AI workstation: a Flask backend, a React/Vite frontend, a Python CLI (`llx`), and 10+ GPU service plugins. Everything runs locally by default. The exhaustive feature/model/tool enumeration lives in `CAPABILITIES.md`; the marquee overview is in `README.md`.
+
+## Running & developing
+
+`./start.sh` is the single entry point. On first run it provisions everything: PostgreSQL, Redis, the Python venv (`backend/venv`), Node modules, schema sync, frontend build, and all services (Flask API on `:5000`, Vite UI on `:5173`). Useful flags: `--test` (health diagnostics), `--no-browser`, `--no-auto-build`, `--no-voice`. `./stop.sh` stops services; `./killswitch.sh` is the emergency full-stop (locks the codebase in the DB, kills Celery + agents — see Safety below).
+
+For iterative work, run services individually rather than re-running `start.sh`:
+
+```bash
+# Backend (from repo root, venv active)
+source backend/venv/bin/activate
+export FLASK_APP=backend.app GUAARDVARK_ROOT=$(pwd)
+flask run --debug --host=0.0.0.0 --port=5000
+
+# Frontend (HMR)
+cd frontend && npm run dev -- --host --port=5173
+```
+
+## LAN / remote access
+
+Both servers already bind to `0.0.0.0` (Flask `FLASK_RUN_HOST`, Vite `server.host`/`preview.host`), so they're reachable at the host's LAN IP. Two allowlists gate a browser arriving from a non-localhost origin; both are driven from `.env`:
+
+- `VITE_ALLOWED_HOSTS` — comma-separated hosts/IPs added to Vite's host check (`vite.config.js`). Without your LAN IP here, Vite returns **"Blocked request."** Use `all` to disable the check (trusted nets only).
+- `VITE_FRONTEND_URL` — your LAN origin (e.g. `http://192.168.1.108:5173`). Added to the backend REST CORS list (`backend/app.py`) and the SocketIO `cors_allowed_origins` (`backend/socketio_instance.py`); the socket handshake's `Origin` is checked even though Vite proxies the connection.
+
+`start.sh` serves the **production build via `vite preview`**, which does *not* share the `server:` block — so `vite.config.js` repeats host-allowlist + `/api`+`/socket.io` proxy under a `preview:` block (shared `ALLOWED_HOSTS`/`PROXY` consts). The frontend calls relative `/api` and connects the socket to `window.location.origin`, relying on that proxy. `VITE_ALLOWED_HOSTS` is read at build time, so rebuild (re-run `start.sh`, or `npm run build`) after changing it. Caution: this exposes the full API (agent/desktop/system tooling) to anyone on the LAN — only on a trusted network, never port-forwarded to the internet.
+
+## Tests & lint
+
+```bash
+python3 run_tests.py                              # full suite: installs deps, runs migrations, then pytest
+python3 -m pytest backend/tests/test_rules.py -vv # single file (set GUAARDVARK_MODE=test, DISABLE_CELERY=true)
+cd frontend && npm run lint                        # eslint, --max-warnings 0
+cd frontend && npm run test                        # vitest (jsdom)
+scripts/lint.sh                                    # flake8 (syntax-only: E9,E11,F63,F7,F82) + black --check
+```
+
+`run_tests.py` forces `GUAARDVARK_MODE=test` and `DISABLE_CELERY=true`; replicate those env vars when running pytest directly. Backend tests are under `backend/tests/` (mirrors source: `api/`, `services/`, `models/`, `integration/`); shared fixtures in `conftest.py`.
+
+## Architecture
+
+**App bootstrap (`backend/app.py`).** A Flask app singleton built by `create_app()`, guarded so it runs **exactly once per process** (`get_or_create_app()` is the accessor — never call `create_app()` directly). Holds SocketIO, SQLAlchemy, Celery, and an Executor. The `__name__ == "__main__"` guard at the top aliases `backend.app` into `sys.modules` to prevent a dual-import that would create a second Flask app and corrupt shared state.
+
+**Blueprint auto-discovery.** API endpoints in `backend/api/` (~90 modules ending `_api.py`) are **not** registered manually — `backend/utils/blueprint_discovery.py` scans the directory and registers every Flask blueprint it finds. Add a new endpoint by dropping a module that exports a `Blueprint`; no central wiring needed. (A handful of blueprints with import-order constraints are still registered explicitly near the end of `create_app()`.)
+
+**Tool registry (`backend/tools/` + `backend/services/agent_tools.py`).** ~70 tool classes (subclasses of `BaseTool`) registered into a global registry at startup via `backend/tools/tool_registry_init.py`. Tools carry a **category** (content, generation, desktop, agent_control, system, browser, etc.) and flags (`is_dangerous`, `requires_approval`). These categories/flags are what the MCP policy gates on — see below.
+
+**AgentBrain (`backend/services/agent_brain.py`).** Three-tier router every chat message enters at Tier 1 and escalates only if needed: **Reflex** (<100ms, pattern match, 0 LLM calls) → **Instinct** (single pre-warmed shot) → **Deliberation** (full ReACT loop). Telemetry appends to `logs/tier_telemetry.jsonl`. State lives in `backend/services/brain_state.py`.
+
+**MCP (`backend/mcp/`).** Bidirectional. The stdio **server** exposes tools/resources to external clients under a strict **default-deny** policy (`backend/mcp/config.py`): the `desktop`, `agent_control`, `system`, `test_execution`, `browser`, and `mcp` categories are hidden, plus anything flagged dangerous/approval-required. Only `data/outputs/` is served, read-only, as `guaardvark://outputs/...`. Config source of truth is `data/config/mcp.json`; env vars override. **When adding a tool that touches the machine, set its category/flags correctly — that is the security boundary.**
+
+**Async work (Celery).** `backend/celery_app.py` + `backend/tasks/`. Long-running work (video render, training, self-improvement, social outreach, backups, RAG autoresearch) runs as Celery tasks; `celery beat` schedules periodic jobs. Workers use the `spawn` multiprocessing start method. Tasks fetch an app context via `get_or_create_app()`. `start_celery.sh` / `start_redis.sh` / `start_postgres.sh` bring up the dependencies.
+
+**Plugins (`plugins/`).** Each is a self-contained GPU service (comfyui, ollama, swarm, audio_foundry, lora_trainer, upscaling, video_editor, vision_pipeline, gpu_embedding, discord, training) with a `plugin.json` manifest (id, port, `vram_estimate_mb`, endpoints, config). The **System Resource Orchestrator** arbitrates VRAM across them. Plugins run as separate processes on their own ports and are health-checked.
+
+**Frontend (`frontend/src/`).** React 18 + Vite + Material-UI v5. `pages/` (~38 routes), `components/` (chat, agent, videoeditor, documents, swarm, …), `stores/` (Zustand for global state, React Context for layout/status). REST via Axios, realtime via `socket.io-client`, code editing via Monaco, graph views via reactflow/d3-force, VNC viewer via `@novnc/novnc`. The Vite config proxies to Flask on `:5000` and includes node polyfills for browser builds.
+
+**CLI (`cli/llx/`).** The `llx` command (published to PyPI as `guaardvark`) — a REPL + command catalog (`commands/`, `command_catalog.py`) that talks to the backend, with its own lite server fallback. Version is single-sourced from the repo-root `VERSION` file.
+
+## Database & schema
+
+SQLAlchemy models in `backend/models.py` (~56 models; `db = SQLAlchemy()` shared instance). **Schema is kept in sync via `scripts/schema_sync.py`, not migration replay** — it diffs `models.py` against the live DB and applies changes (`--check` to verify only). `start.sh` and `run_tests.py` run schema sync / `scripts/check_migrations.py` automatically. After changing `models.py`, run `python3 scripts/schema_sync.py` (or `--check` in CI). Default DB URL: `postgresql://guaardvark:guaardvark@localhost:5432/guaardvark` (override via `DATABASE_URL`).
+
+## Configuration
+
+All paths resolve through `backend/config.py` — **never hardcode paths.** `GUAARDVARK_ROOT` anchors everything; storage/upload/output/cache/log/backup dirs are derived (`data/`, `logs/`, `backups/`) and overridable via `GUAARDVARK_*` env vars. Secrets and `DATABASE_URL` come from the repo-root `.env`. `GUAARDVARK_MODE` selects runtime mode (`default` / `test`).
+
+## Safety-critical systems
+
+These have real teeth — understand them before touching agent/self-improvement/outreach code:
+
+- **Codebase lock.** `killswitch.sh` and the `codebase_locked` / `self_improvement_enabled` rows in `system_settings` (plus the `data/.codebase_lock` lockfile) gate whether the self-improvement engine may modify code. Self-improvement runs test → agent fix → verify, optionally behind an "Uncle Claude" (Anthropic API) guardian review and a Pending Fixes approval queue.
+- **Outreach** (`backend/tasks/social_outreach_tasks.py`, `backend/tools/outreach_tools.py`) is **supervised by default** — drafts queue and nothing posts without explicit approval. Per-platform cadence limits, a JSONL audit trail, persona enforcement, and a global kill switch all apply. Operator identity is config-driven (do not hardcode a person — see commit history).
+- **MCP default-deny** (above) is the boundary for what external clients can invoke.
+
+## Conventions
+
+- Commit messages: conventional format `type(scope): description` (`feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`).
+- Python: type hints where surrounding code uses them; imports grouped stdlib / third-party / local; paths via `backend.config`.
+- React: functional components + hooks; MUI v5 for UI; Zustand for global state, Context for layout.
+- Keep changes focused and match surrounding style; one concern per PR.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,34 @@ import rollupNodePolyFill from "rollup-plugin-polyfill-node";
 const FLASK_PORT = process.env.FLASK_PORT || process.env.FLASK_RUN_PORT || 5000;
 const VITE_PORT = process.env.VITE_PORT || 5173;
 
+// Extra hostnames/IPs allowed to reach the dev server (comma-separated).
+// Set VITE_ALLOWED_HOSTS to your LAN IP (e.g. "192.168.1.108") to reach the UI
+// from another device, or "all" to skip the host check entirely (trusted nets only).
+const EXTRA_ALLOWED_HOSTS = (process.env.VITE_ALLOWED_HOSTS || "")
+  .split(",")
+  .map((h) => h.trim())
+  .filter(Boolean);
+const ALLOWED_HOSTS = EXTRA_ALLOWED_HOSTS.includes("all")
+  ? "all"
+  : ["localhost", "127.0.0.1", ".local", ...EXTRA_ALLOWED_HOSTS];
+
+// Shared by both the dev (`server`) and production-preview (`preview`) servers.
+// The frontend calls a relative "/api" and connects the socket to the page
+// origin, so whichever server serves the page must proxy these to Flask.
+const PROXY = {
+  "/api": {
+    target: `http://localhost:${FLASK_PORT}`,
+    changeOrigin: true,
+    secure: false,
+  },
+  "/socket.io": {
+    target: `http://localhost:${FLASK_PORT}`,
+    changeOrigin: true,
+    secure: false,
+    ws: true,
+  },
+};
+
 export default defineConfig({
   plugins: [react()],
   test: {
@@ -70,23 +98,17 @@ export default defineConfig({
     host: '0.0.0.0',
     port: parseInt(VITE_PORT),
     strictPort: true,
-    allowedHosts: [
-      'localhost',
-      '127.0.0.1',
-      '.local',
-    ],
-    proxy: {
-      "/api": {
-        target: `http://localhost:${FLASK_PORT}`,
-        changeOrigin: true,
-        secure: false,
-      },
-      "/socket.io": {
-        target: `http://localhost:${FLASK_PORT}`,
-        changeOrigin: true,
-        secure: false,
-        ws: true,
-      },
-    },
+    allowedHosts: ALLOWED_HOSTS,
+    proxy: PROXY,
+  },
+  // `start.sh` serves the production build via `vite preview`, which does NOT
+  // share the `server:` block above — so host allowlist + API/WS proxy must be
+  // repeated here, or LAN clients get "Blocked request" and /api + sockets 404.
+  preview: {
+    host: '0.0.0.0',
+    port: parseInt(VITE_PORT),
+    strictPort: true,
+    allowedHosts: ALLOWED_HOSTS,
+    proxy: PROXY,
   },
 });

--- a/start.sh
+++ b/start.sh
@@ -103,7 +103,10 @@ if [ -f "$MANAGER_SCRIPT" ]; then
     fi
 fi
 
-PYTHON_CMD="python3"
+# Interpreter used for the version gate and venv creation. Override when the
+# system `python3` isn't 3.12 (e.g. deadsnakes installs `python3.12` side-by-side
+# without repointing the symlink): `PYTHON_CMD=python3.12 ./start.sh`.
+PYTHON_CMD="${PYTHON_CMD:-python3}"
 NPM_CMD="npm"
 OLLAMA_SERVICE_NAME="ollama"
 BACKEND_DIR="$SCRIPT_DIR/backend"
@@ -258,12 +261,12 @@ check_with_cache() {
 }
 
 check_python_version() {
-    if ! command_exists python3; then
-        vader_error "python3 not found. Install via: apt-get install -y python3 python3-venv python3-dev python3-pip"
+    if ! command_exists "$PYTHON_CMD"; then
+        vader_error "$PYTHON_CMD not found. Install via: apt-get install -y python3 python3-venv python3-dev python3-pip"
         return 1
     fi
     local ver
-    ver=$(python3 --version 2>&1 | awk '{print $2}')
+    ver=$("$PYTHON_CMD" --version 2>&1 | awk '{print $2}')
     local major=${ver%%.*}
     local minor=${ver#*.}
     minor=${minor%%.*}
@@ -273,7 +276,7 @@ check_python_version() {
     # instead. NOTE: the old logic was inverted — it returned success for 3.13+
     # and fell through to a failure for 3.12, the one version that works.
     if [ "$major" -ne 3 ] || [ "$minor" -lt 12 ]; then
-        vader_error "Python 3.12 is required (found $ver). Install it: 'sudo apt-get install -y python3.12 python3.12-venv python3.12-dev python3.12-distutils', then re-run."
+        vader_error "Python 3.12 is required (found $ver). Install it: 'sudo apt-get install -y python3.12 python3.12-venv python3.12-dev' (on Ubuntu 22.04, add the deadsnakes PPA first; note 3.12 has no distutils package), then re-run with 'PYTHON_CMD=python3.12 ./start.sh'."
         return 1
     fi
     if [ "$minor" -ge 13 ]; then
@@ -892,10 +895,46 @@ fi
 
 source "$VENV_DIR/bin/activate" || { vader_error "Failed to activate venv"; exit 1; }
 
-# Dependency reconciliation is intentionally disabled during startup. It was
-# blocking otherwise healthy boots when the reconciler drift check failed.
+# Dependency reconciliation (drift repair) is intentionally disabled during
+# startup — it was blocking otherwise healthy boots when its drift check failed.
 # Run scripts/dep_reconciler.py manually when dependency repair is needed.
+#
+# Initial install is NOT optional, though: a freshly created venv has no
+# packages, so the backend dies on `import numpy`. Install the requirements
+# (and PyTorch via the smart installer) once, gated by a marker file so normal
+# boots stay fast. Delete the marker to force a reinstall.
 vader_info "Dependency reconciliation skipped"
+DEPS_MARKER="$VENV_DIR/.deps_installed"
+if [ ! -f "$DEPS_MARKER" ]; then
+    vader_info "Installing Python dependencies (first run; this takes a while)..."
+    "$VENV_DIR/bin/python" -m pip install --quiet --upgrade pip wheel
+    if "$VENV_DIR/bin/pip" install -r "$BACKEND_DIR/requirements.txt"; then
+        vader_success "Python dependencies installed"
+        # PyTorch is installed separately — the smart installer picks the right
+        # CUDA/CPU build for this machine. Non-fatal: generation features need
+        # it, but the API boots without it.
+        if [ -f "$SCRIPT_DIR/scripts/install_pytorch.sh" ]; then
+            vader_info "Installing PyTorch (GPU-aware)..."
+            bash "$SCRIPT_DIR/scripts/install_pytorch.sh" || vader_warn "PyTorch install failed (non-fatal; generation features unavailable)."
+            # install_pytorch.sh runs `pip install --upgrade ... --index-url .../whl/<ver>`,
+            # which drags numpy 2.x and an old setuptools in — both violate the pins in
+            # requirements.txt (the ML stack needs numpy<2.0; llama-index needs
+            # setuptools>=80.9.0). Re-assert the constrained versions without touching
+            # torch (--no-deps).
+            vader_info "Re-pinning numpy/setuptools after PyTorch install..."
+            "$VENV_DIR/bin/pip" install --no-deps --force-reinstall \
+                'numpy<2.0,>=1.26.4' 'setuptools>=80.9.0,<81' >/dev/null 2>&1 \
+                || vader_warn "Could not re-pin numpy/setuptools — check 'pip check'."
+        fi
+        touch "$DEPS_MARKER"
+    else
+        vader_error "Python dependency install failed. Fix the error above, then re-run. (Delete $DEPS_MARKER is not needed; it was not created.)"
+        deactivate
+        exit 1
+    fi
+else
+    vader_info "Python dependencies present (delete $DEPS_MARKER to force reinstall)"
+fi
 deactivate
 
 # --- CLI tool setup ---
@@ -1369,8 +1408,8 @@ echo "$BACKEND_PID" > "$SCRIPT_DIR/pids/backend.pid"
 
 sleep 4
 
-if ! is_port_listening "$FLASK_PORT" 30 "Backend"; then
-    vader_error "Backend failed to start listening on port $FLASK_PORT after 30 seconds."
+if ! is_port_listening "$FLASK_PORT" 90 "Backend"; then
+    vader_error "Backend failed to start listening on port $FLASK_PORT after 90 seconds."
     if [ -f "$BACKEND_STARTUP_LOG_FILE" ]; then
         vader_error "Last 10 lines of startup log:"
         tail -n 10 "$BACKEND_STARTUP_LOG_FILE"


### PR DESCRIPTION
## What

Fixes the first-run path so `./start.sh` reaches a running stack on a clean Ubuntu machine, and makes the UI reachable over the LAN. Each change is small and independent.

Closes #39

## Changes

**`start.sh` — first-run setup** (`fix(start.sh)`)
- Honor a `PYTHON_CMD` override (default `python3`) and use it in the version gate, so a side-installed `python3.12` (deadsnakes, symlink not repointed) is usable: `PYTHON_CMD=python3.12 ./start.sh` (or set it in `.env`).
- Install Python deps on first run (marker-guarded, so normal boots stay fast) — a fresh venv was empty and the backend died on `import numpy`.
- Re-pin `numpy<2.0` / `setuptools>=80.9.0` after `install_pytorch.sh` (its `--upgrade` drags numpy 2.x + old setuptools in); done with `--no-deps` so torch is untouched.
- Widen the backend bind-wait 30s → 90s (cold ML-stack import takes ~40s on CPU).
- Fix the 3.12 error hint (no `distutils` package; mention deadsnakes + the `PYTHON_CMD` prefix).

**`frontend/vite.config.js` — LAN access** (`feat(frontend)`)
- `start.sh` serves the prod build via `vite preview`, which doesn't share the `server:` block. Add a `preview:` block mirroring `server:` (host allowlist + `/api`+`/socket.io` proxy), extracted to a shared `PROXY` const.
- Make `allowedHosts` env-driven via `VITE_ALLOWED_HOSTS` (comma-separated, or `all`), defaulting to localhost/127.0.0.1/.local. Pairs with `VITE_FRONTEND_URL` (already added to the backend CORS/SocketIO origin allowlist).

**`CLAUDE.md`** (`docs`) — architecture + build/test/lint + setup + LAN section. CONTRIBUTING.md already references it.

## Testing

- Full clean-machine run: `./start.sh` reaches all 11 steps, backend binds on :5000, frontend builds + serves, basic health checks pass.
- LAN: UI reachable at `http://<lan-ip>:5173` with the env vars set; REST + Socket.IO work through the preview proxy.
- `bash -n start.sh` clean; frontend `eslint` + production build green.

## Notes

- No new runtime dependencies.
- The first-run dependency install is intentionally marker-guarded (`backend/venv/.deps_installed`) so it only runs when the venv is fresh; delete the marker to force a reinstall.
