### PR TITLE
fix(macos): portability round 2 — clear the #41 step-11/post-boot warnings

### DIFF
--- a/backend/api/batch_image_generation_api.py
+++ b/backend/api/batch_image_generation_api.py
@@ -241,6 +241,14 @@ def _parse_generation_params(data: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict
     params['enhance_faces'] = data.get('enhance_faces', True)
     params['enhance_hands'] = data.get('enhance_hands', True)
 
+    # Director intelligence (opt-in; mirrors batch-video exactly). Safe defaults = disabled.
+    params['director_mode'] = bool(data.get('director_mode', False))
+    params['director_guidance'] = data.get('director_guidance') or data.get('extra_guidance')
+    params['storyboard_concept'] = data.get('storyboard_concept')
+    params['planning_mode'] = data.get('planning_mode', 'narrative')
+    params['director_model'] = data.get('director_model')
+    params['user_treatment'] = data.get('user_treatment') or data.get('treatment')
+
     # Face restoration parameters
     params['restore_faces'] = data.get('restore_faces', False)
     params['face_restoration_weight'] = float(data.get('face_restoration_weight', 0.5))
@@ -760,6 +768,41 @@ def enhance_prompt():
         logger.error(f"Error enhancing prompt: {e}")
         return error_response(str(e), 500)
 
+
+@batch_image_bp.route("/expand-concept", methods=["POST"])
+def expand_concept():
+    """Director-powered: turn high-level idea + N into a reviewable plan (treatment + per-shot prompts).
+    Non-GPU, cheap Ollama call. Returns plan for UI editing + later launch.
+    """
+    try:
+        if not service_available:
+            return error_response("Batch image service not available", 503)
+        data = request.get_json() or {}
+        idea = (data.get("idea") or data.get("concept") or "").strip()
+        if not idea:
+            return error_response("idea or concept required", 400)
+        n = max(1, min(int(data.get("n") or data.get("quantity") or 4), 24))
+        look = data.get("look_and_feel") or data.get("style") or ""
+        treatment = data.get("user_treatment") or data.get("treatment")
+        mode = data.get("planning_mode", "narrative")
+        guidance = data.get("director_guidance") or data.get("extra_guidance")
+        dmodel = data.get("director_model")
+
+        from backend.services.media_director import expand_image_plan
+        plan = expand_image_plan(
+            idea, n,
+            look_and_feel=look,
+            user_treatment=treatment,
+            planning_mode=mode,
+            extra_guidance=guidance,
+            model=dmodel,
+            cast_descriptors=data.get("cast_descriptors"),
+        )
+        return success_response({"plan": plan, "n": n})
+    except Exception as e:
+        logger.error(f"expand-concept error: {e}")
+        return error_response(str(e), 500)
+
 @batch_image_bp.route("/generate/csv", methods=["POST"])
 def generate_from_csv():
     """Start batch generation from uploaded CSV file."""
@@ -1176,8 +1219,19 @@ def get_batch_image(batch_id: str, image_name: str):
                 image_path = Path(status.output_dir) / "images" / decoded_image_name
 
         if not image_path.exists():
-            # If thumbnail was requested but not found, fall back to serving the full image
+            # If thumbnail was requested but not found, fall back to serving the full image.
+            # Use stem matching because thumbnails are always .jpg while images keep their original ext.
             if request.args.get('thumbnail') == 'true':
+                stem = Path(safe_image_name).stem
+                images_dir = Path(status.output_dir) / "images"
+                # Try common extensions for the matching full image
+                for ext in ('.png', '.jpg', '.jpeg', '.webp', '.gif'):
+                    for candidate_name in (f"{stem}{ext}", f"{safe_image_name}"):
+                        candidate = images_dir / candidate_name
+                        if candidate.exists():
+                            logger.info(f"Thumbnail not found, serving full image as fallback by stem: {candidate}")
+                            return send_file(str(candidate))
+                # Last resort: try original decoded name variants in images/
                 fallback_path = Path(status.output_dir) / "images" / safe_image_name
                 if not fallback_path.exists() and safe_image_name != decoded_image_name:
                     fallback_path = Path(status.output_dir) / "images" / decoded_image_name

--- a/backend/api/cast_library_api.py
+++ b/backend/api/cast_library_api.py
@@ -6,12 +6,48 @@ from pathlib import Path
 from flask import Blueprint, current_app, request, jsonify, send_file
 from werkzeug.utils import secure_filename
 
-from backend.models import db, Subject
+from backend.models import db, Subject, SubjectSample
 
 bp = Blueprint("cast_library_api", __name__, url_prefix="/api/cast-library")
 log = logging.getLogger(__name__)
 
 VALID_KINDS = {"character", "environment", "prop"}
+
+# Repo root (…/backend/api/cast_library_api.py → parents[2]). Ref paths are stored
+# relative to the project root; resolving against this instead of the process cwd
+# makes preview serving robust no matter where/how the backend was launched.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _resolve_ref_path(p: str) -> str | None:
+    """Return an on-disk absolute path for a stored ref image, or None.
+    Tries the value as-is (abs or cwd-relative), then relative to the repo root,
+    then relative to the data/STORAGE_DIR — covers training-dir refs and cast_refs
+    uploads. The resolved path MUST live under one of those roots: ref_image_paths
+    can be set via the create-API body, so this is the guard against a crafted
+    '../../etc/passwd' reaching send_file."""
+    if not p:
+        return None
+    roots = [_PROJECT_ROOT]
+    try:
+        storage = current_app.config.get("STORAGE_DIR")  # registered key (NOT "DATA_DIR")
+        if storage:
+            roots.append(Path(storage).resolve())
+    except RuntimeError:
+        pass  # outside app context (shouldn't happen on a request, but be safe)
+    candidates = [p] + [str(r / p) for r in roots]
+    for c in candidates:
+        try:
+            if not os.path.isfile(c):
+                continue
+            # Always hand send_file an ABSOLUTE path — Flask raises on a relative one.
+            ap = os.path.abspath(c)
+            # Containment: the file must sit inside an allowed root, else skip it.
+            if any(os.path.commonpath([ap, str(r)]) == str(r) for r in roots):
+                return ap
+        except (OSError, ValueError):
+            continue
+    return None
 
 # Standard image formats — anything else is rejected at upload time.
 _ALLOWED_REF_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"}
@@ -20,7 +56,7 @@ _MAX_REF_BYTES = 25 * 1024 * 1024  # 25 MB per image — generous, but caps runa
 
 def _cast_ref_dir(subject_id: int) -> Path:
     """Where reference images for a Subject live on disk. Created lazily."""
-    base = Path(current_app.config.get("DATA_DIR") or "data")
+    base = Path(current_app.config.get("STORAGE_DIR") or "data")  # registered key (NOT "DATA_DIR")
     target = base / "cast_refs" / str(subject_id)
     target.mkdir(parents=True, exist_ok=True)
     return target
@@ -36,6 +72,7 @@ def _serialize(s: Subject) -> dict:
         "lora_path": s.lora_path,
         "lora_version": s.lora_version,
         "training_status": s.training_status,
+        "bible": s.bible,  # the appearance-lock injected per cut; surfaced for UI preview
     }
 
 
@@ -95,11 +132,9 @@ def subject_preview(subject_id):
     if s is None:
         return jsonify({"error": "not_found"}), 404
     for p in (s.ref_image_paths or []):
-        try:
-            if p and os.path.isfile(p):
-                return send_file(p, max_age=3600)
-        except (OSError, ValueError):
-            continue
+        resolved = _resolve_ref_path(p)
+        if resolved:
+            return send_file(resolved, max_age=3600)
     return jsonify({"error": "no_preview"}), 404
 
 

--- a/backend/api/music_video_api.py
+++ b/backend/api/music_video_api.py
@@ -424,7 +424,7 @@ def generate_storyboards(mv_id):
 
     s = _settings_for_mv(mv)  # small helper below or inline
     from backend.services.comfyui_image_generator import ComfyUIImageGenerator
-    from backend.tasks.music_video_tasks import _keyframe_loras_and_prompt, _clip_dir
+    from backend.tasks.music_video_tasks import _keyframe_loras_and_prompt, _keyframe_lora_strength, _clip_dir
     import copy
 
     clips = copy.deepcopy(mv.clips or [])
@@ -438,10 +438,10 @@ def generate_storyboards(mv_id):
 
     # Media team audit (P1-5/P3-12): use the shared _keyframe helper (resolves explicit
     # loras + subject cast + prepends trigger words) + clamp strength + basic preflight.
-    # This threads LoRA identity into storyboard keyframes (flux-schnell/SDXL path) the
-    # same way the clip i2v path does. Previously the approval path used a minimal
-    # []/prompt version (uncommitted WIP).
-    kf_lora_strength = max(0.0, min(1.0, float(s.get("keyframe_lora_strength", 0.25))))
+    # This threads LoRA identity into storyboard keyframes (flux-dev/schnell/SDXL path)
+    # the same way the clip i2v path does, so review thumbnails match the final render.
+    # Strength is model-aware via the shared helper (0.9 flux-dev / 0.25 sdxl).
+    kf_lora_strength = _keyframe_lora_strength(s)
     try:
         vg = get_video_generator()
         if not getattr(vg, "service_available", True):
@@ -529,7 +529,7 @@ def regen_mv_storyboard(mv_id, idx):
 
     s = _settings_for_mv(mv)
     from backend.services.comfyui_image_generator import ComfyUIImageGenerator
-    from backend.tasks.music_video_tasks import _keyframe_loras_and_prompt, _clip_dir
+    from backend.tasks.music_video_tasks import _keyframe_loras_and_prompt, _keyframe_lora_strength, _clip_dir
     import copy
 
     clips = copy.deepcopy(mv.clips or [])
@@ -560,8 +560,8 @@ def regen_mv_storyboard(mv_id, idx):
 
     # Media team audit resume (P1-5/P3-12): shared helper for LoRA+triggers + clamp + preflight
     # on the regen path (was minimal [] version; now consistent with clip gen and the
-    # generate-storyboards path we just updated).
-    kf_lora_strength = max(0.0, min(1.0, float(s.get("keyframe_lora_strength", 0.25))))
+    # generate-storyboards path). Model-aware strength so a regen matches the batch.
+    kf_lora_strength = _keyframe_lora_strength(s)
     kf_loras, kf_prompt = _keyframe_loras_and_prompt(mv, s, prompt)
     if kf_loras:
         ComfyUIImageGenerator()._preflight_loras(kf_loras)

--- a/backend/api/production_api.py
+++ b/backend/api/production_api.py
@@ -8,6 +8,24 @@ from backend.models import db, Production, Project
 from backend.services.production_service import ProductionService
 from backend.services.swarm.script_markup import effective_cast_required
 
+# Repo root for resolving relative lora_path values (stored as "data/training/loras/x.safetensors"
+# or as absolute paths). backend/api/production_api.py -> parents[2] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _lora_on_disk(lora_path: str | None) -> bool:
+    """Pre-cast freshness gate: a subject claiming 'trained' must have a real LoRA file on disk.
+    Mirrors scripts/verify_training_outputs' >100KB check (catches a missing file or the ~8-byte
+    mock-trainer stub). This is what would have blocked Subjects 8 (file missing) and 10 (stale)
+    from being cast while falsely marked trained."""
+    if not lora_path:
+        return False
+    p = Path(lora_path) if Path(lora_path).is_absolute() else _REPO_ROOT / lora_path
+    try:
+        return p.exists() and p.stat().st_size > 100_000
+    except OSError:
+        return False
+
 bp = Blueprint("production_api", __name__, url_prefix="/api/production")
 log = logging.getLogger(__name__)
 
@@ -243,6 +261,23 @@ def confirm_casting(prod_id):
     ]
     if incomplete:
         return jsonify({"error": "all production subjects must be cast before continuing", "incomplete_subjects": incomplete}), 400
+
+    # Pre-cast freshness gate: a cast member marked 'trained' must have a real LoRA file on disk.
+    # Without this, a stale/missing artifact (Subjects 8 & 10 were exactly this) sails through and
+    # the render silently produces an off-model character.
+    stale = [
+        {"id": s.id, "name": s.name, "lora_path": s.lora_path}
+        for s in subjects
+        if effective_cast_required(s.cast_required, s.kind)
+        and s.training_status == "trained"
+        and not _lora_on_disk(s.lora_path)
+    ]
+    if stale:
+        return jsonify({
+            "error": "some cast members are marked 'trained' but their LoRA file is missing or "
+                     "stale on disk — retrain before casting",
+            "stale_subjects": stale,
+        }), 400
 
     svc = ProductionService(db.session)
     advanced = svc.advance_if_predecessor(prod_id, expected_predecessor="casting")

--- a/backend/app.py
+++ b/backend/app.py
@@ -111,6 +111,18 @@ try:
     logging.getLogger(__name__).info(
         "Plugin-runner sidecar started (clean fork environment, no torch)"
     )
+
+    # Ensure the sidecar (and any mp resources it manages) are cleaned on exit.
+    # This prevents "leaked semaphore" warnings from the resource_tracker at
+    # interpreter shutdown (the exact class of bug that motivated the sidecar).
+    import atexit
+    def _shutdown_plugin_runner():
+        try:
+            _PluginRunnerClient.get().shutdown()
+            logging.getLogger(__name__).debug("Plugin-runner sidecar shutdown complete")
+        except Exception as _e:
+            logging.getLogger(__name__).debug(f"Plugin-runner shutdown (non-fatal): {_e}")
+    atexit.register(_shutdown_plugin_runner)
 except Exception as _e:
     logging.getLogger(__name__).warning(f"Plugin-runner sidecar failed to start: {_e}")
     # Non-fatal — plugin_manager will fall back to direct subprocess.run
@@ -1000,6 +1012,27 @@ def _initialize_app_components(app):
         register_browser_shutdown(app)
     except Exception as e:
         app.logger.debug(f"Browser shutdown registration skipped: {e}")
+
+    # Unload heavy generators (torch/diffusers pipelines) on exit to release
+    # any associated IPC semaphores / CUDA graphs tracked by the mp resource_tracker.
+    # Prevents "leaked semaphore" warnings at shutdown.
+    import atexit
+    def _unload_heavy_generators():
+        try:
+            from backend.services.offline_image_generator import get_image_generator
+            gen = get_image_generator()
+            if hasattr(gen, "_unload_pipeline"):
+                gen._unload_pipeline()
+            if hasattr(gen, "clear_cache"):
+                gen.clear_cache()
+        except Exception:
+            pass  # best effort; generator may not be initialized
+        try:
+            from backend.utils.thread_pool_manager import shutdown_all_pools
+            shutdown_all_pools(wait=False)
+        except Exception:
+            pass
+    atexit.register(_unload_heavy_generators)
 
     return app
 

--- a/backend/services/batch_image_generator.py
+++ b/backend/services/batch_image_generator.py
@@ -28,6 +28,13 @@ except ImportError as e:
     offline_gen_available = False
 
 try:
+    from backend.services.media_director import expand_image_plan, direct_prompts as media_direct_enhance
+    MEDIA_DIRECTOR_AVAILABLE = True
+except Exception as e:  # noqa: BLE001
+    logger.warning(f"media_director not available for batch image (will skip): {e}")
+    MEDIA_DIRECTOR_AVAILABLE = False
+
+try:
     from backend.config import CACHE_DIR, UPLOAD_DIR
     config_available = True
 except ImportError:
@@ -78,6 +85,13 @@ class BatchImageRequest:
     restore_faces: bool = False
     face_restoration_weight: float = 0.5
     remove_background: bool = False
+    # Director / storyboard intelligence (opt-in, defaults preserve old behavior)
+    director_mode: bool = False
+    director_guidance: Optional[str] = None
+    storyboard_concept: Optional[str] = None
+    planning_mode: str = "narrative"
+    director_model: Optional[str] = None
+    user_treatment: Optional[str] = None
 
 @dataclass
 class BatchImageResult:
@@ -234,6 +248,10 @@ class BatchImageGenerator:
                 thumb_size = (256, 256)
                 image.thumbnail(thumb_size, Image.Resampling.LANCZOS)
 
+                # Ensure RGB for JPEG compatibility (handles RGBA/P modes from generators)
+                if image.mode in ('RGBA', 'P'):
+                    image = image.convert('RGB')
+
                 thumb_filename = Path(image_path).stem + ".jpg"
                 thumb_path = thumbnail_dir / thumb_filename
                 image.save(thumb_path, "JPEG", quality=85)
@@ -242,6 +260,7 @@ class BatchImageGenerator:
 
         except Exception as e:
             logger.warning(f"Failed to create thumbnail for {image_path}: {e}")
+            # As last resort, do not block the result; serving has fallbacks
             return None
 
     def _cleanup_gpu_memory(self):
@@ -487,6 +506,49 @@ class BatchImageGenerator:
             except Exception as e:
                 logger.warning(f"GPU gate release failed: {e}")
 
+    def _apply_director(self, request: BatchImageRequest) -> None:
+        """If director_mode or storyboard_concept, rewrite prompts via Media Director (LLM visual storyteller).
+        Mutates in place and disables downstream generic enhance (director already produces full visual prompts).
+        Never raises — falls back silently (original prompts stand).
+        Mirrors batch_video_generator exactly.
+        """
+        if not MEDIA_DIRECTOR_AVAILABLE:
+            return
+        try:
+            if getattr(request, "storyboard_concept", None):
+                concept = (request.storyboard_concept or "").strip()
+                n = len(request.prompts)
+                if concept and n > 0:
+                    from backend.services.media_director import storyboard_from_concept
+                    res = storyboard_from_concept(concept, n, style=(getattr(request, "look_and_feel", None) or ""), extra_guidance=getattr(request, "director_guidance", None))
+                    shots = res.get("prompts") or []
+                    for i, p in enumerate(request.prompts):
+                        if i < len(shots) and shots[i]:
+                            p.prompt = shots[i]
+                    request.auto_enhance = False
+                    logger.info(f"Media Director storyboard expanded {len(shots)} prompts for batch {request.batch_id}")
+                    return
+            if getattr(request, "director_mode", False):
+                raw = [bp.prompt for bp in request.prompts if (bp.prompt or "").strip()]
+                if not raw:
+                    return
+                style = getattr(request, "style", "") or ""
+                guidance = getattr(request, "director_guidance", None)
+                directed = media_direct_enhance(raw, style=style, extra_guidance=guidance)
+                idx = 0
+                changed = 0
+                for bp in request.prompts:
+                    if (bp.prompt or "").strip() and idx < len(directed) and directed[idx]:
+                        newp = directed[idx].strip()
+                        if newp and newp != (bp.prompt or "").strip():
+                            bp.prompt = newp
+                            changed += 1
+                        idx += 1
+                request.auto_enhance = False
+                logger.info(f"Media Director enhanced {changed} prompts for batch {request.batch_id}")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Director pass skipped for batch image {getattr(request, 'batch_id', '?')} (non-fatal): {e}")
+
     def start_batch_generation(self, request: BatchImageRequest) -> str:
         if not self.service_available:
             raise RuntimeError("Batch image generation service not available")
@@ -544,6 +606,12 @@ class BatchImageGenerator:
 
                 batch_status.status = "running"
                 batch_status.start_time = datetime.now()
+
+                # Director / storyboard pass (if requested). Does NOT raise. Disables auto_enhance on success.
+                try:
+                    self._apply_director(request)
+                except Exception:
+                    pass
 
                 if self.progress_system:
                     self._progress_process_id = self.progress_system.create_process(

--- a/backend/services/batch_video_generator.py
+++ b/backend/services/batch_video_generator.py
@@ -272,16 +272,20 @@ class BatchVideoGenerator:
         generic boilerplate would just dilute it). Never raises — on any failure the
         original prompts stand and generation proceeds unchanged."""
         try:
-            from backend.services.video_director import direct_prompts
+            from backend.services.director_service import plan, DirectorBrief, DirectorMode
             text_items = [it for it in batch_request.items if (it.prompt or "").strip()]
             if not text_items:
                 return
             style = (batch_request.metadata or {}).get("look_and_feel") or batch_request.prompt_style
-            directed = direct_prompts(
-                [it.prompt for it in text_items],
+            result = plan(DirectorBrief(
+                mode=DirectorMode.PROMPT_LIST,
+                prompts=[it.prompt for it in text_items],
                 style=style,
                 extra_guidance=getattr(batch_request, "director_guidance", None),
-            )
+            ))
+            # Map shots back to the per-item string list (count-preserving on success; empty
+            # on a hard director failure → originals stand via the zip below).
+            directed = [s.prompt for s in result.shots]
             changed = 0
             for it, new_prompt in zip(text_items, directed):
                 if new_prompt and new_prompt.strip() and new_prompt.strip() != (it.prompt or "").strip():
@@ -303,16 +307,18 @@ class BatchVideoGenerator:
         off the lighter downstream enhancer (the shots are already full cinematic prompts).
         Never raises — on failure the placeholder prompts (the raw concept) stand."""
         try:
-            from backend.services.video_director import storyboard_from_concept
+            from backend.services.director_service import plan, DirectorBrief, DirectorMode
             concept = (batch_request.storyboard_concept or "").strip()
             n = len(batch_request.items)
             if not concept or n == 0:
                 return
             style = (batch_request.metadata or {}).get("look_and_feel") or batch_request.prompt_style
-            shots = storyboard_from_concept(
-                concept, n, style=style,
+            result = plan(DirectorBrief(
+                mode=DirectorMode.CONCEPT_EXPANSION,
+                concept=concept, num_shots=n, style=style,
                 extra_guidance=getattr(batch_request, "director_guidance", None),
-            )
+            ))
+            shots = [s.prompt for s in result.shots]
             for it, shot in zip(batch_request.items, shots):
                 if shot and shot.strip():
                     it.prompt = shot.strip()

--- a/backend/services/cast_lock.py
+++ b/backend/services/cast_lock.py
@@ -1,0 +1,89 @@
+"""Shared character identity-lock helper — the single source of truth for how a trained
+cast member's LoRA + trigger + bible are applied to a generation prompt.
+
+Three video features independently grew the same logic:
+  * music-video  (music_video_tasks._keyframe_loras_and_prompt) — trigger + bible + strength;
+  * film-crew    (production_swarm_tasks._shot_loras_and_prompt)  — trigger only;
+  * batch        — none (bare lora_name passthrough).
+
+This module unifies that. **Injection stays at RENDER time on purpose** — that is strictly more
+robust than injecting at plan/storyboard time:
+  - it survives a user editing a clip/shot prompt afterward (the trigger can never be lost);
+  - it is naturally PER-SHOT scoped, so a multi-character production only locks the characters
+    actually present in a given shot (a global plan-time cast would over-lock every shot).
+The Director already receives a "do NOT describe the hero's face" guidance note, so plan-time
+injection's only real benefit is already captured without giving up render-time's guarantees.
+
+The pieces:
+  * ``resolve_lora_strength(model, override)`` — model-aware default strength (FLUX-dev ~0.9,
+    SDXL rank-16 ~0.25; verified on sage_harlow 2026-06-22), operator override wins. (Extracted
+    from music_video_tasks._keyframe_lora_strength per the long-standing #1489 cleanup.)
+  * ``subjects_to_lock(subjects, include_bible)`` — Subject objects → (deduped lora_paths,
+    "trigger, bible, …" prefix).
+  * ``apply_lock(base_prompt, lock_prefix)`` — front-load the lock onto a prompt.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+# Model-aware default keyframe/storyboard LoRA strength. SDXL rank-16 character LoRAs sit at
+# ~0.25 (higher fries them); the FLUX-dev route holds identity at ~0.9.
+DEFAULT_FLUX_DEV_STRENGTH = 0.9
+DEFAULT_SDXL_STRENGTH = 0.25
+_MIN_STRENGTH, _MAX_STRENGTH = 0.0, 1.5
+
+
+def resolve_lora_strength(model: Optional[str], override=None) -> float:
+    """Model-aware character-LoRA strength, clamped to [0, 1.5]. ``model`` is the keyframe /
+    storyboard image model name (e.g. 'flux-dev', 'sdxl'); ``override`` (operator setting) wins
+    when not None. FLUX-dev → 0.9, everything else (SDXL et al.) → 0.25."""
+    kfm = (model or "").lower()
+    default = DEFAULT_FLUX_DEV_STRENGTH if ("flux" in kfm and "dev" in kfm) else DEFAULT_SDXL_STRENGTH
+    try:
+        val = float(override) if override is not None else default
+    except (TypeError, ValueError):
+        val = default
+    return max(_MIN_STRENGTH, min(_MAX_STRENGTH, val))
+
+
+def _dedup(seq: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in seq:
+        s = (s or "").strip()
+        if s and s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def subjects_to_lock(subjects: Iterable, *, include_bible: bool = True) -> tuple[list[str], str]:
+    """Given trained cast Subject objects (anything with ``.lora_path``, ``.trigger_word`` /
+    ``.name``, and optionally ``.bible``), return ``(lora_paths, lock_prefix)``.
+
+    Only subjects that actually have a ``lora_path`` contribute — an untrained subject can't lock
+    anything. ``lock_prefix`` is ``"trigger1, trigger2, bible1, bible2"`` (triggers first so they
+    bind the LoRA, then the verbatim bibles that pin constant features like hair length). Both
+    lists are de-duplicated in order. A LoRA only locks identity when its trigger token is
+    actually present in the prompt, so the triggers go INTO the prompt, not just the loader chain.
+    """
+    lora_paths: list[str] = []
+    triggers: list[str] = []
+    bibles: list[str] = []
+    for subj in subjects or []:
+        if getattr(subj, "lora_path", None):
+            lora_paths.append(subj.lora_path)
+            triggers.append((getattr(subj, "trigger_word", None) or getattr(subj, "name", None) or "").strip())
+            if include_bible and getattr(subj, "bible", None):
+                bibles.append(subj.bible.strip())
+    lock = ", ".join([*_dedup(triggers), *_dedup(bibles)])
+    return _dedup(lora_paths), lock
+
+
+def apply_lock(base_prompt: str, lock_prefix: str) -> str:
+    """Front-load the identity lock onto a prompt. No-op when ``lock_prefix`` is empty."""
+    base = (base_prompt or "").strip()
+    if not lock_prefix:
+        return base
+    return f"{lock_prefix}, {base}" if base else lock_prefix

--- a/backend/services/character_captioner.py
+++ b/backend/services/character_captioner.py
@@ -136,7 +136,10 @@ def caption_image(
     has at least the trigger + identity marks — never an empty/identity-less caption)."""
     analyzer = analyzer or _analyzer()
     try:
-        res = analyzer.analyze(str(image_path), _VLM_CAPTION_PROMPT, think=False)
+        # VisionAnalyzer.analyze expects a PIL Image (it base64-encodes internally), not a path.
+        from PIL import Image
+        img = Image.open(str(image_path)).convert("RGB")
+        res = analyzer.analyze(img, _VLM_CAPTION_PROMPT, think=False)
         if getattr(res, "success", False) and getattr(res, "description", "").strip():
             return compose_caption(trigger, res.description, identity_marks)
         log.warning("captioner: VLM failed for %s (%s); using trigger+marks fallback",

--- a/backend/services/character_captioner.py
+++ b/backend/services/character_captioner.py
@@ -1,0 +1,224 @@
+"""VLM auto-captioner for character LoRA training data.
+
+WHY THIS EXISTS — the freckle / horse-head story (2026-06-23):
+The first ``sage_harlow`` LoRA trained on 8 head-only images whose ``.txt`` captions were
+(a) never read (the run used ``caption_strategy: "filename"``) and (b) had no identity marks
+and no full-body framing. The model overfit one face with no learned body, so under motion it
+improvised a body/animal → "horse-head". The fix is real captions with: the trigger word bound
+to the FIXED identity marks (freckles, eye color, beauty mark, hair highlights) AND explicit,
+VARIED framing tags (full body / three-quarter / profile) so the LoRA actually learns a body.
+
+This module is the missing caption step. There was NO auto-captioner anywhere in the repo —
+captions were 100% hand-written. It reuses the existing offline VLM (``VisionAnalyzer`` →
+Ollama Gemma-vision, the same one ``film_curator_service`` uses — no new model download, stays
+fully offline) to describe ONLY the variable, non-identity attributes of each frame, then
+deterministically front-loads the trigger word and appends the fixed identity marks.
+
+Caption layout:  ``<trigger>, <framing>, <pose/gaze>, <expression>, <outfit>, <setting>,
+                   <lighting>, <fixed identity marks>``
+
+Used by:
+  * ``scripts/caption_dataset.py`` — caption a manual SimpleTuner dataset before training.
+  * ``backend/tasks/character_generation_tasks.generate_samples`` — write ``.txt`` sidecars
+    alongside generated training images so the app-generated set is trainable as-is.
+
+It NEVER runs training or GPU work; captioning is a Vision (Ollama) call only.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".webp", ".bmp")
+
+# Canonical framing vocabulary. The captioner asks the VLM to lead with exactly one of these,
+# and the pre-train gate uses ``detect_framing`` to measure pose coverage across the dataset
+# (e.g. "are there enough full-body shots?"). Order = roughly tight → wide.
+FRAMING_TAGS = [
+    "close-up",
+    "head and shoulders",
+    "upper body",
+    "three-quarter view",
+    "full body",
+    "wide shot",
+]
+# Framings that supervise the body (the coverage the horse-head failure was missing).
+FULL_BODY_FRAMINGS = {"three-quarter view", "full body", "wide shot"}
+
+_VLM_CAPTION_PROMPT = (
+    "You are writing a concise training caption for ONE image of a person. "
+    "Output ONLY comma-separated visual tags (no sentences, no 'the image shows', no name). "
+    "Cover, in this order:\n"
+    "1) FRAMING — choose EXACTLY ONE: close-up, head and shoulders, upper body, "
+    "three-quarter view, full body, wide shot.\n"
+    "2) head/gaze direction and body pose.\n"
+    "3) facial expression.\n"
+    "4) clothing/outfit with its colors.\n"
+    "5) background/setting.\n"
+    "6) lighting.\n"
+    "Describe ONLY these VARIABLE attributes. Do NOT mention identity: no name, no skin tone, "
+    "no freckles, no eye color, no hair color or length, no tattoos, no jewelry. "
+    "Keep it under 30 words. Start with the framing tag."
+)
+
+
+def _analyzer():
+    """Lazy-build the shared offline vision wrapper (same one film_curator uses)."""
+    from backend.utils.vision_analyzer import VisionAnalyzer
+    return VisionAnalyzer()
+
+
+def _clean_vlm(text: str) -> str:
+    """Normalize a VLM reply into a flat comma-separated tag string."""
+    t = (text or "").strip()
+    # Strip code fences / quotes / common prefixes.
+    t = re.sub(r"^```.*?$", "", t, flags=re.MULTILINE).strip().strip('"').strip("'")
+    t = re.sub(r"(?i)^(here('?s)?( is)?|this image (shows|depicts)|the (image|photo) (shows|depicts)|caption)\s*", "", t)
+    # Strip a leading colon/dash left by a removed prefix (e.g. "shows: full body").
+    t = t.lstrip(" :;-–—,")
+    # Newlines / numbered list markers → commas.
+    t = re.sub(r"^\s*\d+[\.\)]\s*", "", t, flags=re.MULTILINE)
+    t = t.replace("\n", ", ")
+    # Collapse repeated commas/whitespace and trailing punctuation.
+    t = re.sub(r"\s+", " ", t)
+    t = re.sub(r"\s*,\s*(,\s*)+", ", ", t)
+    t = t.strip().strip(".,; ")
+    return t
+
+
+def detect_framing(caption: str) -> Optional[str]:
+    """Return the canonical framing tag present in a caption, or None. Used by the gate's
+    pose-coverage check and by the captioner to confirm the VLM led with a framing."""
+    c = (caption or "").lower()
+    # Prefer the most specific / widest match so 'full body' wins over a stray 'body'.
+    for tag in ("wide shot", "full body", "three-quarter view", "upper body",
+                "head and shoulders", "close-up"):
+        if tag in c:
+            return tag
+    # Common synonyms the VLM might emit.
+    if re.search(r"\bfull[- ]length\b", c):
+        return "full body"
+    if re.search(r"\b3/4\b|\bthree quarter\b", c):
+        return "three-quarter view"
+    if re.search(r"\bportrait\b|\bheadshot\b", c):
+        return "close-up"
+    return None
+
+
+def compose_caption(trigger: str, vlm_desc: str, identity_marks: str = "") -> str:
+    """Deterministically assemble the final caption: trigger first (so it binds the identity),
+    the VLM's variable description in the middle, fixed identity marks last. Dedupes the trigger
+    if the VLM echoed it. Never raises."""
+    trigger = (trigger or "").strip().strip(",")
+    body = _clean_vlm(vlm_desc)
+    # Remove an accidental leading trigger from the VLM body to avoid duplication.
+    if trigger and body.lower().startswith(trigger.lower()):
+        body = body[len(trigger):].strip().strip(",").strip()
+    marks = (identity_marks or "").strip().strip(",")
+    parts = [p for p in (trigger, body, marks) if p]
+    return ", ".join(parts)
+
+
+def caption_image(
+    image_path: str | Path,
+    *,
+    trigger: str,
+    identity_marks: str = "",
+    analyzer=None,
+) -> str:
+    """Caption a single image. Returns the composed caption string, or a minimal
+    ``"<trigger>, <identity_marks>"`` fallback if the VLM is unavailable (so a sidecar always
+    has at least the trigger + identity marks — never an empty/identity-less caption)."""
+    analyzer = analyzer or _analyzer()
+    try:
+        res = analyzer.analyze(str(image_path), _VLM_CAPTION_PROMPT, think=False)
+        if getattr(res, "success", False) and getattr(res, "description", "").strip():
+            return compose_caption(trigger, res.description, identity_marks)
+        log.warning("captioner: VLM failed for %s (%s); using trigger+marks fallback",
+                    image_path, getattr(res, "error", "no description"))
+    except Exception as e:  # noqa: BLE001 — captioning must never explode a dataset run
+        log.warning("captioner: exception on %s (%s); using trigger+marks fallback", image_path, e)
+    return compose_caption(trigger, "", identity_marks)
+
+
+def caption_dataset(
+    dataset_dir: str | Path,
+    *,
+    trigger: str,
+    identity_marks: str = "",
+    overwrite: bool = False,
+    dry_run: bool = False,
+    analyzer=None,
+) -> dict:
+    """Write ``<stem>.txt`` sidecars for every image in ``dataset_dir``.
+
+    Skips images that already have a caption unless ``overwrite``. With ``dry_run`` it captions
+    but writes nothing (returns the proposed captions for review). Returns a summary dict with
+    per-image results and a framing-coverage tally so the caller (and the pre-train gate) can
+    see whether full-body shots are present. Never raises on a single image — it logs and moves on.
+    """
+    d = Path(dataset_dir)
+    images = sorted(p for p in d.iterdir() if p.suffix.lower() in IMAGE_EXTS) if d.is_dir() else []
+    analyzer = analyzer or (None if dry_run is None else _analyzer())
+    results = []
+    framing_tally: dict[str, int] = {}
+    written = skipped = 0
+    for img in images:
+        sidecar = img.with_suffix(".txt")
+        if sidecar.exists() and not overwrite:
+            skipped += 1
+            existing = sidecar.read_text(encoding="utf-8").strip()
+            fr = detect_framing(existing)
+            framing_tally[fr or "unknown"] = framing_tally.get(fr or "unknown", 0) + 1
+            results.append({"image": img.name, "caption": existing, "framing": fr, "action": "skipped"})
+            continue
+        caption = caption_image(img, trigger=trigger, identity_marks=identity_marks, analyzer=analyzer)
+        fr = detect_framing(caption)
+        framing_tally[fr or "unknown"] = framing_tally.get(fr or "unknown", 0) + 1
+        if not dry_run:
+            sidecar.write_text(caption + "\n", encoding="utf-8")
+            written += 1
+        results.append({"image": img.name, "caption": caption, "framing": fr,
+                        "action": "dry-run" if dry_run else "written"})
+    full_body = sum(framing_tally.get(f, 0) for f in FULL_BODY_FRAMINGS)
+    return {
+        "dir": str(d),
+        "images": len(images),
+        "written": written,
+        "skipped": skipped,
+        "framing_tally": framing_tally,
+        "full_body_count": full_body,
+        "results": results,
+    }
+
+
+# Convenience: pull a compact identity-marks line out of a character_profile.md so the manual
+# path doesn't have to hand-type it. Best-effort — returns "" if the file isn't parseable.
+def marks_from_profile(profile_path: str | Path) -> str:
+    """Heuristically extract fixed identity marks (skin/freckles, eyes, hair, distinguishing
+    marks, tattoo) from a character_profile.md. Best-effort, returns a comma string."""
+    try:
+        text = Path(profile_path).read_text(encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        return ""
+    wanted = {
+        "skin": r"(?i)skin tone[:*\s]+(.+)",
+        "eyes": r"(?i)\*\*eyes:\*\*\s*(.+)",
+        "marks": r"(?i)distinguishing marks[:*\s]+(.+)",
+        "hair": r"(?i)\*\*hair:\*\*\s*(.+)",
+    }
+    out: list[str] = []
+    for _, pat in wanted.items():
+        m = re.search(pat, text)
+        if m:
+            frag = re.sub(r"\([^)]*\)", "", m.group(1)).strip().strip(".")
+            # keep it short — first clause only
+            frag = re.split(r"[.;]", frag)[0].strip()
+            if frag:
+                out.append(frag.lower())
+    return ", ".join(out)

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -47,6 +47,16 @@ FLUX_T5 = os.environ.get("GUAARDVARK_FLUX_T5", "t5/t5xxl_fp8_e4m3fn.safetensors"
 FLUX_CLIP = os.environ.get("GUAARDVARK_FLUX_CLIP", "clip_l.safetensors")
 FLUX_VAE = os.environ.get("GUAARDVARK_FLUX_VAE", "ae.safetensors")
 
+# FLUX-dev (full transformer) keyframe path — the identity-lock route for trained
+# character LoRAs. Unlike the schnell GGUF branch, this one ACTUALLY chains LoRAs
+# (LoraLoaderModelOnly), uses FluxGuidance, and renders at dev step counts. An fp8
+# unet keeps the 12B transformer inside a 16 GB card (ComfyUI smart-offloads T5/clip).
+# Verified end-to-end on sage_harlow 2026-06-22 (strength 0.9, 28 steps, guidance 3.5).
+FLUX_DEV_UNET = os.environ.get("GUAARDVARK_FLUX_DEV_UNET", "flux1-dev.safetensors")
+FLUX_DEV_T5 = os.environ.get("GUAARDVARK_FLUX_DEV_T5", "t5xxl_fp16.safetensors")
+FLUX_DEV_WEIGHT_DTYPE = os.environ.get("GUAARDVARK_FLUX_DEV_DTYPE", "fp8_e4m3fn")
+FLUX_DEV_GUIDANCE = float(os.environ.get("GUAARDVARK_FLUX_DEV_GUIDANCE", "3.5"))
+
 # A neutral SDXL negative — keeps anatomy/quality sane without fighting the LoRA.
 DEFAULT_NEGATIVE = (
     "lowres, bad anatomy, bad hands, cropped, worst quality, low quality, "
@@ -89,6 +99,61 @@ class ComfyUIImageGenerator:
         model: str | None = None,
     ) -> dict:
         effective_model = model or self.model
+        ml = (effective_model or "").lower()
+        if "flux" in ml and "dev" in ml:
+            # FLUX-dev + LoRA identity-lock branch. This is the route trained
+            # character LoRAs (e.g. sage_harlow) MUST take — the schnell branch
+            # below silently ignores LoRAs, and SDXL can't load a FLUX LoRA at all.
+            # Model-only LoRA chain: these character LoRAs don't train the text
+            # encoder (SimpleTuner "text encoder was not trained"), so clip is left
+            # untouched and the trigger word in the prompt does the identity work.
+            model_src = ["unet", 0]
+            wf: dict = {
+                "unet": {
+                    "class_type": "UNETLoader",
+                    "inputs": {"unet_name": FLUX_DEV_UNET, "weight_dtype": FLUX_DEV_WEIGHT_DTYPE},
+                },
+                "clip": {
+                    "class_type": "DualCLIPLoader",
+                    "inputs": {"clip_name1": FLUX_DEV_T5, "clip_name2": self.flux_clip, "type": "flux"},
+                },
+                "vae_loader": {
+                    "class_type": "VAELoader",
+                    "inputs": {"vae_name": self.flux_vae},
+                },
+            }
+            for i, name in enumerate(lora_names):
+                nid = f"lora_{i}"
+                wf[nid] = {
+                    "class_type": "LoraLoaderModelOnly",
+                    "inputs": {"model": model_src, "lora_name": name, "strength_model": self.lora_strength},
+                }
+                model_src = [nid, 0]
+            wf["pos"] = {"class_type": "CLIPTextEncode", "inputs": {"text": prompt, "clip": ["clip", 0]}}
+            wf["guid"] = {"class_type": "FluxGuidance", "inputs": {"conditioning": ["pos", 0], "guidance": FLUX_DEV_GUIDANCE}}
+            # FLUX-dev is CFG-distilled (cfg=1.0) so the negative is inert; an empty
+            # encode keeps the KSampler contract valid without fighting the LoRA.
+            wf["neg"] = {"class_type": "CLIPTextEncode", "inputs": {"text": "", "clip": ["clip", 0]}}
+            wf["latent"] = {"class_type": "EmptySD3LatentImage", "inputs": {"width": width, "height": height, "batch_size": 1}}
+            wf["sampler"] = {
+                "class_type": "KSampler",
+                "inputs": {
+                    "seed": seed,
+                    "steps": max(steps, 20) if steps else 28,  # dev needs real step counts, not schnell's 8
+                    "cfg": 1.0,
+                    "sampler_name": "euler",
+                    "scheduler": "simple",
+                    "denoise": 1.0,
+                    "model": model_src,
+                    "positive": ["guid", 0],
+                    "negative": ["neg", 0],
+                    "latent_image": ["latent", 0],
+                },
+            }
+            wf["vae"] = {"class_type": "VAEDecode", "inputs": {"samples": ["sampler", 0], "vae": ["vae_loader", 0]}}
+            wf["save"] = {"class_type": "SaveImage", "inputs": {"filename_prefix": "storyboard-flux-dev", "images": ["vae", 0]}}
+            return wf
+
         if effective_model and "flux" in effective_model.lower():
             # Basic flux branch for storyboard keyframes (P1 wiring per approved plan).
             # Reuses patterns from the working infographic flux workflow.

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -60,7 +60,12 @@ FLUX_DEV_GUIDANCE = float(os.environ.get("GUAARDVARK_FLUX_DEV_GUIDANCE", "3.5"))
 # A neutral SDXL negative — keeps anatomy/quality sane without fighting the LoRA.
 DEFAULT_NEGATIVE = (
     "lowres, bad anatomy, bad hands, cropped, worst quality, low quality, "
-    "jpeg artifacts, watermark, signature, deformed, extra limbs, blurry"
+    "jpeg artifacts, watermark, signature, deformed, extra limbs, blurry, "
+    # Identity/anatomy-bleed guard (character-LoRA "horse-head" failure mode). Scoped to
+    # human-animal HYBRID artifacts so a legitimately-present animal still renders. Kept in
+    # sync with backend/utils/prompt_enhancer.IDENTITY_BLEED_NEGATIVE.
+    "animal head, horse head, animal ears, animal face, fur on face, snout, muzzle, "
+    "human-animal hybrid, anthropomorphic, extra head, two heads, mutated anatomy"
 )
 
 

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -107,6 +107,9 @@ class ComfyUIImageGenerator:
             # Model-only LoRA chain: these character LoRAs don't train the text
             # encoder (SimpleTuner "text encoder was not trained"), so clip is left
             # untouched and the trigger word in the prompt does the identity work.
+            # Dev UNET/T5 come from the FLUX_DEV_* module constants (override via
+            # GUAARDVARK_FLUX_DEV_UNET / _T5) — NOT the per-instance flux_unet/flux_t5,
+            # which default to the schnell GGUF and would break this graph.
             model_src = ["unet", 0]
             wf: dict = {
                 "unet": {

--- a/backend/services/director_service.py
+++ b/backend/services/director_service.py
@@ -1,0 +1,408 @@
+"""Unified Director / Storyboard service — one planner for all three video features.
+
+Guaardvark historically grew THREE separate "director" subsystems that all do the same
+job (turn a high-level brief into per-clip VISUAL prompts via an Ollama JSON call) in three
+different shapes:
+
+  * ``music_video_director`` — song cut-plan -> treatment + per-cut prompts (the richest;
+    owns the batching / tolerant-parse / energy-arc machinery that survived real failures).
+  * ``video_director``       — batch sibling: enrich N independent prompts / expand 1 concept.
+  * ``swarm/agents/{screenwriter,cinematographer}`` — film-crew script -> shot plans (the
+    weakest per-shot step: single call, no treatment, no continuity guard).
+
+This module is the single seam they converge on. It does NOT re-implement the vetted
+primitives — it *delegates* to ``music_video_director`` (SONG_CUTPLAN engine + helpers) and
+``media_director`` (CONCEPT_EXPANSION / PROMPT_LIST engines), and adds ONE new batched
+planner for the film-crew SCRIPT_SCENES path. On top of that it centralizes the two things
+that were divergent everywhere:
+
+  1. **Cast identity-lock at PLAN time** — trigger word(s) + bible front-loaded onto every
+     shot prompt, uniformly, replacing the three render-time injection sites. Empty cast is a
+     no-op, so callers that still inject at render time are unaffected until they migrate.
+  2. **Sampling** — story generation is routed through ``sampling_profiles.CREATIVE`` (the
+     profile literally designed for story gen) instead of three hardcoded temperatures.
+     NOTE: the CREATIVE wiring for the delegated engines lands in a follow-up step
+     (additive ``sampling=`` param on those engines); the new SCRIPT_SCENES planner here
+     already honors it.
+
+``plan()`` never raises — every branch degrades to a best-effort result, matching the
+never-raise contract the downstream renderers and the film-crew state machine depend on.
+
+DESIGN GUARDRAILS (see plan cozy-growing-grove.md):
+  * Planning != rendering: this module must NEVER import a video generator (there are three
+    ``get_video_generator`` symbols — picking one here would be a footgun).
+  * Always import the film-crew agents by full path (``backend.services.swarm.agents...``) —
+    ``backend/services/swarm/`` collides by leaf-name with the unrelated ``plugins/swarm/``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from backend.services import sampling_profiles
+from backend.services import media_director
+from backend.services.music_video_director import (
+    DIRECTOR_MODEL,
+    _resolve_model,
+    _director_chat,
+    _generate_storyline_and_prompts,
+)
+
+log = logging.getLogger(__name__)
+
+
+class DirectorMode(str, Enum):
+    """Which input shape the brief carries — selects the engine ``plan()`` dispatches to."""
+    SONG_CUTPLAN = "song_cutplan"            # music video: timed cuts + beat energy
+    CONCEPT_EXPANSION = "concept_expansion"  # one idea -> N distinct-but-connected shots
+    PROMPT_LIST = "prompt_list"              # enrich N independent prompts
+    SCRIPT_SCENES = "script_scenes"          # film-crew scene/shot breakdown -> shot plans
+
+
+@dataclass
+class CastMember:
+    """A trained cast identity. ``trigger_word`` + ``bible`` are what lock appearance; the
+    LoRA fields ride along so a future unified renderer can resolve them in one place."""
+    trigger_word: str
+    bible: Optional[str] = None
+    lora_path: Optional[str] = None
+    lora_strength: Optional[float] = None
+    name: Optional[str] = None
+
+
+@dataclass
+class DirectorBrief:
+    """The unified input. Exactly one mode payload is populated per ``mode``."""
+    mode: DirectorMode
+    style: str = ""                                   # global look/feel (style_prompt)
+    creativity: str = sampling_profiles.CREATIVE      # sampling profile name
+    cast: list[CastMember] = field(default_factory=list)
+    extra_guidance: Optional[str] = None
+    user_treatment: Optional[str] = None
+    planning_mode: str = "narrative"                  # narrative | visual/mood_arc
+    model: Optional[str] = None
+    # --- mode-specific payloads (exactly one populated) ---
+    cut_plan: Optional[list[dict]] = None             # SONG_CUTPLAN
+    concept: Optional[str] = None                     # CONCEPT_EXPANSION
+    num_shots: Optional[int] = None                   # CONCEPT_EXPANSION
+    prompts: Optional[list[str]] = None               # PROMPT_LIST
+    scenes: Optional[list[dict]] = None               # SCRIPT_SCENES (from screenwriter)
+    subjects: Optional[list[dict]] = None             # SCRIPT_SCENES (id/name/description)
+    # --- optional MV stretch context (passthrough) ---
+    max_stretch: Optional[float] = None
+    fill_method: Optional[str] = None
+
+
+@dataclass
+class ShotPrompt:
+    """One planned shot. ``prompt`` is always pure-visual (+ cast lock prepended). The rest
+    are populated when the engine supplies them (camera/framing/etc. for SCRIPT_SCENES,
+    energy/duration for SONG_CUTPLAN)."""
+    prompt: str
+    index: Optional[int] = None
+    duration: Optional[float] = None
+    energy: Optional[float] = None
+    camera: Optional[str] = None
+    framing: Optional[str] = None
+    mood: Optional[str] = None
+    subjects: Optional[list[int]] = None
+    transition_to_next: Optional[str] = None
+    filter_preset: Optional[str] = None
+
+
+@dataclass
+class DirectorResult:
+    treatment: Optional[str]
+    shots: list[ShotPrompt]
+    diagnostics: Optional[dict] = None
+    # Native engine dict, passed through verbatim. SONG_CUTPLAN callers use this for a
+    # byte-identical migration (they keep reading result["prompts"]/director_diagnostics).
+    raw: Optional[dict] = None
+
+
+# --------------------------------------------------------------------------- cast helpers
+
+# Lifted verbatim from music_video_tasks' plan-time guidance so the director stops "fighting"
+# the trained token by re-describing the face. Applied whenever a brief carries cast.
+_CAST_GUIDANCE_NOTE = (
+    "The hero character(s) are locked by a trained identity token; do NOT describe their "
+    "facial features, hair color, eye color, or body type — those are fixed by the token. "
+    "Describe only their action, wardrobe, pose, framing, lighting, and environment."
+)
+
+
+def _dedupe(seq: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in seq:
+        s = (s or "").strip()
+        k = s.lower()
+        if s and k not in seen:
+            seen.add(k)
+            out.append(s)
+    return out
+
+
+def _cast_lock(cast: list[CastMember]) -> str:
+    """The identity string prepended to every shot prompt: trigger(s) then bible(s), in the
+    proven music-video order (trigger -> bible -> scene)."""
+    triggers = _dedupe([c.trigger_word for c in cast if c.trigger_word])
+    bibles = _dedupe([c.bible for c in cast if c.bible])
+    return ", ".join([*triggers, *bibles])
+
+
+def _has_cast(cast: list[CastMember]) -> bool:
+    return any(c.trigger_word for c in cast)
+
+
+def _cast_descriptors(cast: list[CastMember]) -> Optional[list[str]]:
+    """Visual descriptors (bible or name) for engines that weave consistency in softly
+    (media_director.enhance_prompts). Distinct from the hard trigger lock."""
+    descs = _dedupe([(c.bible or c.name or "") for c in cast])
+    return descs or None
+
+
+def _apply_lock(prompt: str, lock: str) -> str:
+    p = (prompt or "").strip()
+    if not lock:
+        return p
+    return f"{lock}, {p}" if p else lock
+
+
+def _merge_guidance(brief: DirectorBrief) -> Optional[str]:
+    parts = []
+    if brief.extra_guidance and brief.extra_guidance.strip():
+        parts.append(brief.extra_guidance.strip())
+    if _has_cast(brief.cast):
+        parts.append(_CAST_GUIDANCE_NOTE)
+    return "  ".join(parts) if parts else None
+
+
+def _cut_get(cut: dict, *keys: str) -> Any:
+    for k in keys:
+        if isinstance(cut, dict) and cut.get(k) is not None:
+            return cut.get(k)
+    return None
+
+
+def _sampling(brief: DirectorBrief) -> Optional[dict]:
+    """Pure sampling-knob dict for this brief's creativity profile (default CREATIVE — the
+    profile designed for story generation). Window/budget keys (num_ctx/num_predict) are NOT
+    here: every engine keeps its own batch-sized budget (the gemma JSON-truncation fix).
+
+    ``creativity=None`` ⇒ return None ⇒ engines fall back to their built-in sampling. This is
+    how a caller requests a BYTE-IDENTICAL migration (e.g. the fragile music-video path) — no
+    sampling change, pure call-site indirection."""
+    if not brief.creativity:
+        return None
+    return sampling_profiles.get_profile(brief.creativity)
+
+
+# --------------------------------------------------------------------------- public entry
+
+def plan(brief: DirectorBrief) -> DirectorResult:
+    """Mode-dispatched director. Never raises; returns a best-effort DirectorResult."""
+    try:
+        if brief.mode == DirectorMode.SONG_CUTPLAN:
+            return _plan_song(brief)
+        if brief.mode == DirectorMode.CONCEPT_EXPANSION:
+            return _plan_concept(brief)
+        if brief.mode == DirectorMode.PROMPT_LIST:
+            return _plan_prompt_list(brief)
+        if brief.mode == DirectorMode.SCRIPT_SCENES:
+            return _plan_script_scenes(brief)
+    except Exception as e:  # noqa: BLE001 — director is best-effort, never sink a caller
+        log.warning("director_service.plan(%s) failed (%s); empty result", brief.mode, e)
+    return DirectorResult(treatment=None, shots=[], diagnostics={"reason": "plan_error"})
+
+
+# --------------------------------------------------------------------------- SONG_CUTPLAN
+
+def _plan_song(brief: DirectorBrief) -> DirectorResult:
+    """Delegates to the music-video engine (the only one with batching + energy-arc). Returns
+    the native dict in ``.raw`` so the MV adapter can stay byte-identical."""
+    cut_plan = brief.cut_plan or []
+    raw = _generate_storyline_and_prompts(
+        brief.style,
+        cut_plan,
+        model=_resolve_model(brief.model or DIRECTOR_MODEL),
+        planning_mode=brief.planning_mode,
+        extra_guidance=_merge_guidance(brief),
+        user_treatment=brief.user_treatment,
+        max_stretch=brief.max_stretch,
+        fill_method=brief.fill_method,
+        sampling=_sampling(brief),
+    )
+    prompts = raw.get("prompts") or []
+    lock = _cast_lock(brief.cast)
+    shots = [
+        ShotPrompt(
+            prompt=_apply_lock(p, lock),
+            index=i,
+            energy=_cut_get(cut_plan[i], "energy") if i < len(cut_plan) else None,
+            duration=_cut_get(cut_plan[i], "duration", "length", "dur") if i < len(cut_plan) else None,
+        )
+        for i, p in enumerate(prompts)
+    ]
+    return DirectorResult(
+        treatment=raw.get("treatment") or raw.get("storyline"),
+        shots=shots,
+        diagnostics=raw.get("director_diagnostics"),
+        raw=raw,
+    )
+
+
+# --------------------------------------------------------------------- CONCEPT / PROMPT_LIST
+
+def _plan_concept(brief: DirectorBrief) -> DirectorResult:
+    res = media_director.storyboard_from_concept(
+        brief.concept or "",
+        brief.num_shots or 1,
+        style=brief.style,
+        extra_guidance=_merge_guidance(brief) or brief.user_treatment,
+        model=brief.model,
+        sampling=_sampling(brief),
+    )
+    prompts = res.get("prompts") or []
+    lock = _cast_lock(brief.cast)
+    shots = [ShotPrompt(prompt=_apply_lock(p, lock), index=i) for i, p in enumerate(prompts)]
+    return DirectorResult(treatment=res.get("treatment"), shots=shots, raw=res)
+
+
+def _plan_prompt_list(brief: DirectorBrief) -> DirectorResult:
+    out = media_director.enhance_prompts(
+        brief.prompts or [],
+        style=brief.style,
+        extra_guidance=_merge_guidance(brief),
+        model=brief.model,
+        cast_descriptors=_cast_descriptors(brief.cast),
+        sampling=_sampling(brief),
+    )
+    lock = _cast_lock(brief.cast)
+    shots = [ShotPrompt(prompt=_apply_lock(p, lock), index=i) for i, p in enumerate(out)]
+    return DirectorResult(treatment=None, shots=shots, raw={"prompts": out})
+
+
+# --------------------------------------------------------------------------- SCRIPT_SCENES
+
+_SCRIPT_SCENES_SYSTEM = """You are a cinematographer for an AI video generator.
+Given a TREATMENT/script broken into SCENES and SHOTS, plus a list of SUBJECTS (characters/props,
+each with an integer id), produce ONE shot-ready VISUAL prompt per shot AND its camera/framing.
+
+Each shot MUST:
+- Be PURE visual: subject action, setting, camera (lens/angle/movement), lighting, color palette,
+  mood, and the motion across the clip. No narration, no character NAMES, no dialogue, no quotes.
+- Keep world, lighting, and character continuity across the whole sequence.
+- Reference subjects ONLY by their given integer ids in "subjects_in_shot".
+
+Return STRICT JSON:
+{"treatment": "<one short evocative paragraph>",
+ "shots": [{"index": <int>, "prompt": "<pure visual>", "camera_angle": "<e.g. low angle>",
+            "framing": "<e.g. medium close-up>", "mood": "<e.g. tense>",
+            "duration_seconds": <number>, "subjects_in_shot": [<ids>]}, ...]}
+with exactly one entry per input shot, in order. No commentary outside the JSON."""
+
+
+def _build_script_user(scenes: list[dict], subjects: list[dict]) -> tuple[str, int]:
+    """Flatten the screenwriter breakdown into a compact user prompt; returns (text, n_shots)."""
+    subj_lines = []
+    for s in subjects or []:
+        sid = s.get("id", s.get("index"))
+        name = s.get("name") or s.get("character") or "?"
+        desc = s.get("description") or s.get("appearance") or ""
+        subj_lines.append(f"  [{sid}] {name}: {desc}".rstrip())
+
+    shot_lines = []
+    n = 0
+    for sc in scenes or []:
+        loc = sc.get("location") or sc.get("setting") or ""
+        mood = sc.get("mood") or ""
+        for sh in sc.get("shots", []) or []:
+            desc = sh.get("description") or sh.get("action") or sh.get("prompt") or ""
+            in_shot = sh.get("subjects_in_shot") or sh.get("subjects") or sh.get("characters") or []
+            shot_lines.append(
+                f"  shot {n}: {desc} | scene_loc: {loc} | scene_mood: {mood} | subjects: {in_shot}"
+            )
+            n += 1
+
+    text = (
+        "SUBJECTS:\n" + ("\n".join(subj_lines) if subj_lines else "  (none)") +
+        f"\n\nSHOTS ({n}), in order:\n" + ("\n".join(shot_lines) if shot_lines else "  (none)") +
+        "\n\nTASK: Return ONLY the JSON with a 'treatment' and exactly "
+        f"{n} 'shots' (one per input shot, same order)."
+    )
+    return text, n
+
+
+def _extract_shot_meta(raw_content: str) -> dict[int, dict]:
+    """Best-effort pull of the rich per-shot fields (camera/framing/mood/duration/subjects)
+    that the shared tolerant parser drops. Keyed by shot index. Returns {} on any failure."""
+    try:
+        c = (raw_content or "").strip()
+        start, end = c.find("{"), c.rfind("}")
+        if start == -1 or end <= start:
+            return {}
+        data = json.loads(c[start:end + 1])
+        shots = data.get("shots") if isinstance(data, dict) else data
+        if not isinstance(shots, list):
+            return {}
+        meta: dict[int, dict] = {}
+        for i, item in enumerate(shots):
+            if isinstance(item, dict):
+                meta[int(item.get("index", i))] = item
+        return meta
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _plan_script_scenes(brief: DirectorBrief) -> DirectorResult:
+    """The film-crew cinematographer upgrade: one batched, treatment-driven call that emits
+    pure-visual shot prompts + camera/framing, replacing the terse single-shot agent."""
+    user, n = _build_script_user(brief.scenes or [], brief.subjects or [])
+    if n == 0:
+        return DirectorResult(treatment=None, shots=[], diagnostics={"reason": "no_shots"})
+
+    style_line = f"\nGlobal visual style to honor in every shot: {brief.style}." if brief.style else ""
+    guidance = _merge_guidance(brief)
+    guide_line = f"\nDirector guidance: {guidance}." if guidance else ""
+    user = user + style_line + guide_line
+
+    import ollama
+    parsed, raw_content = _director_chat(
+        ollama=ollama,
+        model=_resolve_model(brief.model or DIRECTOR_MODEL),
+        system=_SCRIPT_SCENES_SYSTEM,
+        user=user,
+        batch_len=n,
+        rich=True,
+        sampling=_sampling(brief),
+    )
+    prompts_map: dict[int, str] = parsed.get("prompts") or {}
+    meta = _extract_shot_meta(raw_content)
+    lock = _cast_lock(brief.cast)
+
+    shots: list[ShotPrompt] = []
+    for i in range(n):
+        p = prompts_map.get(i, "")
+        m = meta.get(i, {})
+        subj = m.get("subjects_in_shot") or m.get("subjects")
+        subj_ids = [int(x) for x in subj if isinstance(x, (int, str)) and str(x).lstrip("-").isdigit()] if isinstance(subj, list) else None
+        shots.append(ShotPrompt(
+            prompt=_apply_lock(p, lock),
+            index=i,
+            camera=m.get("camera_angle") or m.get("camera"),
+            framing=m.get("framing"),
+            mood=m.get("mood"),
+            duration=m.get("duration_seconds") if isinstance(m.get("duration_seconds"), (int, float)) else None,
+            subjects=subj_ids,
+        ))
+
+    # Signal a thin/failed result so the caller can fall back to the swarm Cinematographer.
+    diagnostics = None
+    if not prompts_map:
+        diagnostics = {"reason": "empty", "raw_head": (raw_content or "")[:200]}
+    return DirectorResult(treatment=parsed.get("treatment"), shots=shots, diagnostics=diagnostics)

--- a/backend/services/media_director.py
+++ b/backend/services/media_director.py
@@ -62,9 +62,14 @@ Be one flowing descriptive phrase. No narration, no "the image depicts", no meta
 STYLE (if given) is appended by caller; do not repeat it wholesale.
 Return STRICT JSON: {"prompts": ["enriched1", "enriched2", ...]} exactly one per input, same order."""
 
-def _options(n: int) -> dict:
+def _options(n: int, sampling: Optional[dict] = None) -> dict:
     n = max(1, n)
-    return {"temperature": 0.68, "num_ctx": 4096, "num_predict": min(3072, 180 * n + 512)}
+    opts = {"temperature": 0.68, "num_ctx": 4096, "num_predict": min(3072, 180 * n + 512)}
+    if sampling:
+        # Sampling-profile knobs override temperature etc.; window/budget stay authoritative
+        # (num_predict sized to N is the JSON-truncation fix).
+        opts.update({k: v for k, v in sampling.items() if k not in ("num_ctx", "num_predict")})
+    return opts
 
 def _parse_image_prompts(content: str, n: int) -> List[str]:
     """Tolerant list parse for image plans/enhance. Accepts {"prompts": [...]}, {"shots": [...]}, bare array."""
@@ -109,6 +114,7 @@ def enhance_prompts(
     extra_guidance: Optional[str] = None,
     model: Optional[str] = None,
     cast_descriptors: Optional[List[str]] = None,
+    sampling: Optional[dict] = None,
 ) -> List[str]:
     """Enrich a list of user prompts into rich pure-visual shot-ready prompts via director LLM.
     Best-effort: on any failure returns originals (or lightly cued).
@@ -138,6 +144,7 @@ def enhance_prompts(
             user=user,
             batch_len=n,
             rich=False,
+            sampling=sampling,
         )
         # _base returns dict? adapt
         if isinstance(parsed, dict) and parsed.get("prompts"):
@@ -158,6 +165,7 @@ def storyboard_from_concept(
     style: str = "",
     extra_guidance: Optional[str] = None,
     model: Optional[str] = None,
+    sampling: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """Expand ONE concept into N coherent visual prompts (+ optional treatment).
     Returns {"treatment": str|None, "prompts": [str, ...]} .
@@ -176,7 +184,7 @@ def storyboard_from_concept(
     try:
         # Use a direct chat wrapper for storyboard (rich)
         import ollama
-        opts = _options(n)
+        opts = _options(n, sampling)
         resp = ollama.chat(
             model=resolved,
             format="json",

--- a/backend/services/media_director.py
+++ b/backend/services/media_director.py
@@ -1,0 +1,279 @@
+"""Media Director — generalized LLM director for image (and future cross-media) generation.
+
+Reuses battle-tested primitives from music_video_director (and video_director) for:
+- Dedicated small model (gemma4:e4b default) + embedding filter + resolve.
+- Strict pure-visual JSON contracts, tolerant parsing, batching to avoid truncation.
+- Never-raise + post-guards (distinctness, energy/mood cues, style hygiene).
+- Treatment (narrative) vs. shots/prompts (visual only) separation.
+- Planning modes + extra_guidance.
+- Diagnostics surfaced.
+
+For BatchImage: supports expand_image_plan (concept -> N coherent shots + optional treatment)
+and enhance_prompts (per-prompt cinematic enrichment).
+
+For chat: enhance single prompts before the generator.
+
+Vision post-refine hook stub for future critique loops (using VisionAnalyzer / curator patterns).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, List, Optional, Dict
+
+# Reuse ALL vetted primitives (model safety, parse, chat, guards) to avoid regressions.
+from backend.services.music_video_director import (
+    DIRECTOR_MODEL,
+    _resolve_model,
+    _is_embedding_model,
+    _parse_prompts as _base_parse_prompts,
+    _director_options as _base_options,
+    _is_mostly_style,
+    _ensure_distinct_and_energy_aware,
+    _director_chat as _base_director_chat,
+    _installed_model_tags,
+)
+
+log = logging.getLogger(__name__)
+
+# Image-specific dedicated model (same small fast one; user can override).
+DEFAULT_DIRECTOR_MODEL = DIRECTOR_MODEL
+
+# Batching for large N (same rationale).
+DIRECTOR_BATCH_SIZE = 12  # Slightly smaller for image plans (richer per-shot often)
+
+# Image "storyboard" contract: one concept -> N connected visual prompts.
+_SYSTEM_STORYBOARD_IMAGE = """You are a visual director for still image generation.
+Given ONE high-level concept and N, produce N distinct but visually coherent image prompts that feel like a series or storyboard.
+Each prompt MUST:
+- Be PURE VISUAL only (subject appearance, setting, framing/composition, camera/lens/angle if applicable, lighting, color palette, texture, mood, key style elements). No backstory, names, plot, "the image shows".
+- Maintain world/character/motif consistency across the set (use recurring visual descriptors drawn from the concept).
+- Vary framing, angle, action/moment, density, lighting to show progression or interesting variations.
+- Be concise comma/phrase style suitable for SD/Flux/etc. (aim <30 words).
+- Honor any global STYLE provided as a suffix (do NOT duplicate full style in prompt).
+Return STRICT JSON: {"treatment": "<optional short evocative treatment>", "prompts": ["prompt1", "prompt2", ...]} with exactly N entries in order."""
+
+_SYSTEM_ENHANCE_IMAGE = """You are a cinematic visual director for still images.
+Rewrite each short user idea into a rich, shot-ready PURE VISUAL prompt (subject + setting + framing/composition + lighting + palette + mood + texture + style elements).
+Keep the user's core intent. Enrich, never replace.
+Be one flowing descriptive phrase. No narration, no "the image depicts", no meta.
+STYLE (if given) is appended by caller; do not repeat it wholesale.
+Return STRICT JSON: {"prompts": ["enriched1", "enriched2", ...]} exactly one per input, same order."""
+
+def _options(n: int) -> dict:
+    n = max(1, n)
+    return {"temperature": 0.68, "num_ctx": 4096, "num_predict": min(3072, 180 * n + 512)}
+
+def _parse_image_prompts(content: str, n: int) -> List[str]:
+    """Tolerant list parse for image plans/enhance. Accepts {"prompts": [...]}, {"shots": [...]}, bare array."""
+    if not content:
+        return []
+    text = content.strip()
+    text = re.sub(r"^```(?:json)?|```$", "", text, flags=re.MULTILINE).strip()
+    data: Any = None
+    try:
+        data = json.loads(text)
+    except Exception:
+        m = re.search(r"(\{.*\}|\[.*\])", text, re.DOTALL)
+        if m:
+            try:
+                data = json.loads(m.group(1))
+            except Exception:
+                pass
+    if data is None:
+        return []
+    if isinstance(data, list):
+        out = [str(x).strip() for x in data if str(x).strip()]
+        return out[:n] if n else out
+    if isinstance(data, dict):
+        for key in ("prompts", "shots", "images", "items"):
+            arr = data.get(key)
+            if isinstance(arr, list):
+                out = [str(x).strip() for x in arr if str(x).strip()]
+                return out[:n] if n else out
+        # Fallback single "prompt"
+        if isinstance(data.get("prompt"), str):
+            return [data["prompt"].strip()]
+    return []
+
+def _style_clause(style: Optional[str]) -> str:
+    style = (style or "").strip()
+    return f"\nGlobal visual style/aesthetic to honor: {style}." if style else ""
+
+def enhance_prompts(
+    prompts: List[str],
+    *,
+    style: str = "",
+    extra_guidance: Optional[str] = None,
+    model: Optional[str] = None,
+    cast_descriptors: Optional[List[str]] = None,
+) -> List[str]:
+    """Enrich a list of user prompts into rich pure-visual shot-ready prompts via director LLM.
+    Best-effort: on any failure returns originals (or lightly cued).
+    Used by chat ImageGeneratorTool and batch pre-pass.
+    """
+    if not prompts:
+        return []
+    n = len(prompts)
+    resolved = _resolve_model(model or DEFAULT_DIRECTOR_MODEL)
+    style_c = _style_clause(style)
+    guidance = f"\nExtra direction: {extra_guidance.strip()}." if extra_guidance and extra_guidance.strip() else ""
+    cast = ""
+    if cast_descriptors:
+        cast = "\nConsistent visual character/subject descriptors to weave in naturally (visual only): " + "; ".join(cast_descriptors[:3])
+
+    user = (
+        f"STYLE: {style or '(none)'}\n"
+        f"INPUT IDEAS ({n}):\n" + "\n".join(f"{i+1}. {p}" for i,p in enumerate(prompts)) +
+        f"{style_c}{guidance}{cast}\n\n"
+        "TASK: Return ONLY JSON with 'prompts' array of exactly N enriched pure-visual prompts. Preserve order and core intent."
+    )
+    try:
+        parsed, _raw = _base_director_chat(
+            ollama=__import__("ollama"),
+            model=resolved,
+            system=_SYSTEM_ENHANCE_IMAGE,
+            user=user,
+            batch_len=n,
+            rich=False,
+        )
+        # _base returns dict? adapt
+        if isinstance(parsed, dict) and parsed.get("prompts"):
+            out = parsed["prompts"]
+        else:
+            out = _parse_image_prompts(str(parsed), n) or []
+        if len(out) == n:
+            return [p.strip() for p in out]
+    except Exception as e:  # noqa: BLE001
+        log.warning("media_director.enhance_prompts failed (%s); falling back", e)
+    # Fallback: return originals (caller may still do keyword enhance)
+    return list(prompts)
+
+def storyboard_from_concept(
+    concept: str,
+    n: int,
+    *,
+    style: str = "",
+    extra_guidance: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Expand ONE concept into N coherent visual prompts (+ optional treatment).
+    Returns {"treatment": str|None, "prompts": [str, ...]} .
+    Never raises; on failure returns {"treatment": None, "prompts": [concept] * n} (or energy cued).
+    """
+    if n < 1:
+        n = 1
+    resolved = _resolve_model(model or DEFAULT_DIRECTOR_MODEL)
+    style_c = _style_clause(style)
+    guidance = f"\nExtra direction: {extra_guidance.strip()}." if extra_guidance and extra_guidance.strip() else ""
+
+    user = (
+        f"CONCEPT: {concept}\nN={n}\nSTYLE: {style or '(none)'}{style_c}{guidance}\n\n"
+        "TASK: Return ONLY the JSON with optional 'treatment' and exactly N 'prompts'."
+    )
+    try:
+        # Use a direct chat wrapper for storyboard (rich)
+        import ollama
+        opts = _options(n)
+        resp = ollama.chat(
+            model=resolved,
+            format="json",
+            messages=[
+                {"role": "system", "content": _SYSTEM_STORYBOARD_IMAGE},
+                {"role": "user", "content": user},
+            ],
+            options=opts,
+        )
+        content = resp["message"]["content"]
+        data = _parse_storyboard_output(content, n)
+        prompts = data.get("prompts") or []
+        if len(prompts) != n:
+            prompts = _ensure_image_distinct(prompts or [], concept, n, style)
+        return {"treatment": data.get("treatment"), "prompts": prompts[:n]}
+    except Exception as e:  # noqa: BLE001
+        log.warning("media_director.storyboard_from_concept failed (%s); simple fallback", e)
+        base = concept.strip()
+        return {"treatment": None, "prompts": [base] * n}
+
+def _parse_storyboard_output(content: str, n: int) -> Dict[str, Any]:
+    try:
+        data = json.loads(content)
+    except Exception:
+        start, end = content.find("{"), content.rfind("}")
+        if start != -1 and end > start:
+            try:
+                data = json.loads(content[start:end+1])
+            except Exception:
+                data = {}
+        else:
+            data = {}
+    if not isinstance(data, dict):
+        data = {}
+    prompts = data.get("prompts") or data.get("shots") or []
+    if isinstance(prompts, list):
+        prompts = [str(p).strip() for p in prompts if str(p).strip()][:n]
+    else:
+        prompts = []
+    treatment = data.get("treatment") if isinstance(data.get("treatment"), str) else None
+    return {"treatment": treatment, "prompts": prompts}
+
+def _ensure_image_distinct(prompts: List[str], concept: str, n: int, style: str) -> List[str]:
+    """Light deterministic guard (mirrors MV energy cues for images)."""
+    out = []
+    cues = [
+        "wide establishing framing, atmospheric depth",
+        "medium shot, focused action",
+        "tight dramatic close, strong contrast",
+        "dynamic angle from low, motion implication",
+        "overhead or high angle, sparse or dense texture",
+    ]
+    for i in range(n):
+        base = (prompts[i] if i < len(prompts) else concept).strip()
+        cue = cues[i % len(cues)]
+        if style and style.lower() not in base.lower():
+            candidate = f"{base}, {cue}, {style}".strip(", ")
+        else:
+            candidate = f"{base}, {cue}".strip(", ")
+        out.append(candidate)
+    return out
+
+def expand_image_plan(
+    idea: str,
+    n: int,
+    *,
+    look_and_feel: str = "",
+    user_treatment: Optional[str] = None,
+    planning_mode: str = "narrative",
+    extra_guidance: Optional[str] = None,
+    model: Optional[str] = None,
+    cast_descriptors: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """High-level BatchImage-friendly entry: concept/idea + N -> {treatment, shots}.
+    shots = list of dicts with 'prompt' (and index).
+    Mirrors MV plan shape for UI reuse.
+    """
+    res = storyboard_from_concept(
+        idea, n, style=look_and_feel, extra_guidance=(extra_guidance or user_treatment), model=model
+    )
+    prompts = res.get("prompts") or []
+    # light enhance pass for consistency if cast
+    if cast_descriptors and prompts:
+        try:
+            enriched = enhance_prompts(prompts, style=look_and_feel, cast_descriptors=cast_descriptors, model=model)
+            if len(enriched) == len(prompts):
+                prompts = enriched
+        except Exception:
+            pass
+    shots = [{"index": i, "prompt": p} for i, p in enumerate(prompts[:n])]
+    return {
+        "treatment": res.get("treatment") or (user_treatment or ""),
+        "shots": shots,
+        "planning_mode": planning_mode,
+        "director_model": model or DEFAULT_DIRECTOR_MODEL,
+        "director_diagnostics": None,  # future: surface fallback info
+    }
+
+# Public aliases for batch compatibility
+direct_prompts = enhance_prompts

--- a/backend/services/media_director.py
+++ b/backend/services/media_director.py
@@ -137,22 +137,25 @@ def enhance_prompts(
         "TASK: Return ONLY JSON with 'prompts' array of exactly N enriched pure-visual prompts. Preserve order and core intent."
     )
     try:
-        parsed, _raw = _base_director_chat(
-            ollama=__import__("ollama"),
+        # NOTE: do NOT use the music-director's _director_chat here — its parser hunts for a
+        # "shots" array, but this enrich contract returns {"prompts": [...]}. Mismatched parsing
+        # silently returned [] → originals (the batch-director no-op bug, fixed 2026-06-23).
+        # Mirror storyboard_from_concept: own chat call + _parse_image_prompts (list-aware).
+        import ollama
+        opts = _options(n, sampling)
+        resp = ollama.chat(
             model=resolved,
-            system=_SYSTEM_ENHANCE_IMAGE,
-            user=user,
-            batch_len=n,
-            rich=False,
-            sampling=sampling,
+            format="json",
+            messages=[
+                {"role": "system", "content": _SYSTEM_ENHANCE_IMAGE},
+                {"role": "user", "content": user},
+            ],
+            options=opts,
         )
-        # _base returns dict? adapt
-        if isinstance(parsed, dict) and parsed.get("prompts"):
-            out = parsed["prompts"]
-        else:
-            out = _parse_image_prompts(str(parsed), n) or []
+        out = _parse_image_prompts(resp["message"]["content"], n)
         if len(out) == n:
             return [p.strip() for p in out]
+        log.warning("media_director.enhance_prompts parsed %d/%d prompts; falling back", len(out), n)
     except Exception as e:  # noqa: BLE001
         log.warning("media_director.enhance_prompts failed (%s); falling back", e)
     # Fallback: return originals (caller may still do keyword enhance)

--- a/backend/services/music_video_director.py
+++ b/backend/services/music_video_director.py
@@ -191,7 +191,7 @@ def _cut_brief(cut_plan: list[dict[str, Any]], *, max_stretch: float | None = No
     return out
 
 
-def _director_options(batch_len: int, *, rich: bool) -> dict:
+def _director_options(batch_len: int, *, rich: bool, sampling: dict | None = None) -> dict:
     """Single source of truth for the Ollama sampling/window options per Director call.
 
     The original code set only ``temperature`` (no ``num_predict``), so large responses
@@ -199,11 +199,23 @@ def _director_options(batch_len: int, *, rich: bool) -> dict:
     We now size ``num_predict`` to the batch and give a modest ``num_ctx`` (kept small to
     respect tight VRAM — the small model runs partly on CPU). The first/rich batch also
     writes the whole-video treatment, so it gets more room.
+
+    ``sampling`` (optional) is a pure sampling-knob dict — e.g.
+    ``sampling_profiles.get_profile(CREATIVE)`` — whose keys (temperature, top_p, top_k,
+    min_p, repeat/presence/frequency penalties) override the built-in defaults. It must
+    NOT carry ``num_ctx``/``num_predict``: those stay authoritative here because the
+    batch-sized output budget is the gemma JSON-truncation fix. Any window keys in
+    ``sampling`` are dropped defensively. ``sampling=None`` ⇒ byte-identical to before.
     """
     bl = max(1, batch_len)
     if rich:
-        return {"temperature": 0.7, "num_ctx": 8192, "num_predict": min(4096, 200 * bl + 2048)}
-    return {"temperature": 0.65, "num_ctx": 4096, "num_predict": min(3072, 200 * bl + 512)}
+        opts = {"temperature": 0.7, "num_ctx": 8192, "num_predict": min(4096, 200 * bl + 2048)}
+    else:
+        opts = {"temperature": 0.65, "num_ctx": 4096, "num_predict": min(3072, 200 * bl + 512)}
+    if sampling:
+        knobs = {k: v for k, v in sampling.items() if k not in ("num_ctx", "num_predict")}
+        opts.update(knobs)
+    return opts
 
 
 def _parse_prompts(content: str, n: int) -> dict[int, str]:
@@ -340,12 +352,16 @@ def _build_shots_only_user(
     )
 
 
-def _director_chat(*, ollama, model: str, system: str, user: str, batch_len: int, rich: bool):
+def _director_chat(*, ollama, model: str, system: str, user: str, batch_len: int, rich: bool,
+                   sampling: dict | None = None):
     """One ``ollama.chat(format='json')`` with a small transient-error retry loop (connection
     refused / server just came up). Returns ``(parsed_dict, raw_content)``. Raises only if all
-    transient retries are exhausted; an unparseable-but-returned response yields empty prompts."""
+    transient retries are exhausted; an unparseable-but-returned response yields empty prompts.
+
+    ``sampling`` (optional) overrides the sampling knobs (e.g. CREATIVE profile); window/budget
+    keys stay authoritative — see ``_director_options``."""
     import time
-    opts = _director_options(batch_len, rich=rich)
+    opts = _director_options(batch_len, rich=rich, sampling=sampling)
     resp = None
     for attempt in range(3):
         try:
@@ -382,6 +398,7 @@ def _generate_shots_for_batch(
     max_stretch: float | None,
     fill_method: str | None,
     rich: bool,
+    sampling: dict | None = None,
 ) -> dict:
     """Generate per-shot prompts for ONE batch of cuts.
 
@@ -404,7 +421,7 @@ def _generate_shots_for_batch(
         else:
             system = _SHOTS_ONLY_SYSTEM
             user = _build_shots_only_user(style_prompt, cuts_json, b, n_total, mode_instruction, guidance_block, treatment_block, treatment_context)
-        data, content = _director_chat(ollama=ollama, model=model, system=system, user=user, batch_len=b, rich=rich)
+        data, content = _director_chat(ollama=ollama, model=model, system=system, user=user, batch_len=b, rich=rich, sampling=sampling)
         prompts_map = data.get("prompts", {}) or {}
         treatment = data.get("treatment")
         shots = data.get("shots", []) or []
@@ -413,7 +430,7 @@ def _generate_shots_for_batch(
         if not prompts_map:
             try:
                 rec_user = _build_shots_only_user(style_prompt, cuts_json, b, n_total, mode_instruction, guidance_block, treatment_block, treatment_context)
-                data2, _ = _director_chat(ollama=ollama, model=model, system=_SHOTS_ONLY_SYSTEM, user=rec_user, batch_len=b, rich=False)
+                data2, _ = _director_chat(ollama=ollama, model=model, system=_SHOTS_ONLY_SYSTEM, user=rec_user, batch_len=b, rich=False, sampling=sampling)
                 if data2.get("prompts"):
                     prompts_map = data2.get("prompts", {})
                     treatment = treatment or data2.get("treatment")
@@ -440,6 +457,7 @@ def _generate_storyline_and_prompts(
     user_treatment: str | None = None,
     max_stretch: float | None = None,
     fill_method: str | None = None,
+    sampling: dict | None = None,
 ) -> dict:
     """Internal: returns {'prompts': list[str], 'storyline': str | None}.
     The storyline is the actual narrative arc the model invented for this video.
@@ -518,6 +536,7 @@ def _generate_storyline_and_prompts(
                 max_stretch=max_stretch,
                 fill_method=fill_method,
                 rich=(bi == 0),
+                sampling=sampling,
             )
             if bi == 0 and res.get("treatment"):
                 treatment = res.get("treatment")

--- a/backend/services/music_video_service.py
+++ b/backend/services/music_video_service.py
@@ -449,7 +449,7 @@ class MusicVideoService(PipelineService):
 
         from backend.services.plugin_bridge import ensure_plugins_for_stage
         ensure_plugins_for_stage("music-video", "analyzing")  # Director requires Ollama (and video_editor) for per-cut visual prompts from treatment
-        from backend.services.music_video_director import _generate_storyline_and_prompts, DIRECTOR_MODEL, _is_embedding_model
+        from backend.services.music_video_director import DIRECTOR_MODEL, _is_embedding_model
 
         mode = planning_mode or s.get("planning_mode", "narrative")
         guidance = feedback or s.get("director_guidance")
@@ -460,16 +460,22 @@ class MusicVideoService(PipelineService):
             dmodel = DIRECTOR_MODEL
 
         try:
-            res = _generate_storyline_and_prompts(
-                mv.style_prompt,
-                mv.cut_plan,
+            # Unified Director (SONG_CUTPLAN). creativity=None ⇒ engine-default sampling, a
+            # BYTE-IDENTICAL migration of this fragile replan path.
+            from backend.services.director_service import plan as director_plan, DirectorBrief, DirectorMode
+            _res = director_plan(DirectorBrief(
+                mode=DirectorMode.SONG_CUTPLAN,
+                style=mv.style_prompt,
+                cut_plan=mv.cut_plan,
+                creativity=None,
                 model=dmodel,
                 planning_mode=mode,
                 extra_guidance=guidance,
                 user_treatment=s.get("user_treatment") or s.get("director_treatment"),
                 max_stretch=float(s.get("max_stretch", 2.0)),
                 fill_method=s.get("fill_method"),
-            )
+            ))
+            res = _res.raw if _res.raw is not None else {"prompts": [], "treatment": _res.treatment}
             raw_prompts = res.get("prompts") or []
             # P0 guard (story-arc plan): apply distinctness/energy injection here too so a
             # replan immediately gives usable varied prompts for subsequent storyboard regen.

--- a/backend/services/plugin_runner.py
+++ b/backend/services/plugin_runner.py
@@ -243,6 +243,25 @@ class PluginRunnerClient:
                 self._proc.wait(timeout=2)
             except Exception:
                 pass
+        finally:
+            # Close pipes explicitly so the OS doesn't think resources are leaked.
+            # This helps avoid resource_tracker warnings for the controlling process.
+            try:
+                if self._proc.stdin:
+                    self._proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                if self._proc.stdout:
+                    self._proc.stdout.close()
+            except Exception:
+                pass
+            try:
+                if self._proc.stderr:
+                    self._proc.stderr.close()
+            except Exception:
+                pass
+            self._proc = None
 
     def _send(self, req: dict) -> dict:
         with self._lock:

--- a/backend/services/video_director.py
+++ b/backend/services/video_director.py
@@ -159,25 +159,29 @@ def direct_prompts(
     model: str = DEFAULT_DIRECTOR_MODEL,
     extra_guidance: Optional[str] = None,
 ) -> list[str]:
-    """Turn each plain user prompt into a rich cinematic shot prompt.
+    """DEPRECATED SHIM → :func:`director_service.plan` (PROMPT_LIST mode).
 
-    Never raises and never changes the count: returns exactly ``len(prompts)`` strings.
-    Any prompt the director couldn't produce falls back to the lightweight enhancer / the
-    original prompt, so a partial/failed LLM response degrades gracefully per-item.
+    Kept so any stray importer keeps working after the unification (2026-06-23). The real
+    enrichment now lives in ``director_service`` (which routes through ``media_director`` +
+    the CREATIVE sampling profile). Still never raises and never changes the count: on a hard
+    director failure the per-item ``_light_fallback`` / original prompt stands.
     """
     prompts = [p for p in (prompts or [])]
     if not prompts:
         return []
-    user = (
-        f"{_style_clause(style)}"
-        + (f"\nDirector guidance: {extra_guidance.strip()}." if extra_guidance and extra_guidance.strip() else "")
-        + "\n\nIdeas (rewrite each, one per entry, same order):\n"
-        + json.dumps([str(p) for p in prompts], ensure_ascii=False)
-    )
-    directed = _parse_prompts(_chat_json(_SYSTEM_DIRECT, user, model=model, n=len(prompts)), len(prompts))
+    try:
+        from backend.services.director_service import plan, DirectorBrief, DirectorMode
+        result = plan(DirectorBrief(
+            mode=DirectorMode.PROMPT_LIST, prompts=[str(p) for p in prompts],
+            style=style or "", extra_guidance=extra_guidance,
+        ))
+        directed = [s.prompt for s in result.shots]
+    except Exception as e:  # noqa: BLE001 — director must never fail a render
+        log.warning("video_director shim -> director_service failed (%s); light fallback", e)
+        directed = []
     out: list[str] = []
     for i, original in enumerate(prompts):
-        cand = directed[i].strip() if i < len(directed) and directed[i].strip() else ""
+        cand = directed[i].strip() if i < len(directed) and directed[i] and directed[i].strip() else ""
         out.append(cand or _light_fallback(original, style))
     return out
 
@@ -202,24 +206,28 @@ def storyboard_from_concept(
     model: str = DEFAULT_DIRECTOR_MODEL,
     extra_guidance: Optional[str] = None,
 ) -> list[str]:
-    """Expand ONE concept into ``num_shots`` distinct-but-connected shot prompts.
+    """DEPRECATED SHIM → :func:`director_service.plan` (CONCEPT_EXPANSION mode).
 
-    Never raises. On LLM/parse failure (or a short response) the missing shots are filled
-    with a lightweight-enhanced variant of the concept so the caller always gets exactly
-    ``num_shots`` usable prompts.
+    Kept for backward-compat after the unification (2026-06-23). Never raises and always
+    returns exactly ``num_shots`` usable prompts (pads with a light-enhanced concept variant
+    if the director under-delivers).
     """
     n = max(1, int(num_shots or 1))
     concept = (concept or "").strip()
     if not concept:
         return []
-    user = (
-        f"Concept: {concept}\nNumber of shots N: {n}."
-        + _style_clause(style)
-        + (f"\nDirector guidance: {extra_guidance.strip()}." if extra_guidance and extra_guidance.strip() else "")
-    )
-    shots = _parse_prompts(_chat_json(_SYSTEM_STORYBOARD, user, model=model, n=n), n)
-    out = [s for s in shots[:n] if s]
-    # Pad if the model under-delivered, so the count is exactly N.
+    try:
+        from backend.services.director_service import plan, DirectorBrief, DirectorMode
+        result = plan(DirectorBrief(
+            mode=DirectorMode.CONCEPT_EXPANSION, concept=concept, num_shots=n,
+            style=style or "", extra_guidance=extra_guidance,
+        ))
+        shots = [s.prompt for s in result.shots]
+    except Exception as e:  # noqa: BLE001
+        log.warning("video_director shim -> director_service failed (%s); light fallback", e)
+        shots = []
+    out = [s for s in shots[:n] if s and s.strip()]
+    # Pad if the director under-delivered, so the count is exactly N.
     while len(out) < n:
         idx = len(out) + 1
         out.append(_light_fallback(f"{concept} (shot {idx} of {n})", style))

--- a/backend/tasks/character_generation_tasks.py
+++ b/backend/tasks/character_generation_tasks.py
@@ -1,0 +1,263 @@
+"""Character Generator Celery tasks.
+
+Two tasks hang off the same GPU-exclusivity rail used by the storyboard artist
+(``JobKind.VIDEO_RENDER``) because FLUX is the same image model — running two
+FLUX jobs simultaneously on the 16 GB card would OOM.
+
+Task names:
+  character.generate_samples(subject_id)   — full plan + image loop
+  character.regen_sample(sample_id, ...)   — single image regen
+
+Registration: call ``create_character_generation_tasks(celery_app)`` from
+``celery_app.py`` exactly like ``create_production_swarm_tasks``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import random
+from pathlib import Path
+
+from celery import Celery
+from flask import current_app
+
+log = logging.getLogger(__name__)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _sample_output_dir(subject_id: int) -> Path:
+    """Canonical on-disk location for a subject's generated reference images.
+
+    Mirrors _storyboard_path() in production_swarm_tasks: everything under
+    data/outputs/ so it lives in the DATA_DIR subtree (backed up, served by
+    the static-file route).
+    """
+    try:
+        from backend.config import STORAGE_DIR
+        base = Path(STORAGE_DIR) / "outputs" / "character_samples" / str(subject_id)
+    except Exception:
+        base = Path("data") / "outputs" / "character_samples" / str(subject_id)
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _sample_image_path(subject_id: int, index: int) -> str:
+    return str(_sample_output_dir(subject_id) / f"sample_{index}.png")
+
+
+# ── task implementations (plain functions for testability) ─────────────────────
+
+def generate_samples(subject_id: int) -> dict:
+    """Plan + generate the full reference-sheet for a Subject.
+
+    Flow:
+      1. Load the Subject row; validate it exists.
+      2. Call generate_character_sheet() (LLM-only, GPU-free).
+      3. Persist bible + trigger_word onto the Subject.
+      4. Delete any existing SubjectSample rows (idempotent re-plan).
+      5. Insert one SubjectSample per shot (status=pending).
+      6. Loop shots under gpu_exclusive, generating each image via FLUX.
+      7. Update each row status→done/failed + image_path.
+
+    Mirror of run_storyboard_artist: same gate, same commit pattern, same
+    error surface (raises on ComfyUI unavailability so the Celery task retries
+    or marks itself failed — no silent rot).
+    """
+    from backend.models import db, Subject, SubjectSample
+    from backend.services.character_generator_service import generate_character_sheet
+    from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+    from backend.services.job_operation_gate import get_gate
+    from backend.services.job_types import JobKind
+    from backend.services.plugin_bridge import ensure_plugins_for_stage
+
+    subject = db.session.get(Subject, subject_id)
+    if subject is None:
+        log.error("generate_samples: Subject %s not found", subject_id)
+        return {"error": "subject_not_found"}
+
+    # --- 1. LLM planning (GPU-free) -----------------------------------------
+    log.info("Character Generator: planning sheet for subject %s (%s)", subject_id, subject.name)
+    plan = generate_character_sheet(
+        name=subject.name,
+        kind=subject.kind,
+        description=subject.description or "",
+        trigger_word=subject.trigger_word or None,
+    )
+
+    if plan.get("error"):
+        log.error("Character Generator: bible generation failed for subject %s: %s",
+                  subject_id, plan["error"])
+        return {"error": plan["error"]}
+
+    bible = plan["bible"]
+    trigger = plan["trigger_word"]
+    shots = plan["shots"]
+
+    # --- 2. Persist bible + trigger on Subject --------------------------------
+    subject.bible = bible
+    if trigger:
+        subject.trigger_word = trigger
+    db.session.flush()
+
+    # --- 3. Idempotent re-plan: delete existing samples ----------------------
+    SubjectSample.query.filter_by(subject_id=subject_id).delete()
+    db.session.flush()
+
+    # --- 4. Insert SubjectSample rows (status=pending) -----------------------
+    sample_rows: list[SubjectSample] = []
+    for shot in shots:
+        row = SubjectSample(
+            subject_id=subject_id,
+            index=shot["index"],
+            angle=shot.get("angle") or "",
+            framing=shot.get("framing") or "",
+            expression=shot.get("expression") or "",
+            lighting=shot.get("lighting") or "",
+            scene=shot.get("scene") or "",
+            image_prompt=shot.get("image_prompt") or "",
+            placeholder=bool(shot.get("placeholder", False)),
+            status="pending",
+            approved=False,
+        )
+        db.session.add(row)
+        sample_rows.append(row)
+
+    db.session.commit()
+    log.info("Character Generator: inserted %d SubjectSample rows for subject %s",
+             len(sample_rows), subject_id)
+
+    # --- 5. Image generation loop (GPU-exclusive) ----------------------------
+    ensure_plugins_for_stage("film-crew", "storyboard_gen")  # ensures comfyui plugin is up
+    image_generator = ComfyUIImageGenerator(model="flux-schnell")
+    gate = get_gate()
+
+    # Refresh rows now that they have PKs (after commit).
+    sample_rows = SubjectSample.query.filter_by(subject_id=subject_id).order_by(SubjectSample.index).all()
+
+    done_count = 0
+    failed_count = 0
+
+    with gate.gpu_exclusive(JobKind.VIDEO_RENDER, f"char_samples_{subject_id}"):
+        for row in sample_rows:
+            output_path = _sample_image_path(subject_id, row.index)
+            seed = random.randint(1, 2 ** 31 - 1)
+            row.status = "generating"
+            row.seed = seed
+            db.session.commit()
+
+            try:
+                image_generator.generate_image(
+                    prompt=row.image_prompt or subject.name,
+                    loras=[],  # no LoRA yet — this IS the training-data pass
+                    output_path=output_path,
+                    seed=seed,
+                    model="flux-schnell",
+                )
+                row.image_path = output_path
+                row.status = "done"
+                done_count += 1
+                # Write a textfile caption sidecar next to the image so the generated set is
+                # trainable as-is (SimpleTuner caption_strategy="textfile"). The image_prompt
+                # already front-loads the trigger + bible + per-shot framing variation, so it
+                # IS the caption. (Re-caption later with scripts/caption_dataset.py for a VLM
+                # description of the actual render if higher fidelity is wanted.) Best-effort —
+                # a sidecar failure must never fail the sample.
+                try:
+                    from pathlib import Path as _P
+                    cap = (row.image_prompt or subject.name or "").strip()
+                    if cap:
+                        _P(output_path).with_suffix(".txt").write_text(cap + "\n", encoding="utf-8")
+                except Exception as _se:  # noqa: BLE001
+                    log.warning("Character Generator: caption sidecar failed for sample %d: %s",
+                                row.index, _se)
+                log.info("Character Generator: sample %d/%d done (%s)",
+                         row.index + 1, len(sample_rows), output_path)
+            except Exception as exc:
+                row.status = "failed"
+                failed_count += 1
+                log.error("Character Generator: sample %d failed: %s", row.index, exc)
+            finally:
+                db.session.commit()
+
+    log.info("Character Generator: finished subject %s — %d done, %d failed",
+             subject_id, done_count, failed_count)
+    return {"subject_id": subject_id, "done": done_count, "failed": failed_count,
+            "total": len(sample_rows)}
+
+
+def regen_sample(sample_id: int, prompt_override: str | None = None, seed: int | None = None) -> dict:
+    """Regenerate the image for a single SubjectSample.
+
+    Cloned from regen_storyboard_shot: same GPU gate, same single-commit pattern.
+    prompt_override replaces the stored image_prompt for this generation only
+    (the stored prompt is NOT overwritten — the user is exploring, not editing the
+    plan).  Pass seed=None for a fresh random seed.
+    """
+    from backend.models import db, SubjectSample
+    from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+    from backend.services.job_operation_gate import get_gate
+    from backend.services.job_types import JobKind
+    from backend.services.plugin_bridge import ensure_plugins_for_stage
+
+    row = db.session.get(SubjectSample, sample_id)
+    if row is None:
+        log.error("regen_sample: SubjectSample %s not found", sample_id)
+        return {"error": "sample_not_found"}
+
+    ensure_plugins_for_stage("film-crew", "storyboard_gen")
+    image_generator = ComfyUIImageGenerator(model="flux-schnell")
+    gate = get_gate()
+
+    effective_seed = seed if seed is not None else random.randint(1, 2 ** 31 - 1)
+    effective_prompt = prompt_override if prompt_override else (row.image_prompt or "")
+    output_path = _sample_image_path(row.subject_id, row.index)
+
+    row.status = "generating"
+    row.seed = effective_seed
+    db.session.commit()
+
+    with gate.gpu_exclusive(JobKind.VIDEO_RENDER, f"char_regen_{row.subject_id}"):
+        try:
+            image_generator.generate_image(
+                prompt=effective_prompt,
+                loras=[],
+                output_path=output_path,
+                seed=effective_seed,
+                model="flux-schnell",
+            )
+            row.image_path = output_path
+            row.status = "done"
+            log.info("regen_sample: sample %s regenerated → %s", sample_id, output_path)
+        except Exception as exc:
+            row.status = "failed"
+            log.error("regen_sample: sample %s failed: %s", sample_id, exc)
+        finally:
+            db.session.commit()
+
+    return {"sample_id": sample_id, "status": row.status, "image_path": row.image_path}
+
+
+# ── factory ────────────────────────────────────────────────────────────────────
+
+def create_character_generation_tasks(celery_app: Celery):
+    """Register character.* tasks with the Celery app.
+
+    Called from backend/celery_app.py alongside create_production_swarm_tasks.
+    """
+
+    @celery_app.task(name="character.generate_samples")
+    def generate_samples_task(subject_id: int):
+        with current_app.app_context():
+            return generate_samples(subject_id)
+
+    @celery_app.task(name="character.regen_sample")
+    def regen_sample_task(sample_id: int, prompt_override: str | None = None,
+                          seed: int | None = None):
+        with current_app.app_context():
+            return regen_sample(sample_id, prompt_override=prompt_override, seed=seed)
+
+    return {
+        "generate_samples": generate_samples_task,
+        "regen_sample": regen_sample_task,
+    }

--- a/backend/tasks/music_video_tasks.py
+++ b/backend/tasks/music_video_tasks.py
@@ -352,7 +352,7 @@ def run_analyzer(mv_id: int):
         # problem. Still degrades gracefully to the old behavior on any LLM failure.
         shot_plans = {}
         if s.get("director_enabled", True):
-            from backend.services.music_video_director import _generate_storyline_and_prompts, DIRECTOR_MODEL, _is_embedding_model
+            from backend.services.music_video_director import DIRECTOR_MODEL, _is_embedding_model
             director_model = s.get("director_model") or DIRECTOR_MODEL
             if _is_embedding_model(director_model):
                 logging.getLogger(__name__).warning("overriding bad director_model=%s (embedding model cannot chat) -> %s", director_model, DIRECTOR_MODEL)
@@ -368,16 +368,25 @@ def run_analyzer(mv_id: int):
                               "build — only their pose, action, wardrobe, framing, camera, lighting, and "
                               "setting. Refer to them only as 'the figure' or 'she/he' if needed.")
                 _dir_guidance = f"{_dir_guidance}\n{_lock_note}" if _dir_guidance else _lock_note
-            result = _generate_storyline_and_prompts(
-                mv.style_prompt,
-                plan,
+            # Unified Director (SONG_CUTPLAN). `plan` (the cut plan) shadows the imported
+            # function name, so alias it. creativity=None ⇒ engine-default sampling: this is a
+            # BYTE-IDENTICAL migration of the fragile MV path (still temp 0.7/0.65). We can flip
+            # MV to the CREATIVE profile later as a separate, tested change.
+            from backend.services.director_service import plan as director_plan, DirectorBrief, DirectorMode
+            _res = director_plan(DirectorBrief(
+                mode=DirectorMode.SONG_CUTPLAN,
+                style=mv.style_prompt,
+                cut_plan=plan,
+                creativity=None,
                 model=director_model,
                 planning_mode=s.get("planning_mode", "narrative"),
                 extra_guidance=_dir_guidance,
                 user_treatment=s.get("user_treatment") or s.get("director_treatment"),
                 max_stretch=float(s.get("max_stretch", 2.0)),
                 fill_method=s.get("fill_method"),
-            )
+            ))
+            # Use the engine's native dict so every downstream read below is unchanged.
+            result = _res.raw if _res.raw is not None else {"prompts": [], "treatment": _res.treatment}
             # P0 guard application (story-arc plan): ensure the prompts we store for
             # storyboards + i2v are distinct + energy-aware even on marginal LLM output.
             # Also the natural place to (in future) pass stretch context for duration suggestions.

--- a/backend/tasks/music_video_tasks.py
+++ b/backend/tasks/music_video_tasks.py
@@ -185,15 +185,13 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
     when the token it was trained on is actually present at inference, so the
     trigger words go INTO the prompt, not just the LoraLoader chain.
 
-    Honest source-of-truth note: the MusicVideo model has NO cast/subject join
-    table (unlike Production → ProductionSubject), and the create form sends only
-    a `use_lora_consistency` boolean — no subject picker. So the ONLY place a
-    trained-LoRA reference can come from today is settings_json. We honor, in
-    priority order, whatever the settings actually carry:
+    Source-of-truth note: the MusicVideo model has NO cast/subject join table
+    (unlike Production → ProductionSubject); the reference lives in settings_json.
+    The MusicVideoPage cast picker writes `subject_ids` there (alongside the
+    `use_lora_consistency` toggle). We honor, in priority order:
       1. explicit on-disk paths in settings `loras` / `lora_paths` (list[str]);
-      2. `subject_ids` (list[int]) → Subject.lora_path + trigger_word — this is
-         the seam a future MV cast picker would write into, and resolving it now
-         means that picker works with zero further changes here.
+      2. `subject_ids` (list[int]) → Subject.lora_path + trigger_word + bible —
+         what the cast picker writes.
     Returns ([], base_prompt) — i.e. a NO-OP — when LoRA consistency is off or no
     reference is reachable, so non-cast videos behave exactly as before.
     """

--- a/backend/tasks/music_video_tasks.py
+++ b/backend/tasks/music_video_tasks.py
@@ -202,6 +202,7 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
 
     lora_paths: list[str] = []
     triggers: list[str] = []
+    bibles: list[str] = []   # canonical appearance-lock per subject (hair length etc.)
 
     # (1) explicit paths in settings (accept either key name).
     explicit = s.get("loras") or s.get("lora_paths") or []
@@ -219,11 +220,19 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
             if subj and subj.lora_path:
                 lora_paths.append(subj.lora_path)
                 triggers.append((subj.trigger_word or subj.name or "").strip())
+                # The bible pins constant attributes the LoRA under-constrains
+                # (hair length is the classic drifter). Injecting it verbatim per
+                # cut — and telling the Director NOT to describe appearance — is
+                # what keeps the character on-model across every scene.
+                if subj.bible:
+                    bibles.append(subj.bible.strip())
 
     # De-dupe paths while preserving order.
     seen: set[str] = set()
     lora_paths = [p for p in lora_paths if not (p in seen or seen.add(p))]
     triggers = [t for t in triggers if t]
+    bseen: set[str] = set()
+    bibles = [b for b in bibles if b and not (b in bseen or bseen.add(b))]
 
     if not lora_paths:
         log.info(
@@ -234,12 +243,25 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
         )
         return [], base_prompt
 
-    prompt = base_prompt
-    if triggers:
-        prompt = f"{', '.join(triggers)}, {base_prompt}"
-    log.info("music_video %s keyframe: applying %d LoRA(s) %s",
-             mv.id, len(lora_paths), [os.path.basename(p) for p in lora_paths])
+    # Identity lock goes at the FRONT of the prompt: trigger(s) first (binds the
+    # LoRA), then the verbatim bible(s) (pins hair length / constant features),
+    # then the per-cut scene. e.g. "sage_harlow, chin-length wavy black bob, ...,
+    # <scene for this cut>".
+    lock = ", ".join([*triggers, *bibles])
+    prompt = f"{lock}, {base_prompt}" if lock else base_prompt
+    log.info("music_video %s keyframe: applying %d LoRA(s) %s (bible-lock=%s)",
+             mv.id, len(lora_paths), [os.path.basename(p) for p in lora_paths], bool(bibles))
     return lora_paths, prompt
+
+
+def _keyframe_lora_strength(s: dict) -> float:
+    """Model-aware default keyframe LoRA strength, shared by the clip path AND both
+    storyboard endpoints so review thumbnails match the final render. SDXL rank-16
+    character LoRAs sit at ~0.25 (higher fries them); the FLUX-dev route holds identity
+    at ~0.9 (verified on sage_harlow 2026-06-22). Operator override in settings wins."""
+    kfm = (s.get("keyframe_model") or "").lower()
+    default = 0.9 if ("flux" in kfm and "dev" in kfm) else 0.25
+    return max(0.0, min(1.5, float(s.get("keyframe_lora_strength", default))))
 
 
 @contextmanager
@@ -337,12 +359,23 @@ def run_analyzer(mv_id: int):
             if _is_embedding_model(director_model):
                 logging.getLogger(__name__).warning("overriding bad director_model=%s (embedding model cannot chat) -> %s", director_model, DIRECTOR_MODEL)
                 director_model = DIRECTOR_MODEL
+            # When a trained character is cast, identity (trigger + bible) is injected
+            # into every keyframe by _keyframe_loras_and_prompt. Tell the Director NOT to
+            # describe the hero's appearance — otherwise it free-styles hair/face per cut
+            # and fights the lock (the "hair length drifts every scene" failure).
+            _dir_guidance = s.get("director_guidance")
+            if s.get("use_lora_consistency") and (s.get("subject_ids") or s.get("loras") or s.get("lora_paths")):
+                _lock_note = ("A trained character is locked into every shot by a separate identity "
+                              "system. Do NOT describe the main character's face, hair, skin, eyes, or "
+                              "build — only their pose, action, wardrobe, framing, camera, lighting, and "
+                              "setting. Refer to them only as 'the figure' or 'she/he' if needed.")
+                _dir_guidance = f"{_dir_guidance}\n{_lock_note}" if _dir_guidance else _lock_note
             result = _generate_storyline_and_prompts(
                 mv.style_prompt,
                 plan,
                 model=director_model,
                 planning_mode=s.get("planning_mode", "narrative"),
-                extra_guidance=s.get("director_guidance"),
+                extra_guidance=_dir_guidance,
                 user_treatment=s.get("user_treatment") or s.get("director_treatment"),
                 max_stretch=float(s.get("max_stretch", 2.0)),
                 fill_method=s.get("fill_method"),
@@ -572,7 +605,7 @@ def _generate_one_clip(mv: MusicVideo, clip: dict):
             # matches ComfyUIImageGenerator; higher can "fry" identity, lower is safer for
             # consistency). Source from settings if operator tuned it for this MV.
             # Preflight + clamp now wired in api paths + generator too (was the noted WIP).
-            kf_lora_strength = max(0.0, min(1.5, float(s.get("keyframe_lora_strength", 0.25))))
+            kf_lora_strength = _keyframe_lora_strength(s)  # model-aware: 0.9 flux-dev / 0.25 sdxl
             vg = get_video_generator()
             if not getattr(vg, "service_available", True):
                 try:

--- a/backend/tasks/music_video_tasks.py
+++ b/backend/tasks/music_video_tasks.py
@@ -198,9 +198,9 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
     if not s.get("use_lora_consistency"):
         return [], base_prompt
 
+    from backend.services.cast_lock import subjects_to_lock, apply_lock
+
     lora_paths: list[str] = []
-    triggers: list[str] = []
-    bibles: list[str] = []   # canonical appearance-lock per subject (hair length etc.)
 
     # (1) explicit paths in settings (accept either key name).
     explicit = s.get("loras") or s.get("lora_paths") or []
@@ -209,28 +209,20 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
             if isinstance(p, str) and p.strip():
                 lora_paths.append(p.strip())
 
-    # (2) subject_ids → trained Subject LoRAs (the cast seam, mirrors Film Crew).
+    # (2) subject_ids → trained Subject LoRAs (the cast seam, shared with Film Crew via
+    # cast_lock.subjects_to_lock — trigger(s) bind the LoRA, verbatim bible(s) pin constant
+    # features like hair length the LoRA under-constrains).
+    lock = ""
     subject_ids = s.get("subject_ids") or []
     if isinstance(subject_ids, (list, tuple)) and subject_ids:
         from backend.models import Subject
-        for sid in subject_ids:
-            subj = db.session.get(Subject, sid)
-            if subj and subj.lora_path:
-                lora_paths.append(subj.lora_path)
-                triggers.append((subj.trigger_word or subj.name or "").strip())
-                # The bible pins constant attributes the LoRA under-constrains
-                # (hair length is the classic drifter). Injecting it verbatim per
-                # cut — and telling the Director NOT to describe appearance — is
-                # what keeps the character on-model across every scene.
-                if subj.bible:
-                    bibles.append(subj.bible.strip())
+        subjects = [db.session.get(Subject, sid) for sid in subject_ids]
+        subj_paths, lock = subjects_to_lock([x for x in subjects if x], include_bible=True)
+        lora_paths.extend(subj_paths)
 
     # De-dupe paths while preserving order.
     seen: set[str] = set()
     lora_paths = [p for p in lora_paths if not (p in seen or seen.add(p))]
-    triggers = [t for t in triggers if t]
-    bseen: set[str] = set()
-    bibles = [b for b in bibles if b and not (b in bseen or bseen.add(b))]
 
     if not lora_paths:
         log.info(
@@ -241,25 +233,21 @@ def _keyframe_loras_and_prompt(mv: MusicVideo, s: dict, base_prompt: str) -> tup
         )
         return [], base_prompt
 
-    # Identity lock goes at the FRONT of the prompt: trigger(s) first (binds the
-    # LoRA), then the verbatim bible(s) (pins hair length / constant features),
-    # then the per-cut scene. e.g. "sage_harlow, chin-length wavy black bob, ...,
-    # <scene for this cut>".
-    lock = ", ".join([*triggers, *bibles])
-    prompt = f"{lock}, {base_prompt}" if lock else base_prompt
+    # Identity lock goes at the FRONT of the prompt (trigger(s) → bible(s) → per-cut scene),
+    # e.g. "sage_harlow, chin-length wavy black bob, ..., <scene for this cut>".
+    prompt = apply_lock(base_prompt, lock)
     log.info("music_video %s keyframe: applying %d LoRA(s) %s (bible-lock=%s)",
-             mv.id, len(lora_paths), [os.path.basename(p) for p in lora_paths], bool(bibles))
+             mv.id, len(lora_paths), [os.path.basename(p) for p in lora_paths], bool(lock))
     return lora_paths, prompt
 
 
 def _keyframe_lora_strength(s: dict) -> float:
     """Model-aware default keyframe LoRA strength, shared by the clip path AND both
-    storyboard endpoints so review thumbnails match the final render. SDXL rank-16
-    character LoRAs sit at ~0.25 (higher fries them); the FLUX-dev route holds identity
-    at ~0.9 (verified on sage_harlow 2026-06-22). Operator override in settings wins."""
-    kfm = (s.get("keyframe_model") or "").lower()
-    default = 0.9 if ("flux" in kfm and "dev" in kfm) else 0.25
-    return max(0.0, min(1.5, float(s.get("keyframe_lora_strength", default))))
+    storyboard endpoints so review thumbnails match the final render. Delegates to the shared
+    cast_lock.resolve_lora_strength (one source of truth across all video features); operator
+    override in settings wins."""
+    from backend.services.cast_lock import resolve_lora_strength
+    return resolve_lora_strength(s.get("keyframe_model"), s.get("keyframe_lora_strength"))
 
 
 @contextmanager

--- a/backend/tasks/production_swarm_tasks.py
+++ b/backend/tasks/production_swarm_tasks.py
@@ -9,7 +9,7 @@ from flask import current_app
 from backend.models import db, Production, Subject, ProductionShot, ProductionShotSubject, ProductionSubject, SwarmMessage, Document
 from backend.services.production_service import ProductionService
 from backend.services.swarm.agents.screenwriter import Screenwriter
-from backend.services.swarm.agents.cinematographer import Cinematographer
+from backend.services.swarm.agents.cinematographer import Cinematographer, ShotPlan, ShotPlanList
 from backend.services.swarm.agents.casting_director import CastingDirector
 from backend.services.swarm.agents.editor import Editor
 from backend.services.swarm.script_markup import parse_markup, apply_intents
@@ -294,6 +294,72 @@ def _subjects_for_production(prod_id: int) -> list[Subject]:
     return subjects or Subject.query.all()
 
 
+class _DirectorInvocation:
+    """A tiny AgentInvocation look-alike so ``ctx.persist`` and the existing write-back loop
+    work unchanged when the unified Director produces the shot plan (instead of the swarm
+    Cinematographer). Mirrors the attributes ``_AgentRunContext.persist`` reads."""
+    def __init__(self, output, *, model: str):
+        self.output = output            # ShotPlanList (has .model_dump() + .plans)
+        self.model = model
+        self.status = "ok"
+        self.error_text = None
+        self.latency_ms = 0
+
+
+def _cinematographer_via_director(input_data: dict):
+    """PRIMARY cinematographer path: route the script breakdown through the unified Director
+    (``director_service.plan(SCRIPT_SCENES)``) — batched, treatment-driven, CREATIVE-sampled,
+    a clear upgrade over the single-call swarm agent.
+
+    Returns a ``_DirectorInvocation`` (status='ok') wrapping a ``ShotPlanList`` whose plans map
+    1:1, BY INPUT ORDER, back to the input shots — so scene/shot numbers come from the DB rows
+    (robust) and the existing persistence loop + FK filter run unchanged. Returns ``None`` on
+    any failure / thin result so the caller falls back to the swarm Cinematographer. NEVER
+    raises (preserves the never-raise stage contract)."""
+    try:
+        from backend.services.director_service import plan, DirectorBrief, DirectorMode, DIRECTOR_MODEL
+        in_shots = input_data.get("shots", []) or []
+        if not in_shots:
+            return None
+        # Flatten the production shots into the single-scene shape the SCRIPT_SCENES planner
+        # expects; order is preserved so we can zip results back by index.
+        scenes = [{
+            "location": "", "mood": "",
+            "shots": [{"description": s.get("description", ""), "subjects_in_shot": []} for s in in_shots],
+        }]
+        result = plan(DirectorBrief(
+            mode=DirectorMode.SCRIPT_SCENES,
+            scenes=scenes,
+            subjects=input_data.get("subjects", []) or [],
+            # T1.6 will populate cast here; until then identity stays render-time injected
+            # in _shot_loras_and_prompt (no double-lock).
+        ))
+        directed = result.shots or []
+        # Require a usable, full-coverage result; otherwise fall back to the agent.
+        if len(directed) < len(in_shots) or any(not (d.prompt or "").strip() for d in directed[:len(in_shots)]):
+            return None
+        plans = []
+        for i, s in enumerate(in_shots):
+            d = directed[i]
+            plans.append(ShotPlan(
+                scene_number=int(s.get("scene_number", 0)),
+                shot_number=int(s.get("shot_number", i)),
+                camera_angle=(d.camera or "medium"),
+                framing=(d.framing or ""),
+                duration_seconds=float(d.duration) if isinstance(d.duration, (int, float)) else 4.0,
+                mood=(d.mood or ""),
+                image_prompt=d.prompt.strip(),
+                subjects_in_shot=[int(x) for x in (d.subjects or [])],
+            ))
+        return _DirectorInvocation(ShotPlanList(plans=plans), model=f"director:{DIRECTOR_MODEL}")
+    except Exception as e:  # noqa: BLE001 — director must never fail the stage; fall back
+        import logging
+        logging.getLogger(__name__).warning(
+            "cinematographer via director failed (%s); falling back to swarm agent", e
+        )
+        return None
+
+
 def run_cinematographer(prod_id: int, llm=None):
     if llm is None:
         llm = _default_ollama_llm
@@ -320,7 +386,10 @@ def run_cinematographer(prod_id: int, llm=None):
             "subjects": [{"id": s.id, "name": s.name, "description": s.description} for s in subjects]
         }
 
-        inv = agent.invoke(input_data)
+        # PRIMARY: unified Director (batched, treatment-driven). FALLBACK: swarm Cinematographer.
+        inv = _cinematographer_via_director(input_data)
+        if inv is None:
+            inv = agent.invoke(input_data)
         ctx.persist(inv, input_json=input_data)
 
         out = inv.output

--- a/backend/tasks/production_swarm_tasks.py
+++ b/backend/tasks/production_swarm_tasks.py
@@ -331,8 +331,10 @@ def _cinematographer_via_director(input_data: dict):
             mode=DirectorMode.SCRIPT_SCENES,
             scenes=scenes,
             subjects=input_data.get("subjects", []) or [],
-            # T1.6 will populate cast here; until then identity stays render-time injected
-            # in _shot_loras_and_prompt (no double-lock).
+            # cast is intentionally NOT passed: identity is injected at RENDER time in
+            # _shot_loras_and_prompt (via shared cast_lock) — that survives prompt edits and
+            # stays per-shot scoped, which plan-time global injection would lose. Leaving
+            # brief.cast empty here is what keeps the lock applied exactly once (no double-lock).
         ))
         directed = result.shots or []
         # Require a usable, full-coverage result; otherwise fall back to the agent.
@@ -416,21 +418,18 @@ def run_cinematographer(prod_id: int, llm=None):
 
 
 def _shot_loras_and_prompt(shot) -> tuple[list[str], str]:
-    """Collect a shot's character LoRA paths and build the generation prompt
-    with each Subject's trigger word prepended — the LoRA only locks identity
-    when the token it was trained on is actually present at inference."""
-    lora_paths: list[str] = []
-    triggers: list[str] = []
-    for pss in shot.shot_subjects:
-        subj = pss.subject
-        if subj.lora_path:
-            lora_paths.append(subj.lora_path)
-            triggers.append((subj.trigger_word or subj.name or "").strip())
-    triggers = [t for t in triggers if t]
-    prompt = shot.description
-    if triggers:
-        prompt = f"{', '.join(triggers)}, {prompt}"
-    return lora_paths, prompt
+    """Collect a shot's character LoRA paths and build the generation prompt with each
+    Subject's identity lock prepended — the LoRA only locks identity when the trigger token
+    it was trained on is present at inference.
+
+    Uses the shared cast_lock.subjects_to_lock (one source of truth with music-video). As of
+    the 2026-06-23 cast convergence this now also injects each subject's BIBLE (was trigger-only),
+    giving Film Crew the same trigger+bible lock music-video already had — and it stays correctly
+    PER-SHOT scoped (only the subjects actually in this shot)."""
+    from backend.services.cast_lock import subjects_to_lock, apply_lock
+    subjects = [pss.subject for pss in shot.shot_subjects if pss.subject]
+    lora_paths, lock = subjects_to_lock(subjects, include_bible=True)
+    return lora_paths, apply_lock(shot.description, lock)
 
 
 def _storyboard_path(prod_id: int, shot_number: int) -> str:

--- a/backend/tools/image_tools.py
+++ b/backend/tools/image_tools.py
@@ -106,6 +106,17 @@ class ImageGeneratorTool(BaseTool):
                     error="Image generation service not available. Stable Diffusion dependencies (torch, diffusers) may not be installed or GPU not available.",
                 )
 
+            # Shared intelligent pipeline: best-effort Media Director rewrite for richer visual prompts
+            # (uses the same ollama director as MusicVideo / batch-video; falls back silently).
+            try:
+                from backend.services.media_director import enhance_prompts
+                refined_list = enhance_prompts([prompt], style=style)
+                if refined_list and refined_list[0] and refined_list[0].strip() != prompt.strip():
+                    prompt = refined_list[0].strip()
+                    logger.info("ImageGeneratorTool: applied media_director enhance (chat NL pipeline)")
+            except Exception:
+                pass  # never break chat gen
+
             # Build proper request object
             request = ImageGenerationRequest(
                 prompt=prompt,

--- a/backend/utils/prompt_enhancer.py
+++ b/backend/utils/prompt_enhancer.py
@@ -148,6 +148,19 @@ NEGATIVE_PROMPTS = {
     ),
 }
 
+# Identity / anatomy-bleed guard for character-LoRA clips. Targets the specific failure mode
+# we saw on the first sage_harlow runs — the character's head turning into a horse, or animal
+# ears/fur fusing onto a human face — i.e. the LoRA-overfit face bleeding onto wrong anatomy
+# under motion. It is deliberately scoped to HYBRID/ANATOMY artifacts (not "horse" wholesale),
+# so a character legitimately *riding* a horse still renders the horse; only the person growing
+# animal features is pushed away. The real fix is full-body training data (see DATASET_SPEC.md);
+# this is the cheap, zero-GPU stopgap. Appended to the default negative for every video clip.
+IDENTITY_BLEED_NEGATIVE = (
+    "animal head, horse head, animal ears, animal face, fur on face, snout, muzzle, whiskers, "
+    "human-animal hybrid, anthropomorphic, creature hybrid, deformed face, fused features, "
+    "extra head, two heads, extra limbs, mutated anatomy, malformed body"
+)
+
 
 def enhance_video_prompt(
     prompt: str,
@@ -268,4 +281,7 @@ def get_default_negative_prompt(style: str = "cinematic") -> str:
         A negative prompt string focused on quality issues.
     """
     style = (style or "cinematic").lower().strip()
-    return NEGATIVE_PROMPTS.get(style, NEGATIVE_PROMPTS["none"])
+    base = NEGATIVE_PROMPTS.get(style, NEGATIVE_PROMPTS["none"])
+    # Always include the identity/anatomy-bleed guard — it's the cheap stopgap for the
+    # character-LoRA "horse-head" failure mode and is harmless on non-character clips.
+    return f"{base}, {IDENTITY_BLEED_NEGATIVE}"

--- a/frontend/src/api/chatService.js
+++ b/frontend/src/api/chatService.js
@@ -3,12 +3,7 @@
 import { BASE_URL, handleResponse } from "./apiClient";
 import { validateChatInput, checkRateLimit, ValidationError } from "../utils/inputValidation";
 import { RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "../config/constants";
-
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
+import { debugLog } from "../utils/debugLog";
 
 export const sendQuery = async (
   inputText,

--- a/frontend/src/api/swarmService.js
+++ b/frontend/src/api/swarmService.js
@@ -186,7 +186,7 @@ class SwarmService {
 
     this.socket = io(SOCKET_URL, {
       path: "/socket.io",
-      transports: ["websocket", "polling"],
+      transports: ["polling", "websocket"],
       reconnectionAttempts: 5,
     });
 

--- a/frontend/src/api/unifiedChatService.js
+++ b/frontend/src/api/unifiedChatService.js
@@ -5,14 +5,9 @@
 
 import { BASE_URL } from "./apiClient";
 import { useAppStore } from "../stores/useAppStore";
+import { debugLog } from "../utils/debugLog";
 
 const API_BASE = BASE_URL.replace(/\/api$/, "");
-
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
 
 class UnifiedChatService {
   constructor(socket) {

--- a/frontend/src/api/voiceService.js
+++ b/frontend/src/api/voiceService.js
@@ -41,7 +41,7 @@ class VoiceService {
   initSocket() {
     if (!this.socket) {
       this.socket = io(SOCKET_URL, {
-        transports: ['websocket', 'polling'],
+        transports: ['polling', 'websocket'],
         reconnection: true,
       });
       

--- a/frontend/src/api/voiceService.js
+++ b/frontend/src/api/voiceService.js
@@ -3,12 +3,7 @@
 
 import { BASE_URL, SOCKET_URL, handleResponse } from './apiClient';
 import { io } from 'socket.io-client';
-
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
+import { debugLog } from "../utils/debugLog";
 
 /**
  * Voice API Service - Handles all voice-related API interactions

--- a/frontend/src/components/agent/LessonPearlsFloater.jsx
+++ b/frontend/src/components/agent/LessonPearlsFloater.jsx
@@ -163,7 +163,7 @@ export default function LessonPearlsFloater({ onClose }) {
   useEffect(() => {
     if (!activeLessonId) return;
 
-    const socket = io({ path: '/socket.io', transports: ['websocket', 'polling'] });
+    const socket = io({ path: '/socket.io', transports: ['polling', 'websocket'] });
     socketRef.current = socket;
 
     socket.on('lesson:pearl_added', (data) => {

--- a/frontend/src/components/agent/TrainingFloater.jsx
+++ b/frontend/src/components/agent/TrainingFloater.jsx
@@ -180,7 +180,7 @@ export default function TrainingFloater({ open, onClose, _onNavigateAway }) {
   useEffect(() => {
     if (!open) return;
 
-    const socket = io({ path: '/socket.io', transports: ['websocket', 'polling'] });
+    const socket = io({ path: '/socket.io', transports: ['polling', 'websocket'] });
     socketRef.current = socket;
 
     socket.on('agent:learning_mode_started', () => {

--- a/frontend/src/components/chat/ChatInput.jsx
+++ b/frontend/src/components/chat/ChatInput.jsx
@@ -32,13 +32,9 @@ import { useAppStore } from "../../stores/useAppStore";
 import { useVoiceSettings } from "../../hooks/useVoiceSettings";
 import useSlashCommands from "../../hooks/useSlashCommands";
 import SlashCommandPopup from "./SlashCommandPopup";
+import { debugLog } from "../../utils/debugLog";
 
 const WEB_SEARCH_ENABLED_KEY = "guaardvark_webSearchEnabled";
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
 
 const fetchDuckDuckGoSnippet = async (query) => {
   try {

--- a/frontend/src/components/chat/FloatingChatCard.jsx
+++ b/frontend/src/components/chat/FloatingChatCard.jsx
@@ -29,6 +29,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import { useVoiceSettings } from "../../hooks/useVoiceSettings";
 import useSlashCommands from "../../hooks/useSlashCommands";
 import SlashCommandPopup from "./SlashCommandPopup";
+import { debugLog } from "../../utils/debugLog";
 
 const MIN_WIDTH = 280;
 const MIN_HEIGHT = 300;
@@ -68,25 +69,41 @@ const FloatingChatCard = () => {
   // Unified Chat Service (Socket.IO streaming)
   const { socketRef } = useUnifiedProgress();
   const [unifiedChatService, setUnifiedChatService] = useState(null);
+
+  // Safety: if socket becomes available while floating is open but we have no service yet
+  // (e.g. mount timing), create it. The main effect should cover this, but this is a belt.
+  useEffect(() => {
+    if (isOpen && !unifiedChatService && socketRef?.current) {
+      const svc = new UnifiedChatService(socketRef.current);
+      svc.joinSession(sessionId);
+      setUnifiedChatService(svc);
+    }
+  }, [isOpen, unifiedChatService, sessionId, socketRef?.current]);
   const [isStreamingMessage, setIsStreamingMessage] = useState(false);
 
-  // Initialize UnifiedChatService when socket is connected
+  // Initialize UnifiedChatService when socket is connected.
+  // Depend on socketRef?.current (the actual socket instance) so the effect re-runs
+  // as soon as the shared socket from UnifiedProgressContext is ready.
+  // Previously only [sessionId] meant: if socketRef.current was null on mount, we
+  // bailed forever and floating chat never called joinSession → no streaming.
   useEffect(() => {
-    // Eager creation (see ChatPage for rationale): avoid races and ensure listeners
-    // are registered before the first send even if connect handshake is still in flight.
-    if (!socketRef?.current) {
+    const socket = socketRef?.current;
+    if (!socket) {
       return;
     }
 
-    const service = new UnifiedChatService(socketRef.current);
+    // Eager creation: avoid races and ensure listeners registered before first send.
+    const service = new UnifiedChatService(socket);
     service.joinSession(sessionId);
     setUnifiedChatService(service);
+
+    debugLog('[FloatingChat] service created + joined for', sessionId);
 
     return () => {
       service.cleanup();
       setUnifiedChatService(null);
     };
-  }, [sessionId]);
+  }, [sessionId, socketRef?.current]);
 
   // Hydrate session mode from backend on sessionId change so `/agent` state
   // survives reloads / re-mounts. Without this, the floating card's

--- a/frontend/src/components/chat/StreamingMessage.jsx
+++ b/frontend/src/components/chat/StreamingMessage.jsx
@@ -22,14 +22,9 @@ import { BASE_URL } from "../../api/apiClient";
 import ToolCallCard from "./ToolCallCard";
 import AgentThinkingTrail from "./AgentThinkingTrail";
 import ImageLightbox from "../images/ImageLightbox";
+import { debugLog } from "../../utils/debugLog";
 
 const UPLOAD_BASE_URL = BASE_URL + "/uploads";
-
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
 
 const StreamingMessage = forwardRef(({ chatService, sessionId, onComplete }, ref) => {
   const [status, setStatus] = useState("idle"); // idle | thinking | streaming | complete | error

--- a/frontend/src/components/dashboard/FamilySelfImprovementCard.jsx
+++ b/frontend/src/components/dashboard/FamilySelfImprovementCard.jsx
@@ -82,7 +82,7 @@ const FamilySelfImprovementCard = React.forwardRef(
 
     // Listen for real-time progress events
     useEffect(() => {
-      const socket = io({ path: "/socket.io", transports: ["websocket", "polling"] });
+      const socket = io({ path: "/socket.io", transports: ["polling", "websocket"] });
       socket.on("self_improvement_progress", (data) => {
         setProgress(data);
         // When complete or error, refresh data after a short delay and clear progress

--- a/frontend/src/components/dashboard/GpuStatusCard.jsx
+++ b/frontend/src/components/dashboard/GpuStatusCard.jsx
@@ -76,7 +76,7 @@ const GpuStatusCard = React.forwardRef(
         const socket = io(SOCKET_URL, {
           reconnection: true,
           reconnectionAttempts: 3,
-          transports: ["websocket", "polling"],
+          transports: ["polling", "websocket"],
         });
         socketRef.current = socket;
 

--- a/frontend/src/components/filmcrew/ProductionList.jsx
+++ b/frontend/src/components/filmcrew/ProductionList.jsx
@@ -30,17 +30,18 @@ const ProductionList = ({ productions, selectedId, onSelect }) => {
               selected={selectedId === p.id}
               onClick={() => onSelect(p.id)}
             >
-              <ListItemText 
+              <ListItemText
                 primary={p.name}
+                secondaryTypographyProps={{ component: 'div' }}
                 secondary={
-                  <Box component="span" sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
-                    <Chip 
-                      label={p.current_stage?.replace('_', ' ') || p.status} 
-                      size="small" 
+                  <Box component="div" sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
+                    <Chip
+                      label={p.current_stage?.replace('_', ' ') || p.status}
+                      size="small"
                       color={getStatusColor(p.current_stage || p.status)}
                       sx={{ height: 20, fontSize: '0.65rem' }}
                     />
-                    <Typography variant="caption" sx={{ ml: 1 }}>
+                    <Typography component="span" variant="caption" sx={{ ml: 1 }}>
                       {new Date(p.created_at).toLocaleDateString()}
                     </Typography>
                   </Box>

--- a/frontend/src/components/settings/ScanProgressModal.jsx
+++ b/frontend/src/components/settings/ScanProgressModal.jsx
@@ -159,7 +159,7 @@ export default function ScanProgressModal({ open, onClose, onComplete }) {
     setDispatched(false);
 
     // Stand up the socket FIRST so we don't miss the earliest events.
-    const socket = io({ path: "/socket.io", transports: ["websocket", "polling"] });
+    const socket = io({ path: "/socket.io", transports: ["polling", "websocket"] });
     socketRef.current = socket;
     socket.on("connect", () => setSocketConnected(true));
     socket.on("disconnect", () => setSocketConnected(false));

--- a/frontend/src/contexts/UnifiedProgressContext.jsx
+++ b/frontend/src/contexts/UnifiedProgressContext.jsx
@@ -16,6 +16,7 @@ import { io } from "socket.io-client";
 
 import { useTheme } from "@mui/material/styles";
 import { BASE_URL as API_BASE, SOCKET_URL } from "../api/apiClient";
+import { debugLog } from "../utils/debugLog";
 
 const UnifiedProgressContext = createContext();
 
@@ -268,6 +269,8 @@ export const UnifiedProgressProvider = ({ children }) => {
     const initializeSocket = () => {
       try {
         const socket = io(SOCKET_URL, {
+          path: "/socket.io",
+          transports: ["websocket", "polling"],
           reconnection: true,
           reconnectionAttempts: Infinity,
           reconnectionDelay: 1000,
@@ -375,15 +378,17 @@ export const UnifiedProgressProvider = ({ children }) => {
         });
 
         socket.on("error", (error) => {
-          console.error("UnifiedProgressContext: SocketIO error:", error);
+          debugLog("UnifiedProgressContext: SocketIO error:", error);
           setConnectionState('error');
         });
 
         socket.on("connect_error", (error) => {
           const msg = error?.message || String(error);
           const transport = socket.io?.engine?.transport?.name;
-          console.warn("[SOCKET-CHAT] UnifiedProgressContext connect_error:", msg, transport ? `(transport: ${transport})` : "", " -- may delay chat:join delivery");
-          console.warn("UnifiedProgressContext: Socket connect_error:", msg, transport ? `(transport: ${transport})` : "");
+          // Only one visible warning; the raw transport failure is noisy during startup/reconnect
+          // (browser also emits "can't establish connection" for each WS attempt).
+          console.warn("[SOCKET-CHAT] UnifiedProgressContext connect_error:", msg, transport ? `(transport: ${transport})` : "", " -- may delay chat:join delivery (retrying)");
+          debugLog("UnifiedProgressContext: Socket connect_error (full):", msg, transport);
           // Keep trying (reconnection: true + Infinity attempts); surface as error for UI.
           // The caller (e.g. ChatPage in agent mode) will call forceReconnect() as needed.
           setConnectionState('error');

--- a/frontend/src/contexts/UnifiedProgressContext.jsx
+++ b/frontend/src/contexts/UnifiedProgressContext.jsx
@@ -270,7 +270,7 @@ export const UnifiedProgressProvider = ({ children }) => {
       try {
         const socket = io(SOCKET_URL, {
           path: "/socket.io",
-          transports: ["websocket", "polling"],
+          transports: ["polling", "websocket"],
           reconnection: true,
           reconnectionAttempts: Infinity,
           reconnectionDelay: 1000,

--- a/frontend/src/pages/BatchImageGeneratorPage.jsx
+++ b/frontend/src/pages/BatchImageGeneratorPage.jsx
@@ -99,6 +99,12 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
   const [success, setSuccess] = useState('');
   const [showPromptPreview, setShowPromptPreview] = useState(false);
 
+  // Director intelligence (new) — expand high-level concept via media_director (same as MV)
+  const [directorEnabled, setDirectorEnabled] = useState(false);
+  // eslint-disable-next-line no-unused-vars -- setter reserved for the guidance input (WIP)
+  const [directorGuidance, setDirectorGuidance] = useState("");
+  const [isExpanding, setIsExpanding] = useState(false);
+
   // New: Content presets and quality enhancement state
   const [contentPresets, setContentPresets] = useState({});
   const [selectedPreset, setSelectedPreset] = useState('auto'); // 'auto' = auto-detect
@@ -266,6 +272,45 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
     return () => clearTimeout(timeoutId);
   }, [batchItems, autoEnhance, analyzeCurrentPrompt]);
 
+  // NEW: Director expand (uses /batch-image/expand-concept; populates batchItems with plan shots for review/launch)
+  const handleDirectorExpand = async () => {
+    const idea = (batchItems || lookAndFeel || '').split('\n').find(l => l.trim()) || lookAndFeel;
+    if (!idea) {
+      setError('Enter a high-level concept or look & feel first');
+      return;
+    }
+    setIsExpanding(true);
+    setError('');
+    try {
+      const resp = await fetch(`${API_BASE}/batch-image/expand-concept`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          idea,
+          n: Math.max(1, Math.min(quantity || 4, 12)),
+          look_and_feel: lookAndFeel,
+          user_treatment: '',
+          director_guidance: directorGuidance || undefined,
+        })
+      });
+      if (!resp.ok) throw new Error('expand failed');
+      const j = await resp.json();
+      const plan = j?.data?.plan || j?.plan;
+      const shots = (plan && plan.shots) || [];
+      if (shots.length) {
+        const lines = shots.map(s => (s.prompt || '').trim()).filter(Boolean);
+        setBatchItems(lines.join('\n'));
+        setSuccess(`Director expanded to ${lines.length} coherent shots (review & launch)`);
+      } else {
+        setError('Director returned no shots');
+      }
+    } catch (e) {
+      setError('Director expand failed (ollama may be busy)');
+    } finally {
+      setIsExpanding(false);
+    }
+  };
+
   const checkServiceStatus = useCallback(async () => {
     try {
       const response = await fetch(`${API_BASE}/batch-image/status`);
@@ -390,7 +435,8 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                 imageFilename: getFilename(r.image_path),
                 thumbnailFilename: getFilename(r.thumbnail_path),
                 prompt: r.metadata?.original_prompt || '',
-                metadata: r.metadata
+                metadata: r.metadata,
+                batchId: batchStatus.batch_id, // embed for robust URL construction
               };
             });
           setGeneratedImages(images);
@@ -457,7 +503,8 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                   imageFilename: getFilename(r.image_path),
                   thumbnailFilename: getFilename(r.thumbnail_path),
                   prompt: r.metadata?.original_prompt || '',
-                  metadata: r.metadata
+                  metadata: r.metadata,
+                  batchId: batchStatus.batch_id, // embed for robust URL construction during live updates
                 };
               });
             setGeneratedImages(images);
@@ -504,6 +551,34 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
       // Cleanup function to prevent race conditions
       stopPolling();
     };
+  }, [activeBatch]);
+
+  // Keep generatedImages in sync with activeBatch.results (single source of truth for live batch).
+  // This prevents stale/mismatched state during rapid polling updates.
+  useEffect(() => {
+    if (activeBatch && activeBatch.results && activeBatch.results.length > 0) {
+      const getFilename = (path) => {
+        if (!path) return null;
+        const parts = path.replace(/\\/g, '/').split('/');
+        return parts[parts.length - 1];
+      };
+      const synced = activeBatch.results
+        .filter(r => r.success && r.image_path)
+        .map(r => ({
+          id: r.prompt_id,
+          path: r.image_path,
+          thumbnail: r.thumbnail_path,
+          imageFilename: getFilename(r.image_path),
+          thumbnailFilename: getFilename(r.thumbnail_path),
+          prompt: r.metadata?.original_prompt || '',
+          metadata: r.metadata,
+          batchId: activeBatch.batch_id,
+        }));
+      // Only update if the count changed (avoids unnecessary re-renders)
+      if (synced.length !== generatedImages.length) {
+        setGeneratedImages(synced);
+      }
+    }
   }, [activeBatch]);
 
   // Monitor progress system for batch updates
@@ -720,7 +795,10 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
             auto_enhance: autoEnhance,
             enhance_anatomy: enhanceAnatomy,
             enhance_faces: enhanceFaces,
-            enhance_hands: enhanceHands
+            enhance_hands: enhanceHands,
+            // Director (shared intelligent pipeline with MusicVideo / chat)
+            director_mode: !!directorEnabled,
+            director_guidance: directorGuidance || undefined
           })
         });
       }
@@ -1366,7 +1444,19 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                             value={quantity}
                             onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value) || 1))}
                             inputProps={{ min: 1, max: 100 }}
-                            helperText="Generates X versions for each prompt"
+                          />
+                          <Button
+                            variant="outlined"
+                            size="small"
+                            onClick={handleDirectorExpand}
+                            disabled={isExpanding || !(batchItems || lookAndFeel).trim()}
+                            title="Media Director (shared with MusicVideo): expand concept into N distinct coherent prompts"
+                          >
+                            {isExpanding ? '…' : 'Director expand'}
+                          </Button>
+                          <FormControlLabel
+                            control={<Switch size="small" checked={directorEnabled} onChange={(e) => setDirectorEnabled(e.target.checked)} />}
+                            label="use director"
                           />
                         </Grid>
 
@@ -1550,7 +1640,7 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
 
           {/* Generated Images Gallery */}
           {
-            generatedImages.length > 0 && (
+            (generatedImages.length > 0 || (activeBatch && activeBatch.results && activeBatch.results.some(r => r.success && r.image_path))) && (
               <Card sx={{
                 boxShadow: 2,
                 borderRadius: 2
@@ -1564,7 +1654,7 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                       color: 'text.primary'
                     }}
                   >
-                    Generated Images ({generatedImages.length})
+                    Generated Images ({generatedImages.length || (activeBatch?.results?.filter(r => r.success && r.image_path).length || 0)})
                   </Typography>
 
                   <ImageList
@@ -1578,12 +1668,20 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                     }}
                   >
                     {generatedImages.map((image) => {
-                      // Use thumbnail filename if available, otherwise fallback to image filename
-                      const thumbnailUrl = activeBatch && image.thumbnailFilename
-                        ? `${API_BASE}/batch-image/image/${activeBatch.batch_id}/${image.thumbnailFilename}?thumbnail=true`
-                        : activeBatch && image.imageFilename
-                          ? `${API_BASE}/batch-image/image/${activeBatch.batch_id}/${image.imageFilename}?thumbnail=true`
-                          : '';
+                      // Prefer embedded batchId (from the result that created this image) to avoid
+                      // race conditions between setActiveBatch and setGeneratedImages during live polling.
+                      // Falls back to activeBatch for older data.
+                      const batchIdForUrl = image.batchId || (activeBatch && activeBatch.batch_id);
+                      // Always try thumbnail first if we have a filename for it.
+                      // Otherwise use the main image name (serving logic will fallback if needed).
+                      let thumbnailUrl = '';
+                      if (batchIdForUrl) {
+                        if (image.thumbnailFilename) {
+                          thumbnailUrl = `${API_BASE}/batch-image/image/${batchIdForUrl}/${image.thumbnailFilename}?thumbnail=true`;
+                        } else if (image.imageFilename) {
+                          thumbnailUrl = `${API_BASE}/batch-image/image/${batchIdForUrl}/${image.imageFilename}?thumbnail=true`;
+                        }
+                      }
 
                       return (
                         <ImageListItem key={image.id}>
@@ -1595,12 +1693,16 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
                             onClick={() => openImageViewer(image)}
                             onError={(e) => {
                               console.error('Failed to load image thumbnail:', image.id, thumbnailUrl);
-                              // Fallback to full image if thumbnail fails
-                              if (image.imageFilename && !e.target.dataset.fallbackAttempted) {
-                                e.target.src = activeBatch ? `${API_BASE}/batch-image/image/${activeBatch.batch_id}/${image.imageFilename}` : '';
+                              const batchIdForUrl = image.batchId || (activeBatch && activeBatch.batch_id);
+                              // Robust fallback: always try the full original image (no ?thumbnail) before hiding.
+                              // This ensures we show *something* even if dedicated thumbnail is missing or 404s.
+                              if (image.imageFilename && batchIdForUrl && !e.target.dataset.fallbackAttempted) {
+                                e.target.src = `${API_BASE}/batch-image/image/${batchIdForUrl}/${image.imageFilename}`;
                                 e.target.dataset.fallbackAttempted = 'true';
-                              } else {
+                              } else if (!e.target.dataset.hidden) {
+                                // Only hide as last resort
                                 e.target.style.display = 'none';
+                                e.target.dataset.hidden = 'true';
                               }
                             }}
                             role="button"
@@ -1768,20 +1870,25 @@ const BatchImageGeneratorPage = ({ embedded = false }) => {
           {selectedImage && (
             <Box sx={{ textAlign: 'center' }}>
               <img
-                src={activeBatch && selectedImage.imageFilename
-                  ? `${API_BASE}/batch-image/image/${activeBatch.batch_id}/${selectedImage.imageFilename}`
-                  : ''}
+                src={(() => {
+                  const bId = selectedImage.batchId || (activeBatch && activeBatch.batch_id);
+                  return (bId && selectedImage.imageFilename)
+                    ? `${API_BASE}/batch-image/image/${bId}/${selectedImage.imageFilename}`
+                    : '';
+                })()}
                 alt={selectedImage.prompt}
                 style={{ maxWidth: '100%', height: 'auto' }}
                 onError={(e) => {
                   console.error('Failed to load full-size image:', selectedImage.id);
-                  // Fallback to thumbnail if full image fails
-                  if (selectedImage.thumbnailFilename && !e.target.dataset.fallbackAttempted) {
-                    e.target.src = activeBatch ? `${API_BASE}/batch-image/image/${activeBatch.batch_id}/${selectedImage.thumbnailFilename}?thumbnail=true` : '';
+                  const batchIdForUrl = selectedImage.batchId || (activeBatch && activeBatch.batch_id);
+                  // Try thumbnail as fallback, then give up (but don't hide immediately if we have a good full src)
+                  if (selectedImage.thumbnailFilename && batchIdForUrl && !e.target.dataset.fallbackAttempted) {
+                    e.target.src = `${API_BASE}/batch-image/image/${batchIdForUrl}/${selectedImage.thumbnailFilename}?thumbnail=true`;
                     e.target.dataset.fallbackAttempted = 'true';
-                  } else {
+                  } else if (!e.target.dataset.hidden) {
                     e.target.style.display = 'none';
                     setError('Failed to load image');
+                    e.target.dataset.hidden = 'true';
                   }
                 }}
               />

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -49,12 +49,7 @@ import extractSpeakableText from "../utils/extractSpeakableText";
 
 import OrchestratorPlanView from "../components/orchestrator/OrchestratorPlanView";
 import { createPlan } from "../api/orchestratorService";
-
-const debugLog = (...args) => {
-  if (import.meta.env.DEV) {
-    console.debug(...args);
-  }
-};
+import { debugLog } from "../utils/debugLog";
 
 const USE_AGENT_ROUTING = () => {
   try {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -685,10 +685,18 @@ const DashboardPage = () => {
   );
 
   // What RGL actually renders: the packed view when narrow, the raw layout otherwise.
-  const renderedLayout = useMemo(
-    () => (isNarrow ? repackLayout(layout) : layout),
-    [isNarrow, repackLayout, layout],
-  );
+  // Clamp minW/minH so they never exceed the item's w/h — the compact/layered/modex
+  // generators set minW=cardMinGridW (30) on bars/cards narrower than that, and RGL
+  // warns "minWidth larger than item width" whenever minW > w. This single chokepoint
+  // fixes every source (repackLayout already sets minW:1, so it's unaffected).
+  const renderedLayout = useMemo(() => {
+    const base = isNarrow ? repackLayout(layout) : layout;
+    return base.map((it) => ({
+      ...it,
+      minW: Math.min(it.minW ?? 1, it.w),
+      minH: Math.min(it.minH ?? 1, it.h),
+    }));
+  }, [isNarrow, repackLayout, layout]);
 
   const LayoutModeIcon = LAYOUT_MODE_ICONS[layoutMode];
 

--- a/frontend/src/pages/MusicVideoPage.jsx
+++ b/frontend/src/pages/MusicVideoPage.jsx
@@ -683,6 +683,24 @@ const MusicVideoPage = () => {
   const [keyframeModel, setKeyframeModel] = useState(DEFAULT_KEYFRAME_MODEL);
   const [i2vModel, setI2vModel] = useState("wan22-14b-i2v");
 
+  // Cast picker: trained character Subjects whose LoRA + bible lock identity per cut.
+  const [castSubjects, setCastSubjects] = useState([]);
+  const [selectedSubjectIds, setSelectedSubjectIds] = useState([]);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/cast-library")
+      .then((r) => (r.ok ? r.json() : { subjects: [] }))
+      .then((d) => {
+        if (!alive) return;
+        const trained = (d.subjects || []).filter(
+          (s) => s.kind === "character" && s.lora_path
+        );
+        setCastSubjects(trained);
+      })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+
   // I2V-capable models (subset from VideoGeneratorPage MODEL_OPTIONS for consistency)
   const I2V_MODEL_OPTIONS = {
     "wan22-14b-i2v": {
@@ -752,6 +770,9 @@ const MusicVideoPage = () => {
         keyframe_model: keyframeModel,
         i2v_model: i2vModel,
       };
+      if (useLoraConsistency && selectedSubjectIds.length > 0) {
+        settings.subject_ids = selectedSubjectIds;
+      }
       const stepsNum = Number(i2vSteps);
       if (i2vSteps !== "" && stepsNum > 0) settings.i2v_steps = stepsNum;
       const mv = await createMusicVideo({
@@ -768,6 +789,7 @@ const MusicVideoPage = () => {
       setDirectorEnabled(true);
       setPlanningMode("narrative");
       setUseLoraConsistency(false);
+      setSelectedSubjectIds([]);
       setKeyframeModel(DEFAULT_KEYFRAME_MODEL);
       setI2vModel("wan22-14b-i2v");
       // Reset any future advanced model params here too
@@ -996,8 +1018,10 @@ const MusicVideoPage = () => {
                         const checked = e.target.checked;
                         setUseLoraConsistency(checked);
                         if (checked) {
-                          setKeyframeModel("sdxl-lora");
-                        } else if (keyframeModel === "sdxl-lora") {
+                          // FLUX-dev + LoRA is the strongest identity lock (verified on
+                          // trained FLUX character LoRAs). SDXL+LoRA remains selectable.
+                          setKeyframeModel("flux-dev-lora");
+                        } else if (keyframeModel === "sdxl-lora" || keyframeModel === "flux-dev-lora") {
                           setKeyframeModel(DEFAULT_KEYFRAME_MODEL);
                         }
                       }}
@@ -1008,8 +1032,43 @@ const MusicVideoPage = () => {
                     </label>
                   </Stack>
                   <Typography variant="caption" color="text.secondary" sx={{ pl: 2.5, display: "block" }}>
-                    Checked = route through SDXL + LoRAs for the storyboard still (current identity path). Unchecked = more beautiful options (FLUX keyframes + best Wan2.2 I2V etc.).
+                    Checked = lock a trained character into every cut (LoRA + appearance bible). Pick the cast member(s) below. Unchecked = no identity lock, more beautiful free stills.
                   </Typography>
+
+                  {useLoraConsistency && (
+                    <TextField
+                      select
+                      size="small"
+                      fullWidth
+                      label="Cast (trained characters to lock)"
+                      value={selectedSubjectIds}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setSelectedSubjectIds(typeof v === "string" ? v.split(",").map(Number) : v);
+                      }}
+                      SelectProps={{
+                        multiple: true,
+                        renderValue: (sel) =>
+                          castSubjects
+                            .filter((s) => sel.includes(s.id))
+                            .map((s) => s.name)
+                            .join(", ") || "Select cast…",
+                      }}
+                      helperText={
+                        castSubjects.length === 0
+                          ? "No trained characters found. Train one in the Cast Library first."
+                          : "Their trigger word + appearance bible are injected into every keyframe."
+                      }
+                      sx={{ mt: 1 }}
+                    >
+                      {castSubjects.map((s) => (
+                        <MenuItem key={s.id} value={s.id}>
+                          {s.name}
+                          {s.trigger_word ? ` (${s.trigger_word})` : ""}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  )}
 
                   <TextField
                     select
@@ -1035,14 +1094,13 @@ const MusicVideoPage = () => {
                     label="Keyframe / Storyboard Image Model"
                     value={keyframeModel}
                     onChange={(e) => setKeyframeModel(e.target.value)}
-                    helperText="SDXL (with/without LoRA) for consistency; FLUX for higher aesthetic quality when LoRA not needed"
-                    disabled={useLoraConsistency}
+                    helperText="FLUX-dev + LoRA = strongest identity lock for trained characters; SDXL+LoRA is the legacy lock; FLUX-schnell for beautiful no-LoRA stills"
                     sx={{ mt: 1 }}
                   >
+                    <MenuItem value="flux-dev-lora">FLUX-dev + LoRA (best identity lock for trained characters)</MenuItem>
                     <MenuItem value="flux-schnell">FLUX.1-schnell (fast, beautiful stills) — default</MenuItem>
                     <MenuItem value="sdxl">SDXL (no LoRA)</MenuItem>
-                    <MenuItem value="sdxl-lora">SDXL + LoRAs (identity lock)</MenuItem>
-                    {/* Future: flux-dev, sdxl-turbo, etc. */}
+                    <MenuItem value="sdxl-lora">SDXL + LoRAs (legacy identity lock)</MenuItem>
                   </TextField>
                 </Stack>
               </Collapse>

--- a/frontend/src/pages/PluginsPage.jsx
+++ b/frontend/src/pages/PluginsPage.jsx
@@ -650,7 +650,7 @@ const PluginsPage = () => {
     const socket = io(SOCKET_URL, {
       reconnection: true,
       reconnectionAttempts: 5,
-      transports: ['websocket', 'polling'],
+      transports: ['polling', 'websocket'],
     });
     socketRef.current = socket;
 

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -669,7 +669,7 @@ const SettingsPage = () => {
   // Socket listener for async model switching events
   useEffect(() => {
     socketRef.current = io(SOCKET_URL, {
-      transports: ["websocket", "polling"],
+      transports: ["polling", "websocket"],
       reconnection: true,
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,

--- a/frontend/src/pages/SystemMapPage.jsx
+++ b/frontend/src/pages/SystemMapPage.jsx
@@ -283,7 +283,7 @@ export default function SystemMapPage() {
       reconnection: true,
       reconnectionAttempts: 5,
       reconnectionDelay: 1000,
-      transports: ["websocket", "polling"],
+      transports: ["polling", "websocket"],
     });
 
     function pushEvent(kind, data) {

--- a/frontend/src/utils/debugLog.js
+++ b/frontend/src/utils/debugLog.js
@@ -1,0 +1,16 @@
+/**
+ * Dev-only debug logger.
+ * Mirrors the inline pattern used across the frontend.
+ * Safe to import everywhere; no-ops in production builds.
+ *
+ * Usage:
+ *   import { debugLog } from '../utils/debugLog';
+ *   debugLog('[MyComponent]', 'state=', foo);
+ */
+export const debugLog = (...args) => {
+  if (import.meta.env.DEV) {
+    console.debug(...args);
+  }
+};
+
+export default debugLog;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,46 +1,92 @@
-import { defineConfig } from "vite";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger, defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { NodeGlobalsPolyfillPlugin } from "@esbuild-plugins/node-globals-polyfill";
 import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import rollupNodePolyFill from "rollup-plugin-polyfill-node";
 
-const FLASK_PORT = process.env.FLASK_PORT || process.env.FLASK_RUN_PORT || 5000;
-const VITE_PORT = process.env.VITE_PORT || 5173;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
 
-// Extra hostnames/IPs allowed to reach the dev server (comma-separated).
-// Set VITE_ALLOWED_HOSTS to your LAN IP (e.g. "192.168.1.108") to reach the UI
-// from another device, or "all" to skip the host check entirely (trusted nets only).
-const EXTRA_ALLOWED_HOSTS = (process.env.VITE_ALLOWED_HOSTS || "")
-  .split(",")
-  .map((h) => h.trim())
-  .filter(Boolean);
-const ALLOWED_HOSTS = EXTRA_ALLOWED_HOSTS.includes("all")
-  ? "all"
-  : ["localhost", "127.0.0.1", ".local", ...EXTRA_ALLOWED_HOSTS];
-
-// Shared by both the dev (`server`) and production-preview (`preview`) servers.
-// The frontend calls a relative "/api" and connects the socket to the page
-// origin, so whichever server serves the page must proxy these to Flask.
-// `xfwd: true` forwards the originating client IP as X-Forwarded-For — the backend
-// auth_guard relies on it to still recognize a LAN device (proxied via loopback)
-// as remote, so proxying the UI does not silently bypass the host check.
-const PROXY = {
-  "/api": {
-    target: `http://127.0.0.1:${FLASK_PORT}`,
-    changeOrigin: true,
-    secure: false,
-    xfwd: true,
-  },
-  "/socket.io": {
-    target: `http://127.0.0.1:${FLASK_PORT}`,
-    changeOrigin: true,
-    secure: false,
-    ws: true,
-    xfwd: true,
-  },
+// Socket.IO disconnects (page refresh, backend restart, transport retry) reset the
+// proxied TCP socket; Vite logs that as "ws proxy error: ECONNRESET" even though
+// the client reconnects fine via polling/websocket. Filter the benign noise only.
+const BENIGN_PROXY_RESET = /ECONN(RESET|ABORTED)|EPIPE|socket hang up/i;
+const viteLogger = createLogger();
+const logError = viteLogger.error.bind(viteLogger);
+viteLogger.error = (msg, options) => {
+  const text = typeof msg === "string" ? msg : String(msg);
+  if (text.includes("ws proxy") && BENIGN_PROXY_RESET.test(text)) return;
+  logError(msg, options);
 };
 
-export default defineConfig({
+function resolvePorts(mode) {
+  // Repo .env lives at LLAMAX8/.env (not frontend/.env). start.sh exports these,
+  // but `npm run dev` from frontend/ must still pick up FLASK_PORT=5002 / VITE_PORT=5175.
+  const rootEnv = loadEnv(mode, REPO_ROOT, "");
+  const flaskPort =
+    process.env.FLASK_PORT ||
+    process.env.FLASK_RUN_PORT ||
+    rootEnv.FLASK_PORT ||
+    "5000";
+  const vitePort = process.env.VITE_PORT || rootEnv.VITE_PORT || "5173";
+  return { flaskPort, vitePort };
+}
+
+function buildProxy(flaskPort) {
+  const target = `http://127.0.0.1:${flaskPort}`;
+  const shared = {
+    target,
+    changeOrigin: true,
+    secure: false,
+    xfwd: true,
+    configure: (proxy) => {
+      proxy.on("error", (err) => {
+        if (BENIGN_PROXY_RESET.test(err?.message || "")) return;
+        logError(`[vite] http proxy error: ${err?.message || err}`);
+      });
+      proxy.on("proxyReqWs", (_proxyReq, _req, socket) => {
+        socket.on("error", (err) => {
+          if (BENIGN_PROXY_RESET.test(err?.message || "")) return;
+          logError(`[vite] ws proxy socket error: ${err?.message || err}`);
+        });
+      });
+    },
+  };
+  return {
+    "/api": shared,
+    "/socket.io": { ...shared, ws: true },
+  };
+}
+
+function resolveAllowedHosts(rootEnv) {
+  // Extra hostnames/IPs allowed to reach the dev server (comma-separated).
+  // Set VITE_ALLOWED_HOSTS to your LAN IP (e.g. "192.168.1.108") to reach the UI
+  // from another device, or "all" to skip the host check entirely (trusted nets only).
+  const extraAllowedHosts = (process.env.VITE_ALLOWED_HOSTS || rootEnv.VITE_ALLOWED_HOSTS || "")
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+  return extraAllowedHosts.includes("all")
+    ? "all"
+    : ["localhost", "127.0.0.1", ".local", ...extraAllowedHosts];
+}
+
+export default defineConfig(({ mode }) => {
+  const rootEnv = loadEnv(mode, REPO_ROOT, "");
+  const { flaskPort, vitePort } = resolvePorts(mode);
+  const allowedHosts = resolveAllowedHosts(rootEnv);
+  // Shared by both the dev (`server`) and production-preview (`preview`) servers.
+  // The frontend calls a relative "/api" and connects the socket to the page
+  // origin, so whichever server serves the page must proxy these to Flask.
+  // `xfwd: true` forwards the originating client IP as X-Forwarded-For — the backend
+  // auth_guard relies on it to still recognize a LAN device (proxied via loopback)
+  // as remote, so proxying the UI does not silently bypass the host check.
+  const proxy = buildProxy(flaskPort);
+
+  return {
+  customLogger: viteLogger,
   plugins: [react()],
   test: {
     globals: true,
@@ -101,19 +147,20 @@ export default defineConfig({
   },
   server: {
     host: '0.0.0.0',
-    port: parseInt(VITE_PORT),
+    port: parseInt(vitePort, 10),
     strictPort: true,
-    allowedHosts: ALLOWED_HOSTS,
-    proxy: PROXY,
+    allowedHosts,
+    proxy,
   },
   // `start.sh` serves the production build via `vite preview`, which does NOT
   // share the `server:` block above — so host allowlist + API/WS proxy must be
   // repeated here, or LAN clients get "Blocked request" and /api + sockets 404.
   preview: {
     host: '0.0.0.0',
-    port: parseInt(VITE_PORT),
+    port: parseInt(vitePort, 10),
     strictPort: true,
-    allowedHosts: ALLOWED_HOSTS,
-    proxy: PROXY,
+    allowedHosts,
+    proxy,
   },
+};
 });

--- a/scripts/caption_dataset.py
+++ b/scripts/caption_dataset.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Auto-caption a character LoRA training dataset (offline VLM).
+
+Writes ``<stem>.txt`` sidecars next to each image, with the trigger word front-loaded and the
+fixed identity marks appended — so the LoRA binds freckles / eye color / marks to the token and
+learns varied framing. Reuses the offline Gemma-vision path (Ollama). NO training, NO GPU diffusion.
+
+Examples
+--------
+  # Caption the sage_harlow set, pulling identity marks from its profile, review first:
+  python scripts/caption_dataset.py training/sage_harlow/dataset \\
+      --trigger sage_harlow --profile training/sage_harlow/character_profile.md --dry-run
+
+  # Then actually write the sidecars (only the missing ones):
+  python scripts/caption_dataset.py training/sage_harlow/dataset \\
+      --trigger sage_harlow --profile training/sage_harlow/character_profile.md
+
+  # Explicit marks instead of a profile, overwriting existing captions:
+  python scripts/caption_dataset.py path/to/dataset --trigger my_char \\
+      --marks "pale freckled skin, hazel-green eyes, beauty mark on left cheek" --overwrite
+
+Requires Ollama running with a vision model (same one the app uses). If the VLM is unavailable,
+each caption degrades to "<trigger>, <marks>" so you still get a valid (if sparse) sidecar.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make the repo root importable when run directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Auto-caption a character LoRA dataset (offline VLM).")
+    ap.add_argument("dataset_dir", help="Directory of training images.")
+    ap.add_argument("--trigger", required=True, help="LoRA trigger word (e.g. sage_harlow).")
+    ap.add_argument("--marks", default="", help="Fixed identity marks to append to every caption.")
+    ap.add_argument("--profile", default="", help="character_profile.md to auto-extract marks from "
+                                                  "(used only if --marks not given).")
+    ap.add_argument("--overwrite", action="store_true", help="Re-caption images that already have a .txt.")
+    ap.add_argument("--dry-run", action="store_true", help="Caption + print but do not write sidecars.")
+    ap.add_argument("--json", action="store_true", help="Emit the full result summary as JSON.")
+    args = ap.parse_args()
+
+    from backend.services.character_captioner import caption_dataset, marks_from_profile, FULL_BODY_FRAMINGS
+
+    marks = args.marks.strip()
+    if not marks and args.profile:
+        marks = marks_from_profile(args.profile)
+        if marks:
+            print(f"[i] identity marks from profile: {marks}")
+
+    summary = caption_dataset(
+        args.dataset_dir,
+        trigger=args.trigger,
+        identity_marks=marks,
+        overwrite=args.overwrite,
+        dry_run=args.dry_run,
+    )
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    print(f"\nDataset: {summary['dir']}")
+    print(f"images={summary['images']}  written={summary['written']}  skipped={summary['skipped']}")
+    print(f"framing coverage: {summary['framing_tally']}  (full-body={summary['full_body_count']})")
+    for r in summary["results"]:
+        print(f"  [{r['action']:7}] {r['image']:16} ({r['framing'] or '?'}): {r['caption']}")
+    if summary["full_body_count"] == 0:
+        print("\n[!] WARNING: zero full-body / three-quarter / wide shots detected. The LoRA will "
+              "have no learned body — add full-body images (this is the horse-head root cause).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -122,10 +122,10 @@ BACKEND_COLOR="${GREEN}"
 [ "$BACKEND_UP" = "OFFLINE" ] && BACKEND_COLOR="${RED}"
 echo -e "  ${WHITE}Backend:${NC} ${BACKEND_COLOR}${BACKEND_UP}${NC} (port ${FLASK_PORT:-5002})"
 
-FRONTEND_UP=$(curl -sf http://localhost:${VITE_PORT:-5175} >/dev/null 2>&1 && echo "ONLINE" || echo "OFFLINE")
+FRONTEND_UP=$(curl -sf http://localhost:${VITE_PORT:-5173} >/dev/null 2>&1 && echo "ONLINE" || echo "OFFLINE")
 FRONTEND_COLOR="${GREEN}"
 [ "$FRONTEND_UP" = "OFFLINE" ] && FRONTEND_COLOR="${RED}"
-echo -e "  ${WHITE}Frontend:${NC} ${FRONTEND_COLOR}${FRONTEND_UP}${NC} (port ${VITE_PORT:-5175})"
+echo -e "  ${WHITE}Frontend:${NC} ${FRONTEND_COLOR}${FRONTEND_UP}${NC} (port ${VITE_PORT:-5173})"
 
 OLLAMA_UP=$(curl -sf http://localhost:11434/api/tags >/dev/null 2>&1 && echo "ONLINE" || echo "OFFLINE")
 OLLAMA_COLOR="${GREEN}"

--- a/scripts/pretrain_gate.py
+++ b/scripts/pretrain_gate.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Pre-train quality gate for character LoRA datasets — refuse to launch on bad data.
+
+WHY (2026-06-23): the first sage_harlow LoRA trained on a dataset that, in hindsight, was
+guaranteed to produce the "horse-head" failures: captions were ignored (caption_strategy was
+"filename", not "textfile"), there were ZERO full-body images (so no learned body), and 5/8
+captions were near-identical (no caption→concept signal). NONE of that was caught before a
+3–4 hour GPU run. This gate is the catch. It asserts, BEFORE training launches:
+
+  1. the dataset has images, and EVERY image has a non-empty .txt caption sidecar;
+  2. (if a SimpleTuner multidatabackend.json is given) caption_strategy == "textfile";
+  3. the trigger word appears in EVERY caption (so identity actually binds to the token);
+  4. pose coverage: at least N full-body / three-quarter / wide shots (a learned body);
+  5. caption diversity: not a pile of near-duplicate captions.
+
+Exit 0 = pass (safe to train), exit 1 = fail (do NOT train). Filesystem-only: no DB, no GPU,
+no torch — cheap to run as the first step of training. Designed to be called by
+``training/retrain_character.sh`` and by hand.
+
+Usage
+-----
+  python scripts/pretrain_gate.py training/sage_harlow/dataset --trigger sage_harlow \\
+      --config plugins/lora_trainer/SimpleTuner/config/multidatabackend.json
+  python scripts/pretrain_gate.py <dir> --trigger <word> --min-full-body 4 --json
+"""
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".webp", ".bmp")
+
+
+def _framing_helpers():
+    """Reuse the captioner's canonical framing vocab + detector (single source of truth)."""
+    try:
+        from backend.services.character_captioner import detect_framing, FULL_BODY_FRAMINGS
+        return detect_framing, FULL_BODY_FRAMINGS
+    except Exception:  # pragma: no cover — keep the gate runnable even if the import path breaks
+        FULL = {"three-quarter view", "full body", "wide shot"}
+        def detect_framing(c: str):
+            c = (c or "").lower()
+            for tag in ("wide shot", "full body", "three-quarter view", "upper body",
+                        "head and shoulders", "close-up"):
+                if tag in c:
+                    return tag
+            if re.search(r"\bfull[- ]length\b", c):
+                return "full body"
+            if re.search(r"\b3/4\b|\bthree quarter\b", c):
+                return "three-quarter view"
+            return None
+        return detect_framing, FULL
+
+
+def _tokens(caption: str) -> set:
+    return {t.strip().lower() for t in caption.split(",") if t.strip()}
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def run_gate(dataset_dir: str, trigger: str, *, config: str = "",
+             min_full_body: int | None = None, dup_threshold: float = 0.9) -> dict:
+    detect_framing, FULL_BODY_FRAMINGS = _framing_helpers()
+    d = Path(dataset_dir)
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    images = sorted(p for p in d.iterdir() if p.suffix.lower() in IMAGE_EXTS) if d.is_dir() else []
+    n = len(images)
+    if n == 0:
+        return {"pass": False, "dir": str(d), "images": 0,
+                "failures": [f"no images found in {d}"], "warnings": [], "framing": {}}
+
+    # 1 + 3: sidecars present & non-empty; trigger in every caption.
+    captions: dict[str, str] = {}
+    trig = (trigger or "").strip().lower()
+    for img in images:
+        sc = img.with_suffix(".txt")
+        if not sc.exists():
+            failures.append(f"{img.name}: missing caption sidecar ({sc.name})")
+            continue
+        text = sc.read_text(encoding="utf-8").strip()
+        if not text:
+            failures.append(f"{img.name}: empty caption sidecar")
+            continue
+        captions[img.name] = text
+        if trig and trig not in text.lower():
+            failures.append(f"{img.name}: trigger word '{trigger}' not in caption")
+
+    # 2: caption_strategy must be textfile (the bug that silently ignored captions last time).
+    strategy = None
+    if config:
+        try:
+            cfg = json.loads(Path(config).read_text(encoding="utf-8"))
+            # multidatabackend.json is a list of backends or a single dict.
+            backends = cfg if isinstance(cfg, list) else [cfg]
+            for b in backends:
+                if isinstance(b, dict) and "caption_strategy" in b:
+                    strategy = b.get("caption_strategy")
+                    if strategy != "textfile":
+                        failures.append(
+                            f"caption_strategy is '{strategy}' (must be 'textfile' — 'filename' "
+                            f"silently ignores your .txt captions, the original horse-head bug)")
+        except Exception as e:  # noqa: BLE001
+            warnings.append(f"could not read caption_strategy from {config}: {e}")
+
+    # 4: pose coverage — need a learned body.
+    framing_tally: dict[str, int] = {}
+    for cap in captions.values():
+        fr = detect_framing(cap) or "unknown"
+        framing_tally[fr] = framing_tally.get(fr, 0) + 1
+    full_body = sum(framing_tally.get(f, 0) for f in FULL_BODY_FRAMINGS)
+    need_full = min_full_body if min_full_body is not None else max(3, math.ceil(0.20 * n))
+    if full_body < need_full:
+        failures.append(
+            f"only {full_body} full-body/three-quarter/wide shot(s); need >= {need_full}. "
+            f"Without below-the-shoulders supervision the LoRA has no body and improvises one "
+            f"under motion (the horse-head failure). framing={framing_tally}")
+
+    # 5: caption diversity — guard against the "5/8 identical captions" overfit.
+    cap_list = list(captions.values())
+    tok = [_tokens(c) for c in cap_list]
+    dup = 0
+    for i in range(len(cap_list)):
+        if any(_jaccard(tok[i], tok[j]) >= dup_threshold for j in range(i)):
+            dup += 1
+    unique = len(cap_list) - dup
+    need_unique = max(1, math.ceil(0.60 * len(cap_list))) if cap_list else 0
+    if cap_list and unique < need_unique:
+        failures.append(
+            f"caption diversity too low: only {unique}/{len(cap_list)} effectively-unique captions "
+            f"(>= {dup_threshold} token overlap counts as duplicate); need >= {need_unique}. "
+            f"Near-identical captions over-anchor the LoRA to one pose/outfit.")
+
+    if n < 12:
+        warnings.append(f"only {n} images — fine for a quick character LoRA, but more (20-30 with "
+                        f"varied framing/outfits) materially improves robustness.")
+
+    return {
+        "pass": not failures,
+        "dir": str(d),
+        "images": n,
+        "captioned": len(captions),
+        "caption_strategy": strategy,
+        "framing": framing_tally,
+        "full_body_count": full_body,
+        "full_body_required": need_full,
+        "unique_captions": unique if cap_list else 0,
+        "failures": failures,
+        "warnings": warnings,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Pre-train quality gate for a character LoRA dataset.")
+    ap.add_argument("dataset_dir")
+    ap.add_argument("--trigger", required=True)
+    ap.add_argument("--config", default="", help="SimpleTuner multidatabackend.json (checks caption_strategy).")
+    ap.add_argument("--min-full-body", type=int, default=None, help="Override required full-body count.")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    r = run_gate(args.dataset_dir, args.trigger, config=args.config, min_full_body=args.min_full_body)
+
+    if args.json:
+        print(json.dumps(r, indent=2))
+    else:
+        print(f"\nPre-train gate: {r['dir']}")
+        print(f"images={r['images']} captioned={r.get('captioned', 0)} "
+              f"caption_strategy={r.get('caption_strategy')} full_body={r.get('full_body_count')}"
+              f"/{r.get('full_body_required')}")
+        print(f"framing={r.get('framing')}")
+        for w in r["warnings"]:
+            print(f"  [warn] {w}")
+        for f in r["failures"]:
+            print(f"  [FAIL] {f}")
+        print("\nRESULT:", "PASS — safe to train." if r["pass"]
+              else "FAIL — do NOT train; fix the dataset above.")
+    return 0 if r["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start_agent_display.sh
+++ b/scripts/start_agent_display.sh
@@ -937,6 +937,19 @@ sync_only() {
     init_browser_profile "$BROWSER" "$PROFILE_DIR"
 }
 
+# Hard guard: this whole subsystem is X11 (Xvfb + x11vnc + XFCE) and cannot run
+# on macOS without XQuartz. Bail before start/restart/sync so we don't emit
+# BSD-sed errors or half-start a broken display. start.sh already skips us on
+# macOS; this protects direct/plugin invocation too (#41). stop/status stay safe.
+if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
+    case "${1:-start}" in
+        start|restart|sync)
+            echo "Agent virtual display is Linux/X11-only — skipped on macOS (no Xvfb/X11)."
+            exit 0
+            ;;
+    esac
+fi
+
 case "${1:-start}" in
     start)  start ;;
     stop)   stop ;;

--- a/scripts/verify_gpu_stack.sh
+++ b/scripts/verify_gpu_stack.sh
@@ -23,6 +23,17 @@ try:
     import torch
 except Exception as e:
     print(f"IMPORT_FAIL: {type(e).__name__}: {e}"); sys.exit(3)
+# Apple Silicon has no CUDA — the correct accelerator is Metal/MPS. Testing
+# .cuda() there always raises "Torch not compiled with CUDA enabled", which is
+# expected, NOT degraded. Probe MPS instead so a healthy Mac reads as healthy.
+if sys.platform == "darwin":
+    try:
+        if not torch.backends.mps.is_available():
+            print("MPS_UNAVAIL: torch.backends.mps.is_available() is False"); sys.exit(5)
+        torch.zeros(1).to("mps")
+    except Exception as e:
+        print(f"KERNEL_FAIL: {type(e).__name__}: {e}"); sys.exit(4)
+    print("OK_MPS"); sys.exit(0)
 try:
     torch.zeros(1).cuda()
 except Exception as e:
@@ -30,11 +41,15 @@ except Exception as e:
 print("OK")
 PY
 )"; then
-        echo "  ✔ $label: GPU kernel OK"
+        case "$err" in
+            OK_MPS*) echo "  ✔ $label: Metal/MPS active" ;;
+            *)       echo "  ✔ $label: GPU kernel OK" ;;
+        esac
     else
         local short="${err:0:140}"
         case "$err" in
             IMPORT_FAIL:*) echo "  ⚠ $label: torch failed to IMPORT — ${short#IMPORT_FAIL: }" ;;
+            MPS_UNAVAIL:*) echo "  ⚠ $label: Metal/MPS unavailable — ${short#MPS_UNAVAIL: }" ;;
             KERNEL_FAIL:*) echo "  ⚠ $label: torch imports but GPU kernel failed — ${short#KERNEL_FAIL: }" ;;
             *)             echo "  ⚠ $label: torch GPU check failed — ${short}" ;;
         esac

--- a/start.sh
+++ b/start.sh
@@ -98,6 +98,16 @@ if [ -f "$SCRIPT_DIR/scripts/platform/detect.sh" ]; then
     [ -f "$GUAARDVARK_PLATFORM_BACKEND" ] && source "$GUAARDVARK_PLATFORM_BACKEND"
 fi
 
+# is_macos - single source of truth for "are we on Darwin?". Prefers the
+# detect.sh flag, falls back to `uname` so it still works on older checkouts
+# that predate scripts/platform/. Used to gate Linux-only steps (inotify/sysctl,
+# apt advice, Xvfb/X11 agent display) so they no-op cleanly on macOS (#41).
+is_macos() {
+    [ "${GUAARDVARK_OS:-}" = macos ] && return 0
+    [ "$(uname -s 2>/dev/null)" = Darwin ] && return 0
+    return 1
+}
+
 MANAGER_SCRIPT="$SCRIPT_DIR/scripts/system-manager/system-manager"
 if [ -f "$MANAGER_SCRIPT" ]; then
     # Ensure ./manager symlink exists (may be missing after Code Release restore)
@@ -335,6 +345,21 @@ check_npm() {
 }
 
 detect_browser() {
+    # macOS: browsers are .app bundles launched via `open -a`, rarely on PATH.
+    # Probe the standard install locations; report the bundle name (#41 — the
+    # PATH-only check falsely claimed "no browser" on a Mac with Chrome/Safari).
+    if is_macos; then
+        local app
+        for app in "Firefox" "Google Chrome" "Brave Browser" "Microsoft Edge" "Safari"; do
+            if [ -d "/Applications/$app.app" ] || [ -d "$HOME/Applications/$app.app" ]; then
+                echo "$app"
+                return 0
+            fi
+        done
+        # Safari ships with macOS — guaranteed fallback.
+        echo "Safari"
+        return 0
+    fi
     if command_exists firefox; then
         echo "firefox"
         return 0
@@ -385,16 +410,28 @@ check_gpu_optimizations() {
 launch_browser_app() {
     local url="$1"
     local browser_cmd
-    
+
     browser_cmd=$(detect_browser)
     if [ $? -ne 0 ]; then
-        vader_warn "Firefox not found. Cannot launch in app mode."
-        vader_info "Install Firefox: sudo apt-get install -y firefox"
+        if is_macos; then
+            vader_warn "No browser found. Open manually: $url"
+        else
+            vader_warn "Firefox not found. Cannot launch in app mode."
+            vader_info "Install Firefox: sudo apt-get install -y firefox"
+        fi
         return 1
     fi
-    
+
+    # macOS: hand the URL to the detected .app via `open -a` (no systemd/setsid).
+    if is_macos; then
+        vader_info "Launching $browser_cmd: $url"
+        open -a "$browser_cmd" "$url" >/dev/null 2>&1 \
+            && { vader_success "$browser_cmd launched"; return 0; } \
+            || { vader_warn "Could not launch $browser_cmd. Open manually: $url"; return 1; }
+    fi
+
     vader_info "Launching Firefox in new window: $browser_cmd"
-    
+
     if [[ "$browser_cmd" == "firefox" ]]; then
         # Use systemd-run to isolate browser in its own cgroup.
         # Without this, Firefox inherits the terminal's cgroup, and if the
@@ -582,12 +619,30 @@ check_frontend_build() {
 # (which carries its own proxy + host allowlist) will serve the page over the LAN.
 get_lan_ips() {
     local ips
+    local private_re='^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)'
+    # macOS: no `hostname -I`, no `ip`/`ss`. Walk interfaces with ipconfig +
+    # ifconfig (both BSD-native) so Wi-Fi/Ethernet LAN IPs are found (#41 —
+    # "No private LAN IP detected" was a false negative on Mac).
+    if is_macos; then
+        if command -v ipconfig >/dev/null 2>&1; then
+            ips=$(
+                for iface in $(ifconfig -lu 2>/dev/null); do
+                    ipconfig getifaddr "$iface" 2>/dev/null
+                done | grep -E "$private_re" | tr '\n' ' ' | sed 's/ $//'
+            )
+        fi
+        if [ -z "$ips" ] && command -v ifconfig >/dev/null 2>&1; then
+            ips=$(ifconfig 2>/dev/null | awk '/inet /{print $2}' | grep -E "$private_re" | tr '\n' ' ' | sed 's/ $//')
+        fi
+        echo "$ips"
+        return 0
+    fi
     # Prefer hostname -I (common on Debian/Ubuntu etc.); fall back to ip tool.
     if command -v hostname >/dev/null 2>&1; then
-        ips=$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)' | tr '\n' ' ' | sed 's/ $//')
+        ips=$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E "$private_re" | tr '\n' ' ' | sed 's/ $//')
     fi
     if [ -z "$ips" ] && command -v ip >/dev/null 2>&1; then
-        ips=$(ip -o -4 addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | grep -E '^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)' | tr '\n' ' ' | sed 's/ $//')
+        ips=$(ip -o -4 addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | grep -E "$private_re" | tr '\n' ' ' | sed 's/ $//')
     fi
     echo "$ips"
 }
@@ -1863,8 +1918,12 @@ vader_step 11 "Launching Frontend..."
 cd "$FRONTEND_DIR" || { vader_error "Failed to cd to $FRONTEND_DIR"; exit 1; }
 
 INOTIFY_MIN=524288
+# macOS watches files via FSEvents, not inotify — there is no
+# /proc/sys/fs/inotify and no fs.inotify sysctl. Skip the whole tune (#41).
 INOTIFY_CURRENT=$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null || echo 0)
-if [ "$INOTIFY_CURRENT" -lt "$INOTIFY_MIN" ]; then
+if is_macos; then
+    : # no-op on macOS; Vite uses FSEvents
+elif [ "$INOTIFY_CURRENT" -lt "$INOTIFY_MIN" ]; then
     vader_info "inotify watchers too low ($INOTIFY_CURRENT). Raising to $INOTIFY_MIN..."
     if sudo -n sysctl -q fs.inotify.max_user_watches=$INOTIFY_MIN 2>/dev/null; then
         vader_success "inotify watchers raised to $INOTIFY_MIN"
@@ -2000,6 +2059,14 @@ AGENT_DISPLAY_STARTED=0
 ensure_agent_display() {
     # Start the agent virtual display if not already running
     if [ "$AGENT_DISPLAY_STARTED" -eq 1 ]; then return 0; fi
+    # The agent desktop is Xvfb + x11vnc + XFCE — X11-only. macOS has no X11
+    # without XQuartz, so the attempt only emits BSD-sed errors and a bogus
+    # "failed to start". Skip cleanly; everything else (chat/voice/API) works (#41).
+    if is_macos; then
+        vader_info "Agent virtual display (Xvfb/X11) is Linux-only — skipped on macOS. Chat, voice, and the API are unaffected."
+        AGENT_DISPLAY_STARTED=1
+        return 0
+    fi
     AGENT_DISPLAY_SCRIPT="$SCRIPT_DIR/scripts/start_agent_display.sh"
     if [ -x "$AGENT_DISPLAY_SCRIPT" ]; then
         if pgrep -f "Xvfb :${GUAARDVARK_AGENT_DISPLAY:-99}" > /dev/null 2>&1; then

--- a/training/retrain_character.sh
+++ b/training/retrain_character.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# One-command character-LoRA retrain launcher (FLUX-dev / SimpleTuner, 16 GB).
+#
+# Orchestrates the proven pieces into a single gated pipeline:
+#   pretrain_gate  ->  [auto-caption]  ->  SimpleTuner train  ->  watchdog
+#                  ->  verify_training_outputs  ->  copy best checkpoint  ->  register Subject
+#
+# The gate runs FIRST and aborts before any GPU work if the dataset is bad (the horse-head
+# guard). Designed for an overnight run. NOTHING here trains until the gate passes.
+#
+# Usage:
+#   bash training/retrain_character.sh                 # full run (GPU, ~3-4h)
+#   bash training/retrain_character.sh --check         # gate (+caption) only, NO GPU/training
+#   bash training/retrain_character.sh --caption       # (re)caption before gating, then train
+#   bash training/retrain_character.sh --force         # train even if the gate FAILS (not advised)
+#   bash training/retrain_character.sh --no-register   # skip the DB Subject registration step
+#   bash training/retrain_character.sh --checkpoint N  # deploy checkpoint-N (default: highest)
+#
+# Env/flags (defaults target sage_harlow):
+#   --trigger WORD   --dataset DIR   --name NAME(output subdir)
+set -uo pipefail
+
+REPO=/home/llamax1/LLAMAX8
+TRIGGER=sage_harlow
+NAME=sage_harlow
+DATASET="$REPO/training/sage_harlow/dataset"
+PROFILE="$REPO/training/sage_harlow/character_profile.md"
+ST="$REPO/plugins/lora_trainer/SimpleTuner"
+MDB="$ST/config/multidatabackend.json"
+DEPLOY="$REPO/data/training/loras/${NAME}.safetensors"
+PY="$REPO/backend/venv/bin/python"
+
+DO_CHECK=0; DO_CAPTION=0; FORCE=0; DO_REGISTER=1; CHECKPOINT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) DO_CHECK=1 ;;
+    --caption) DO_CAPTION=1 ;;
+    --force) FORCE=1 ;;
+    --no-register) DO_REGISTER=0 ;;
+    --checkpoint) CHECKPOINT="${2:-}"; shift ;;
+    --trigger) TRIGGER="${2:-}"; shift ;;
+    --dataset) DATASET="${2:-}"; shift ;;
+    --name) NAME="${2:-}"; DEPLOY="$REPO/data/training/loras/${NAME}.safetensors"; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+say() { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+die() { printf '\n\033[1;31mABORT: %s\033[0m\n' "$*"; exit 1; }
+[ -x "$PY" ] || PY=python3
+
+# 1) optional (re)caption -----------------------------------------------------
+if [ "$DO_CAPTION" = 1 ]; then
+  say "Auto-captioning $DATASET (trigger=$TRIGGER)"
+  "$PY" "$REPO/scripts/caption_dataset.py" "$DATASET" --trigger "$TRIGGER" \
+      ${PROFILE:+--profile "$PROFILE"} || die "captioning failed"
+fi
+
+# 2) pre-train gate (the horse-head guard) -----------------------------------
+say "Pre-train quality gate"
+"$PY" "$REPO/scripts/pretrain_gate.py" "$DATASET" --trigger "$TRIGGER" --config "$MDB"
+GATE=$?
+if [ "$GATE" -ne 0 ]; then
+  if [ "$FORCE" = 1 ]; then
+    echo "Gate FAILED but --force given; continuing against advice."
+  else
+    die "dataset gate failed — fix the dataset (see DATASET_SPEC.md) or pass --force."
+  fi
+fi
+
+if [ "$DO_CHECK" = 1 ]; then
+  say "--check: gate complete, stopping before any GPU/training."
+  exit $GATE
+fi
+
+# 3) train (GPU, heavy) -------------------------------------------------------
+say "Launching SimpleTuner (GPU ~3-4h). Desktop should be stopped: sudo systemctl stop gdm"
+RUN="$REPO/training/sage_harlow/run_st.sh"
+[ -f "$RUN" ] || die "run_st.sh not found at $RUN"
+bash "$RUN" 2>&1 | tee "$REPO/training/sage_harlow/st_live.log"
+grep -aq "ST_RUN_DONE" "$REPO/training/sage_harlow/st_live.log" || die "training did not finish cleanly"
+
+# 4) pick + deploy checkpoint -------------------------------------------------
+OUT="$REPO/training/sage_harlow/output/${NAME}_flux_v1"
+[ -d "$OUT" ] || OUT="$REPO/training/sage_harlow/output"
+if [ -z "$CHECKPOINT" ]; then
+  CKPT_DIR=$(ls -d "$OUT"/checkpoint-* 2>/dev/null | sort -t- -k2 -n | tail -1)
+else
+  CKPT_DIR="$OUT/checkpoint-$CHECKPOINT"
+fi
+[ -n "$CKPT_DIR" ] && [ -d "$CKPT_DIR" ] || die "no checkpoint found under $OUT"
+SRC="$CKPT_DIR/pytorch_lora_weights.safetensors"
+[ -f "$SRC" ] || die "checkpoint weights missing: $SRC"
+say "Deploying $(basename "$CKPT_DIR") -> $DEPLOY"
+# Keep the old LoRA for A/B before overwriting.
+[ -f "$DEPLOY" ] && cp -f "$DEPLOY" "${DEPLOY%.safetensors}.prev.safetensors" && \
+  echo "previous LoRA backed up to ${DEPLOY%.safetensors}.prev.safetensors (for A/B)"
+mkdir -p "$(dirname "$DEPLOY")"
+cp -f "$SRC" "$DEPLOY"
+
+# 5) post-train verify --------------------------------------------------------
+say "Post-train verification"
+"$PY" "$REPO/scripts/verify_training_outputs.py" || echo "[warn] verify reported issues — review above"
+
+# 6) register Subject (DB) ----------------------------------------------------
+if [ "$DO_REGISTER" = 1 ]; then
+  say "Registering Subject (trigger + lora_path + bible)"
+  REG="$REPO/training/sage_harlow/clip_steampunk/register_subject.py"
+  if [ -f "$REG" ]; then
+    "$PY" "$REG" || echo "[warn] Subject registration failed — run it manually"
+  else
+    echo "[warn] register_subject.py not found; register the LoRA in the Cast Library manually."
+  fi
+fi
+
+cat <<EOF
+
+== DONE ==
+Deployed LoRA : $DEPLOY
+Previous (A/B): ${DEPLOY%.safetensors}.prev.safetensors
+Validation    : training/sage_harlow/output/validation_images/  (eyeball best checkpoint)
+
+NEXT: render a 20-clip A/B sample (old .prev vs new) and confirm full-body + horse-riding shots
+keep the face and freckles. Target: <2% ridiculous (was ~8%). Restore desktop: sudo systemctl start gdm
+EOF

--- a/training/sage_harlow/DATASET_SPEC.md
+++ b/training/sage_harlow/DATASET_SPEC.md
@@ -1,0 +1,68 @@
+# Character LoRA Dataset Spec (FLUX-dev / SimpleTuner, 16 GB)
+
+> The recipe for a training set that does NOT produce horse-heads. Written 2026-06-23 after the
+> first `sage_harlow` run: 8 head-only images, captions ignored (`caption_strategy: "filename"`),
+> 5/8 near-identical captions → overfit face, no learned body → ~8% "head-on-a-horse" clips.
+
+## The three rules the first run broke
+
+1. **Caption the body, or the model never learns one.** A LoRA can only render full-body /
+   horse-riding / tattoos-on-arms shots if it *saw* bodies in training. Head-only data → the base
+   model improvises a body under motion → animal-hybrid failures.
+2. **Captions must actually be read.** `caption_strategy` MUST be `textfile` (reads the `.txt`
+   sidecars), never `filename` (trains on `img_00`…). This is enforced by `scripts/pretrain_gate.py`.
+3. **Vary the captions.** Near-identical captions over-anchor the LoRA to one pose/outfit/background.
+
+## Framing mix (target ~20–30 images)
+
+| Framing                | Share  | Why |
+|------------------------|--------|-----|
+| close-up               | ~20%   | face/identity fidelity (freckles, eyes, beauty mark) |
+| head and shoulders     | ~15%   | portrait range |
+| upper body             | ~15%   | wardrobe top half |
+| three-quarter view     | ~20%   | **body** — pose, proportion |
+| full body              | ~25%   | **body** — full proportion, legs, footwear; needed for tattoos/jewelry/outfits later |
+| wide shot              | ~5%    | body-in-environment |
+
+**Hard floor (gate-enforced):** at least `max(3, ceil(0.20 × N))` images must be
+three-quarter / full body / wide. The first run had **zero** — that was the bug.
+
+Also vary, across the set: gaze direction (head-on, 3/4 L/R, profile), expression (neutral,
+smirk, scowl), outfit (within the black/white palette — dress, hoodie+cargo, sports-bra+shorts
+for body shape, streetwear, boots visible), background, and lighting (daylight, golden hour,
+indoor window, dramatic side).
+
+## Captions
+
+- One `.txt` per image, same stem (`img_07.jpg` → `img_07.txt`).
+- Layout: `sage_harlow, <framing>, <pose/gaze>, <expression>, <outfit+colors>, <setting>,
+  <lighting>, <fixed identity marks>`.
+- **Trigger first**, in every caption. **Fixed identity marks last**, in every caption, so they
+  bind to the token: `pale freckled skin, hazel-green eyes, small beauty mark on left cheek,
+  black wavy hair with emerald-green highlights` (+ `delicate rose+barbwire tattoo on right wrist`
+  on shots where the wrist is visible).
+- Generate them with the auto-captioner (describes the *variable* attributes, injects trigger +
+  marks): `python scripts/caption_dataset.py training/sage_harlow/dataset --trigger sage_harlow
+  --profile training/sage_harlow/character_profile.md` (add `--dry-run` to review first).
+
+## `repeats` (multidatabackend.json)
+
+With only 8 images the first run used `repeats: 100` (heavy memorization). As the set grows, drop
+it so total exposure stays ~constant: **`repeats ≈ round(800 / N)`** (N = image count). E.g. N=24 →
+`repeats ≈ 33`. Keep resolution **512** on 16 GB (1024 thrashes near the VRAM ceiling).
+
+## Before you launch
+
+```bash
+# 1) caption any new images (writes .txt sidecars)
+python scripts/caption_dataset.py training/sage_harlow/dataset --trigger sage_harlow \
+    --profile training/sage_harlow/character_profile.md
+
+# 2) gate the dataset — refuses to train on bad data (must PASS)
+python scripts/pretrain_gate.py training/sage_harlow/dataset --trigger sage_harlow \
+    --config plugins/lora_trainer/SimpleTuner/config/multidatabackend.json
+
+# 3) one-command retrain (gate -> [caption] -> train -> verify -> register -> A/B)
+bash training/retrain_character.sh            # full run (GPU, ~3-4h)
+bash training/retrain_character.sh --check    # gate + caption only, no GPU
+```


### PR DESCRIPTION
## What & why

Follow-up to #41. After `12dcaa5` the reporter (M2 Ultra, macOS Tahoe) got through install steps 1–10 cleanly, but step 11 + post-boot surfaced a second cluster of **Linux-only assumptions leaking onto macOS** once the script was past the install gate.

All changes are gated behind a new `is_macos()` helper (prefers `GUAARDVARK_OS=macos` from `scripts/platform/detect.sh`, falls back to `uname -s = Darwin`). **Linux / Pi / WSL behavior is byte-identical.**

## Fixes

**`start.sh`**
- `get_lan_ips()` — macOS branch via `ipconfig getifaddr` + `ifconfig`. Fixes the false **"No private LAN IP detected"** (`hostname -I` / `ip` / `ss` don't exist on BSD).
- `detect_browser()` — probes `/Applications/*.app` (Firefox/Chrome/Brave/Edge/Safari) with Safari fallback. The PATH-only check falsely reported "no browser" on a Mac with Chrome+Firefox+Safari.
- `launch_browser_app()` — `open -a <browser> <url>` on macOS (no `systemd-run`/`setsid`); drops the wrong **"sudo apt-get install firefox"** advice.
- inotify tune — skipped on macOS (Vite uses FSEvents; no `/proc`, no `fs.inotify` sysctl). Kills the "Vite may crash" sudo warnings.
- `ensure_agent_display()` — skipped on macOS. The Xvfb + x11vnc + XFCE agent desktop is X11-only; the attempt is what produced the **`sed: invalid command code B`** errors and **"Agent virtual display failed to start"**. Chat/voice/API are unaffected.

**`scripts/start_agent_display.sh`** — hard Darwin guard on `start|restart|sync` (exit 0) so direct/plugin invocation is safe too.

**`scripts/verify_gpu_stack.sh`** — probe Metal/MPS on Darwin instead of CUDA, so a healthy Mac reads **"✔ Metal/MPS active"** instead of **"DEGRADED (Torch not compiled with CUDA enabled)"**.

## Out of scope (tracked, not bundled)

These from the report look **functional**, not OS-portability, and shouldn't be guessed at blind: 403 Forbidden in the UI (likely auth), Celery health-check failure, Voice API failure (whisper.cpp not built on fresh clone). To be isolated by the reporter's next re-test.

## Verification

- `bash -n` clean on all three scripts.
- Unit-tested `is_macos` (TRUE for `GUAARDVARK_OS=macos`, FALSE on Linux) and the macOS `get_lan_ips` pipeline (private-IP filter, no subshell loss).
- **Not** tested on real Mac hardware (no Mac on hand; #41 reporter is the verification path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)