### PR TITLE
feat(cli): add offline recipe inspection commands

### DIFF
--- a/cli/llx/commands/recipes.py
+++ b/cli/llx/commands/recipes.py
@@ -1,0 +1,187 @@
+"""Offline commands for inspecting and validating agent recipes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from llx import output
+from llx.commands.system import _find_project_root
+from llx.global_opts import get_global_json
+
+
+recipes_app = typer.Typer(
+    help="List, inspect, and validate agent recipes without starting the backend.",
+    no_args_is_help=True,
+)
+
+KNOWN_ACTIONS = frozenset(
+    {"hotkey", "type", "click", "wait_until_settled", "wait_until_visible", "wait"}
+)
+
+
+def _default_recipes_path() -> Path:
+    start = os.environ.get("GUAARDVARK_ROOT") or os.getcwd()
+    return Path(_find_project_root(start)) / "data" / "agent" / "recipes.json"
+
+
+def load_recipes(path: Path) -> dict[str, Any]:
+    """Load a recipe document, raising a readable ValueError on malformed input."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Recipe file not found: {path}") from exc
+    except OSError as exc:
+        raise ValueError(f"Could not read recipe file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Invalid JSON in {path} at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Recipe document must be a JSON object.")
+    return payload
+
+
+def recipe_entries(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return actual recipes while excluding reserved document metadata."""
+    return {name: recipe for name, recipe in payload.items() if not name.startswith("_")}
+
+
+def validate_recipes(payload: dict[str, Any]) -> list[str]:
+    """Return all schema errors found in a recipe document."""
+    errors: list[str] = []
+    recipes = recipe_entries(payload)
+    if not recipes:
+        return ["Document contains no recipes."]
+
+    for name, recipe in recipes.items():
+        prefix = f"Recipe '{name}'"
+        if not isinstance(recipe, dict):
+            errors.append(f"{prefix} must be an object.")
+            continue
+
+        description = recipe.get("description")
+        if not isinstance(description, str) or not description.strip():
+            errors.append(f"{prefix} must have a non-empty string 'description'.")
+
+        triggers = recipe.get("triggers")
+        if not (
+            isinstance(triggers, list)
+            and triggers
+            and all(isinstance(trigger, str) and trigger.strip() for trigger in triggers)
+        ):
+            errors.append(f"{prefix} must have a non-empty string list 'triggers'.")
+
+        steps = recipe.get("steps")
+        if not isinstance(steps, list) or not steps:
+            errors.append(f"{prefix} must have a non-empty list 'steps'.")
+            continue
+
+        for index, step in enumerate(steps, start=1):
+            step_prefix = f"{prefix}, step {index}"
+            if not isinstance(step, dict):
+                errors.append(f"{step_prefix} must be an object.")
+                continue
+            action = step.get("action")
+            if not isinstance(action, str) or not action.strip():
+                errors.append(f"{step_prefix} must have a non-empty string 'action'.")
+            elif action not in KNOWN_ACTIONS:
+                errors.append(
+                    f"{step_prefix} uses unknown action '{action}'. "
+                    f"Known actions: {', '.join(sorted(KNOWN_ACTIONS))}."
+                )
+
+    return errors
+
+
+def _load_or_exit(path: Path) -> dict[str, Any]:
+    try:
+        return load_recipes(path)
+    except ValueError as exc:
+        output.print_error(str(exc), code="INVALID_RECIPE_FILE")
+        raise typer.Exit(1) from exc
+
+
+@recipes_app.command("list")
+def list_recipes(
+    json_out: bool = typer.Option(False, "--json", "-j", help="Output structured JSON."),
+):
+    """List recipe names and one-line descriptions."""
+    recipes = recipe_entries(_load_or_exit(_default_recipes_path()))
+    rows = [
+        {"name": name, "description": recipe.get("description", "")}
+        for name, recipe in recipes.items()
+        if isinstance(recipe, dict)
+    ]
+
+    if json_out or get_global_json():
+        output.print_json({"status": "success", "data": {"recipes": rows}})
+    else:
+        output.print_table(rows, columns=["name", "description"], title="Agent Recipes")
+
+
+@recipes_app.command("show")
+def show_recipe(
+    name: str = typer.Argument(..., help="Recipe key to inspect."),
+    json_out: bool = typer.Option(False, "--json", "-j", help="Output structured JSON."),
+):
+    """Show a recipe's triggers, step count, and success proof."""
+    recipes = recipe_entries(_load_or_exit(_default_recipes_path()))
+    recipe = recipes.get(name)
+    if not isinstance(recipe, dict):
+        output.print_error(f"Unknown recipe: {name}", code="RECIPE_NOT_FOUND")
+        raise typer.Exit(1)
+
+    details = {
+        "name": name,
+        "description": recipe.get("description", ""),
+        "triggers": recipe.get("triggers", []),
+        "step_count": len(recipe.get("steps", [])) if isinstance(recipe.get("steps"), list) else 0,
+        "success_proof": recipe.get("success_proof"),
+    }
+    if json_out or get_global_json():
+        output.print_json({"status": "success", "data": {"recipe": details}})
+    else:
+        display = dict(details)
+        display["triggers"] = "\n".join(details["triggers"])
+        display["success_proof"] = details["success_proof"] or "Not specified"
+        output.print_kv(display, title=f"Recipe: {name}")
+
+
+@recipes_app.command("validate")
+def validate_recipe_file(
+    file: Path | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Candidate JSON file (defaults to data/agent/recipes.json).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j", help="Output structured JSON."),
+):
+    """Validate recipe JSON shape, required fields, and action names."""
+    path = file.expanduser().resolve() if file else _default_recipes_path()
+    payload = _load_or_exit(path)
+    errors = validate_recipes(payload)
+    result = {"file": str(path), "recipe_count": len(recipe_entries(payload)), "errors": errors}
+
+    if errors:
+        if json_out or get_global_json():
+            output.print_json(
+                {"status": "error", "error": {"code": "VALIDATION_FAILED"}, "data": result}
+            )
+        else:
+            output.print_error(
+                "Recipe validation failed:\n- " + "\n- ".join(errors),
+                code="VALIDATION_FAILED",
+            )
+        raise typer.Exit(1)
+
+    if json_out or get_global_json():
+        output.print_json({"status": "success", "data": result})
+    else:
+        output.print_success(f"Validated {result['recipe_count']} recipes in {path}")

--- a/cli/llx/main.py
+++ b/cli/llx/main.py
@@ -28,6 +28,7 @@ from llx.commands.videos import videos_app
 from llx.commands.launch import launch
 from llx.commands.quality import quality_app
 from llx.commands.outreach import outreach_app
+from llx.commands.recipes import recipes_app
 
 app = typer.Typer(
     name="guaardvark",
@@ -150,6 +151,7 @@ app.add_typer(images_app, name="images")
 app.add_typer(videos_app, name="videos")
 app.add_typer(quality_app, name="quality")
 app.add_typer(outreach_app, name="outreach")
+app.add_typer(recipes_app, name="recipes")
 
 
 def version_callback(value: bool):

--- a/cli/tests/test_recipes.py
+++ b/cli/tests/test_recipes.py
@@ -1,0 +1,86 @@
+"""Agent recipe commands must work offline and reject malformed recipes."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from llx.commands.recipes import load_recipes, validate_recipes
+from llx.main import app
+
+
+runner = CliRunner()
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _recipe(action: str = "click") -> dict:
+    return {
+        "description": "A test recipe.",
+        "triggers": ["^test$"],
+        "steps": [{"action": action}],
+    }
+
+
+def test_current_recipe_file_is_valid():
+    payload = load_recipes(REPO_ROOT / "data" / "agent" / "recipes.json")
+    assert validate_recipes(payload) == []
+
+
+def test_validate_reports_required_fields_and_unknown_actions():
+    payload = {
+        "missing_triggers": {"description": "Missing triggers", "steps": [{"action": "click"}]},
+        "empty_steps": {"description": "No steps", "triggers": ["^empty$"], "steps": []},
+        "unknown_action": _recipe("launch_rocket"),
+    }
+
+    errors = validate_recipes(payload)
+
+    assert any("missing_triggers" in error and "triggers" in error for error in errors)
+    assert any("empty_steps" in error and "steps" in error for error in errors)
+    assert any("unknown_action" in error and "launch_rocket" in error for error in errors)
+
+
+def test_validate_rejects_invalid_json(tmp_path):
+    path = tmp_path / "recipes.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    result = runner.invoke(app, ["recipes", "validate", "--file", str(path)])
+
+    assert result.exit_code == 1
+    assert "Invalid JSON" in result.stdout
+
+
+def test_validate_candidate_file_success(tmp_path):
+    path = tmp_path / "recipes.json"
+    path.write_text(json.dumps({"sample": _recipe()}), encoding="utf-8")
+
+    result = runner.invoke(app, ["recipes", "validate", "--file", str(path), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["data"]["recipe_count"] == 1
+
+
+def test_list_and_show_work_with_backend_offline(monkeypatch):
+    monkeypatch.setenv("GUAARDVARK_ROOT", str(REPO_ROOT))
+
+    listed = runner.invoke(app, ["recipes", "list", "--json"])
+    shown = runner.invoke(app, ["recipes", "show", "navigate_url", "--json"])
+
+    assert listed.exit_code == 0
+    assert shown.exit_code == 0
+    assert json.loads(listed.stdout)["data"]["recipes"]
+    details = json.loads(shown.stdout)["data"]["recipe"]
+    assert details["name"] == "navigate_url"
+    assert details["triggers"]
+    assert details["step_count"] > 0
+
+
+def test_show_unknown_recipe_is_clear(monkeypatch):
+    monkeypatch.setenv("GUAARDVARK_ROOT", str(REPO_ROOT))
+
+    result = runner.invoke(app, ["recipes", "show", "not-a-recipe"])
+
+    assert result.exit_code == 1
+    assert "Unknown recipe: not-a-recipe" in result.stdout


### PR DESCRIPTION
## Summary

- add an offline `recipes` Typer command group with `list`, `show`, and `validate`
- support structured JSON output for scripting
- validate required recipe fields and the documented action allowlist
- keep reserved metadata such as `_meta` out of recipe listings and counts
- add focused tests for valid data, malformed JSON, missing fields, unknown actions, offline list/show behavior, and unknown recipe errors

## Test plan

- `python -m pytest cli/tests/test_recipes.py -q` — 6 passed
- `python -m pytest cli/tests -q` — 124 passed
- `guaardvark recipes validate --json` — validates all 14 current recipes

Closes #48
