### PR TITLE
ci: run the CLI test suite (cli/tests) in the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
     branches: [main]
 
 jobs:
+  cli:
+    name: CLI Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install CLI package
+        run: pip install -e ./cli pytest
+
+      - name: Run CLI test suite
+        run: python -m pytest cli/tests -q
+
   frontend:
     name: Frontend Lint & Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #52.

The CI workflow ran frontend lint/build and backend static validation, but never executed `cli/tests` — the CLI suite (124 tests as of today, including the `test_recipes.py` coverage from #50) only ever ran on contributors' machines. This adds a third job, **CLI Tests**, alongside the existing two.

## Approach

- `pip install -e ./cli pytest` rather than `pip install -r cli/requirements.txt`: the editable install pulls the CLI's real dependency set from `setup.py`, which includes `flask` — a runtime dependency that `cli/requirements.txt` omits — and also puts the `llx` package itself on the path, which the tests import directly.
- Python 3.12 to match the Backend Validation job and the package's `python_requires`.

## Verification

Reproduced the exact job recipe locally in a clean 3.12 venv (only `pip install -e ./cli pytest`, nothing from `backend/requirements.txt`): **124 passed in ~10s**, offline. This also gives #55 a meaningful CI signal — its parity tests currently aren't exercised by the green checkmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)