### PR TITLE
docs: add hardware tier guide (docs/HARDWARE.md)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,8 @@ curl -fsSL https://guaardvark.com/install.sh | bash
 
 Clones to `~/guaardvark` (override with `GUAARDVARK_HOME=/path`) and hands off to `./start.sh`. Re-running updates an existing install; `GUAARDVARK_NO_START=1` clones without launching.
 
+**Not sure what your machine can run?** See [docs/HARDWARE.md](docs/HARDWARE.md) — a tier-by-tier guide to what works CPU-only, on 8–12 GB cards, on the 16 GB design target, and beyond.
+
 **Or from a release zip:**
 
 1. **Extract:**

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ State-of-the-art video generation running entirely on your GPU. No cloud APIs, n
 - **Quality tiers** — Fast (10 steps), Standard (30), High (40), Maximum (50)
 - **Frame interpolation** — 1x raw, 2x doubled FPS, 2x + upscale for cinema-quality output
 - **Prompt enhancement** — Cinematic, Realistic, Artistic, Anime, or raw
-- **Low VRAM mode** — automatically reduces resolution, frames, and inference steps for 8–12GB GPUs (mutually exclusive with High consistency)
+- **Low VRAM mode** — reduces resolution, frames, and inference steps to keep 16GB cards inside budget (mutually exclusive with High consistency); video generation itself needs a 16GB-class card — see [docs/HARDWARE.md](docs/HARDWARE.md)
 - **Batch processing** — queue multiple videos from a prompt list via an in-process worker (one batch at a time; ComfyUI primary, offline CogVideoX fallback)
 - **ComfyUI integration** — one-click launch to the node editor for custom workflows; Wan/LTX require ComfyUI. LTX-2.5 needs ComfyUI ≥ 0.32.0 and a one-time license accept on [Lightricks/LTX-2.5](https://huggingface.co/Lightricks/LTX-2.5) (`HF_TOKEN` in `.env`); after download, generation stays local.
 
@@ -444,15 +444,19 @@ guaardvark files upload report.pdf      # Upload and index
 | Ollama | latest | Local LLM inference |
 | CUDA GPU | 8GB+ VRAM | 16GB recommended for video generation |
 
+**Which tier is your machine?** See **[docs/HARDWARE.md](docs/HARDWARE.md)** for what runs CPU-only, on 8–12 GB, on the 16 GB design target, and with 24 GB+ of headroom.
+
 ### GPU Memory Guide
 
 | Feature | Minimum | Recommended |
 |---------|---------|-------------|
 | Chat + RAG | 4GB | 8GB |
 | Image generation | 6GB | 12GB |
-| Wan 2.2 video | 11GB | 16GB |
+| Wan 2.2 video | 16GB* | 16GB |
 | CogVideoX-5B video | 16GB | 20GB |
 | Upscaling | 0.5GB | 2–4GB |
+
+\* Wan's weights fit in ~11GB, but the generation preflight requires a 16GB-class card for every current video family — see [docs/HARDWARE.md](docs/HARDWARE.md).
 
 ---
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,174 @@
+# Hardware Guide
+
+Which Guaardvark features actually run on your machine, tier by tier.
+
+Every number below comes from the code: the VRAM budgets the GPU orchestrator
+debits per job, the preflight gates that refuse work, and the download sizes in
+the model registry. Treat them as design targets and calibrated estimates — not
+formal benchmarks (a measured benchmark suite is a planned follow-up). Where
+something is untested we say so and under-promise.
+
+## The short answer
+
+| Tier | GPU VRAM | What to expect |
+|------|----------|----------------|
+| **A — CPU-only / no NVIDIA GPU** | none | Chat + RAG (keyword-first retrieval), voice in and out, the parallel coding-agent Swarm, the video editor, MCP. No image, video, or music generation; no upscaling. |
+| **B — Entry GPU** | 8–12 GB | Everything above, plus vector RAG, screen agents, SD/SDXL-class image generation, upscaling, and (at 12 GB) music generation. Video generation is refused — the preflight requires a 16 GB-class card. |
+| **C — Design target** | 16 GB | The tier Guaardvark is built and tested on. The full stack: FLUX-class images, Wan 2.2 / LTX / CogVideoX video, music + neural voice, Film Crew, music videos — one heavy job at a time. |
+| **D — Headroom** | 20–24 GB+ | Concurrency and quality upgrades: two resident LLMs, heavier image models preferred automatically, text encoders stay on-GPU, larger agent step budgets, full-batch LoRA training. |
+
+A single NVIDIA (CUDA) GPU is the primary target. AMD and Apple Silicon support
+is partial — see the sections at the end.
+
+The canonical question — **"can I run this on a 12 GB card?"** — has a clean
+answer: yes for chat, RAG, screen agents, SD/SDXL images, upscaling, music, and
+voice; no for video generation, whose preflight checks total VRAM against a
+16 GB minimum for the Wan / LTX / CogVideoX families and refuses below it
+(with ~0.5 GB of grace, so "16 GB" cards that report 15.9 GB pass).
+
+On first run, `./start.sh` detects your hardware (written to
+`~/.guaardvark/hardware.json`) and derives the PyTorch build, Ollama server
+tuning, and default models from it — see
+`backend/services/hardware_policy.py`. You don't pick a tier; the system adapts.
+
+## Tier A — CPU-only
+
+What works, and how the system adapts:
+
+- **Chat + RAG.** Ollama runs the default models on CPU. Machines with ≤ 8 GB
+  RAM (or any ARM machine) get a small text-only tier (`llama3.2:1b` +
+  `nomic-embed-text`); everything else gets `gemma4:e2b` (5.1B, ~7.2 GB
+  download, vision-capable). With no GPU, models are kept resident in RAM
+  instead of being unloaded, so you pay the load cost once.
+- **Retrieval degrades honestly.** Advanced (vector) RAG defaults off on
+  CPU-only hosts; retrieval falls back to BM25 keyword search under memory
+  pressure rather than thrashing.
+- **Voice.** Speech-to-text (whisper.cpp) is a CPU build. Kokoro TTS is
+  near-realtime on CPU; Chatterbox TTS works on CPU but is slow.
+- **Coding agents.** The Swarm Orchestrator (parallel coding agents in git
+  worktrees) declares zero VRAM and no GPU requirement.
+- **Not available:** image, video, and music generation, and upscaling — all
+  require an accelerator. The video pipeline refuses outright with
+  "GPU required for video generation" when no NVIDIA GPU is detected.
+- **Screen agents: not validated on CPU.** There is no hard GPU gate on the
+  agent path, but every See-Think-Act iteration is a vision-model inference;
+  on CPU expect it to be far too slow to be useful. Treat agents as GPU
+  territory.
+
+## Tier B — entry GPU (8–12 GB)
+
+- **Chat, RAG, and vision** are comfortable; the chat pipeline budgets ~8 GB
+  for the resident LLM.
+- **Screen agents work**, with a reduced step budget: below 16 GB VRAM an agent
+  task gets 10 steps instead of 20.
+- **Image generation** is realistic with SD (~4 GB working estimate) and
+  SDXL-class (~8 GB) models. The heavier paths (FLUX, Z-Image) budget
+  11–12 GB — tight-to-refused on a 12 GB card, refused on 8 GB.
+- **Upscaling** runs fine (~1.5 GB, tiled to avoid OOM).
+- **Music generation** (ACE-Step, ~10 GB, runs exclusively) fits on 12 GB —
+  the orchestrator evicts everything else first — but not on 8 GB. FX
+  generation (~6 GB) and TTS (≤ 2 GB) are fine on both.
+- **Video generation is gated off.** The preflight requires a 16 GB-class card
+  for every current video family (Wan 2.2 including the 5B, LTX-2.3/2.5,
+  CogVideoX-5B). The Low VRAM preset reduces frames/resolution/steps but does
+  not bypass this gate — it exists to keep 16 GB cards inside budget.
+
+## Tier C — the 16 GB design target
+
+16 GB is the tier the project is engineered against ("the 16 GB ceiling is the
+design target" — `hardware_policy.py`), and where everything has been tuned to
+coexist:
+
+- Wan 2.2 TI2V-5B, the default video model, was built for 16 GB cards; the
+  LTX-2.3 FP8 and LTX-2.5 int8 variants specifically target 16 GB
+  Ada-generation cards.
+- Image pipelines automatically enable sequential CPU offload on cards
+  ≤ 18 GB; Wan's text encoders are placed on the CPU on cards ≤ 20 GB. Both
+  are automatic — no settings to find.
+- Film Crew and music-video renders claim ~14 GB exclusively and evict the
+  chat model and ComfyUI caches before starting (see the contention section).
+- Expect **one heavy job at a time**: chat plus a render works because the
+  render evicts chat and it reloads after; two renders do not overlap.
+
+## Tier D — headroom (20–24 GB+)
+
+- **≥ 20 GB:** Ollama serves 2 parallel requests and keeps 2 models loaded
+  (below this, 1 and 1); the heavier Krea2 model becomes the preferred
+  automatic image model; Wan's text encoders stay on the GPU.
+- **> 24 GB:** agent tasks get a 30-step budget (vs 20 at 16 GB); LoRA
+  training runs at its top configuration (batch 4, 4096 sequence length, no
+  CPU offload — the 24 GB-class ladder in
+  `backend/services/hardware_service.py`).
+- CogVideoX-5B is happiest here (20 GB recommended).
+
+## One GPU, many models — contention is managed, not free
+
+Running Ollama, ComfyUI, and audio backends against one card only works
+because a set of arbitration layers coordinates them
+(`backend/services/gpu_resource_policy.py` enumerates them):
+
+- **GPU Memory Orchestrator** — every heavy job debits a VRAM budget before
+  touching the card (images ~8–12 GB, video ~14 GB, music ~10 GB exclusive)
+  and is refused or queued if it doesn't fit, with a ~10% safety margin.
+- **Job gate + cross-process lock** — heavy renders are exclusive: they evict
+  the resident chat model (it reloads afterwards) and free ComfyUI's caches.
+- **RAM admission gate** — system RAM and swap are checked before big loads.
+
+Practical consequences: a resident chat model and a video render cannot share
+a 16 GB card, so the system doesn't try — evict-and-reload is the designed
+behavior, not a bug. Your desktop compositor also permanently holds
+~600–800 MB of VRAM, which the budgets account for.
+
+## System RAM, swap, and disk
+
+- **≤ 8 GB RAM (or ARM):** the bootstrap installs the small text-only model
+  tier — the ~7.2 GB Gemma4 download doesn't fit.
+- **Image generation uses serious system RAM** when CPU offload kicks in:
+  calibrated figures range from ~10 GB (SDXL) to ~21–24 GB (Z-Image / Krea2)
+  of resident memory per job. 32 GB of system RAM is a sensible floor for the
+  generation stack; 64 GB is comfortable.
+- **Swap:** ≥ 16 GB swap with low swappiness is recommended so a spike
+  degrades instead of freezing the desktop — setup commands are in
+  [INSTALL.md](../INSTALL.md).
+- **Disk:** generation models are multi-GB downloads (Wan 2.2 5B ~9.5 GB,
+  FLUX ~12.6 GB, CogVideoX ~11 GB, LTX-2.5 ~20 GB plus companion files).
+  Plan on tens of GB free for a full video stack, plus ~8 GB of headroom for
+  the CUDA Python stack itself.
+
+## Apple Silicon (macOS)
+
+Partial, actively improving — tracked in
+[#43](https://github.com/guaardvark/guaardvark/issues/43).
+
+- **Works:** chat, RAG, and voice through Ollama (which uses Metal on its
+  own); the install and startup path; the video editor (with `melt`/Shotcut
+  installed).
+- **Conservative default:** ARM machines currently get the small
+  `llama3.2:1b` tier regardless of unified memory — pull a larger model
+  manually if your machine can hold it.
+- **Experimental:** the offline (diffusers) video path has an MPS branch with
+  tentative, advisory limits — untested on real Apple hardware.
+- **Not available:** the ComfyUI video pipeline (requires NVIDIA), the offline
+  image generator's GPU path (CUDA-only today), and the agent virtual desktop
+  (X11-only: Xvfb + XFCE + x11vnc).
+
+## AMD (ROCm)
+
+Best-effort and unverified on real hardware: detection installs the ROCm
+PyTorch build and reads VRAM via `rocm-smi`, but several GPU-presence checks
+are NVIDIA-only, so generation paths should be considered NVIDIA-first for
+now. If you run Guaardvark on an AMD card, an issue report with logs would
+genuinely help.
+
+## Where these numbers live
+
+For contributors updating this guide: hardware detection and policy are in
+`backend/services/hardware_policy.py` and `hardware_detector.py`; per-model
+VRAM budgets in `backend/services/video_model_registry.py`; the video
+preflight minimums in `backend/services/comfyui_video_generator.py`
+(`MODEL_MIN_VRAM_GB`); arbitration in
+`backend/services/gpu_memory_orchestrator.py` and `gpu_resource_policy.py`;
+plugin budgets in each `plugins/*/plugin.json` (`vram_estimate_mb`).
+
+See also: [README Requirements](../README.md#requirements) ·
+[CAPABILITIES.md](../CAPABILITIES.md) · [ARCHITECTURE.md](ARCHITECTURE.md)


### PR DESCRIPTION
## Summary

Closes #49.

Adds `docs/HARDWARE.md`: a four-tier guide (CPU-only / 8–12 GB / the 16 GB design target / 20–24 GB+) that answers the fresh-reader test from the issue — "can I run this on a 12 GB card?" gets an explicit answer. Linked from README's Requirements section and from INSTALL.md.

## Accuracy

Per the issue's accuracy rule, every number is sourced from code, not invented:

- Tier boundaries are the code's own: the `MODEL_MIN_VRAM_GB` 16 GB family floors in `comfyui_video_generator.py` (with the 0.5 GB grace for 15.9 GB "16 GB" cards), `hardware_policy.py`'s model tiers (≤8 GB RAM or ARM → 1B model) and Ollama tuning (≥20 GB → 2 parallel / 2 loaded), the agent step budget (<16 GB → 10, >24 GB → 30), image sequential offload ≤18 GB, Wan CLIP-on-CPU ≤20 GB, and the LoRA training ladder in `hardware_service.py`.
- Contention section describes the real arbitration layers from `gpu_resource_policy.py` (orchestrator budget debits, exclusive renders evicting chat, ~10% margin, 600–800 MB compositor reserve).
- Apple Silicon / AMD sections under-promise: only what has an actual code path (MPS branch on the offline video generator, ROCm torch channel) is claimed, with the X11-only agent desktop and CUDA-only paths called out; points at #43.
- "Measured benchmarks are a follow-up" note included, as the issue asked.

## Two README claims synced with code (tiny accuracy fixes, allowed by the issue)

- **GPU Memory Guide, Wan minimum 11GB → 16GB\*** with a footnote: ~11 GB is the model's VRAM footprint, but the generation preflight requires a 16 GB-class card for every current video family — a 12 GB card is refused, so 11 GB as a "minimum" was misleading.
- **Low VRAM mode** described as keeping 16 GB cards inside budget (matching the UI string in `VideoGeneratorPage.jsx`) rather than enabling 8–12 GB GPUs, which the preflight contradicts.

## Noted while researching, deliberately NOT in this PR

Doc/code drift found during verification, left for follow-ups: README says the agent desktop is 1024×1024 (script default is 1000×1000, matched to Gemma4's box_2d grid); README's "System Resource Orchestrator" doesn't exist under that name in code; README describes Film Crew as parallel while `backend/services/swarm/README.md` says it's sequential; `test_hardware_policy.py` still asserts the old cu121 torch channel (code returns cu124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)