### PR TITLE
Unify-CLI-recipe-validation

### DIFF
--- a/cli/llx/commands/recipes.py
+++ b/cli/llx/commands/recipes.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -14,13 +16,49 @@ from llx.commands.system import _find_project_root
 from llx.global_opts import get_global_json
 
 
+def _load_backend_validator():
+    """Load the dependency-free canonical validator without importing the backend app."""
+    validator_path = (
+        Path(__file__).resolve().parents[3]
+        / "backend"
+        / "services"
+        / "agent_knowledge_validator.py"
+    )
+    if not validator_path.is_file():
+        return None
+    module_name = "_guaardvark_agent_knowledge_validator"
+    spec = importlib.util.spec_from_file_location(module_name, validator_path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except (ImportError, OSError):
+        sys.modules.pop(module_name, None)
+        return None
+    return module
+
+
+_BACKEND_VALIDATOR = _load_backend_validator()
+SUPPORTED_RECIPE_ACTIONS = (
+    _BACKEND_VALIDATOR.SUPPORTED_RECIPE_ACTIONS if _BACKEND_VALIDATOR is not None else None
+)
+validate_recipe_library = (
+    _BACKEND_VALIDATOR.validate_recipe_library if _BACKEND_VALIDATOR is not None else None
+)
+
+
 recipes_app = typer.Typer(
     help="List, inspect, and validate agent recipes without starting the backend.",
     no_args_is_help=True,
 )
 
-KNOWN_ACTIONS = frozenset(
+_FALLBACK_ACTIONS = frozenset(
     {"hotkey", "type", "click", "wait_until_settled", "wait_until_visible", "wait"}
+)
+KNOWN_ACTIONS = (
+    frozenset(SUPPORTED_RECIPE_ACTIONS) if SUPPORTED_RECIPE_ACTIONS is not None else _FALLBACK_ACTIONS
 )
 
 
@@ -95,6 +133,12 @@ def validate_recipes(payload: dict[str, Any]) -> list[str]:
                     f"{step_prefix} uses unknown action '{action}'. "
                     f"Known actions: {', '.join(sorted(KNOWN_ACTIONS))}."
                 )
+
+    if validate_recipe_library is not None:
+        canonical = validate_recipe_library(recipes, strict=True)
+        for message in canonical.error_messages():
+            if message not in errors:
+                errors.append(message)
 
     return errors
 

--- a/cli/tests/test_recipes.py
+++ b/cli/tests/test_recipes.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from llx.commands.recipes import load_recipes, validate_recipes
+from llx.commands.recipes import (
+    KNOWN_ACTIONS,
+    SUPPORTED_RECIPE_ACTIONS,
+    load_recipes,
+    validate_recipe_library,
+    validate_recipes,
+)
 from llx.main import app
 
 
@@ -17,7 +23,7 @@ def _recipe(action: str = "click") -> dict:
     return {
         "description": "A test recipe.",
         "triggers": ["^test$"],
-        "steps": [{"action": action}],
+        "steps": [{"action": action, "target_description": "Submit button"}],
     }
 
 
@@ -38,6 +44,38 @@ def test_validate_reports_required_fields_and_unknown_actions():
     assert any("missing_triggers" in error and "triggers" in error for error in errors)
     assert any("empty_steps" in error and "steps" in error for error in errors)
     assert any("unknown_action" in error and "launch_rocket" in error for error in errors)
+
+
+def test_cli_actions_match_canonical_backend_actions():
+    assert validate_recipe_library is not None
+    assert KNOWN_ACTIONS == frozenset(SUPPORTED_RECIPE_ACTIONS)
+
+
+def test_validate_uses_strict_canonical_trigger_checks():
+    invalid_regex = _recipe()
+    invalid_regex["triggers"] = ["^[broken$"]
+    unanchored = _recipe()
+    unanchored["triggers"] = ["test"]
+
+    errors = validate_recipes({"invalid_regex": invalid_regex, "unanchored": unanchored})
+
+    assert any("invalid_regex.triggers[0]" in error and "invalid regex" in error for error in errors)
+    assert any("unanchored.triggers[0]" in error and "anchored with ^" in error for error in errors)
+    assert any("unanchored.triggers[0]" in error and "anchored at the end" in error for error in errors)
+
+
+def test_validate_rejects_unsafe_click_targets_and_coordinates():
+    no_target = _recipe()
+    no_target["steps"] = [{"action": "click"}]
+    stored_coordinates = _recipe()
+    stored_coordinates["steps"] = [
+        {"action": "click", "target_description": "Submit button", "x": 100, "y": 200}
+    ]
+
+    errors = validate_recipes({"no_target": no_target, "stored_coordinates": stored_coordinates})
+
+    assert any("no_target.steps[0]" in error and "target_description" in error for error in errors)
+    assert any("stored_coordinates.steps[0]" in error and "x/y coordinates" in error for error in errors)
 
 
 def test_validate_rejects_invalid_json(tmp_path):

--- a/data/agent/recipes.json
+++ b/data/agent/recipes.json
@@ -372,7 +372,7 @@
       "firefox_running"
     ],
     "triggers": [
-      "^(?:leave|post|write|add|make|submit)\\s+(?:a\\s+)?(?:youtube\\s+)?comment\\b[^\\\"']*[\\\"'](.+?)[\\\"']",
+      "^(?:leave|post|write|add|make|submit)\\s+(?:a\\s+)?(?:youtube\\s+)?comment\\b[^\\\"']*[\\\"'](.+?)[\\\"']\\s*$",
       "^(?:leave|post|write|add|make)\\s+(?:a\\s+)?(?:youtube\\s+)?comment\\s+(?:saying|that says|which says|reading)\\s+(.+?)\\s*(?:on\\s+(?:this|the)\\b.*)?$"
     ],
     "steps": [


### PR DESCRIPTION
## Summary

- load the dependency-free backend recipe validator directly when the repository layout is available, without importing the backend application;
- preserve the lightweight standalone CLI fallback;
- derive CLI action names from the canonical validator in repository mode and test parity;
- apply strict canonical checks for regex compilation, trigger anchoring, click target descriptions, and stored click coordinates;
- anchor the one existing YouTube comment trigger exposed by strict validation.

## Scope

This intentionally implements only the core validation-parity request in #51. It does not include the optional `list` / `show` `--file` or display-field polish.

## Verification

- `PYTHONPATH=.;cli python -m pytest cli/tests/test_recipes.py -q` — 9 passed
- `PYTHONPATH=.;cli python -m pytest cli/tests/test_recipes.py cli/tests/test_lite_server.py -q` — 15 passed
- CLI suite excluding the unrelated Windows-specific final JSON contract file — 122 passed

Closes #51
