### PR TITLE
fix(gate): say "system RAM (not VRAM)" when the RAM gate refuses a job

### DIFF
--- a/backend/services/system_load_gate.py
+++ b/backend/services/system_load_gate.py
@@ -205,9 +205,10 @@ class GlobalLoadGate:
         ram_floor = effective_ram_hard_min_gb()
         if eff_ram - weight.ram_gb < ram_floor:
             return (
-                f"RAM too low: {eff_ram:.1f} GB available "
+                f"system RAM too low (not VRAM): {eff_ram:.1f} GB available "
                 f"(reserved {reading.reserved_ram_gb:.1f} GB), "
-                f"need {weight.ram_gb:.1f} GB + {ram_floor:.1f} GB floor"
+                f"need {weight.ram_gb:.1f} GB + {ram_floor:.1f} GB floor. "
+                "Swap does not count; pick a lighter model or add system RAM"
             )
         if reading.swap_used_gb > SWAP_HARD_MAX_GB:
             return f"swap in use: {reading.swap_used_gb:.1f} GB > {SWAP_HARD_MAX_GB:.0f} GB"

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -127,6 +127,13 @@ behavior, not a bug. Your desktop compositor also permanently holds
   calibrated figures range from ~10 GB (SDXL) to ~21–24 GB (Z-Image / Krea2)
   of resident memory per job. 32 GB of system RAM is a sensible floor for the
   generation stack; 64 GB is comfortable.
+- **Big GPU, small RAM (cloud shapes):** the system-RAM gate applies no matter
+  how large the card is. Z-Image and Krea2 always run with CPU offload, so
+  their weights live in system RAM between stages even on a 24 GB GPU. A
+  16 GB-RAM VM such as Google Cloud's `g2-standard-4` (one 24 GB L4) will
+  refuse them with `system RAM too low (not VRAM)`; the 32 GB `g2-standard-8`
+  admits them. On 16 GB of RAM, pick SDXL or SD 1.5 explicitly — Auto resolves
+  to Z-Image. Swap does not count toward the gate.
 - **Swap:** ≥ 16 GB swap with low swappiness is recommended so a spike
   degrades instead of freezing the desktop — setup commands are in
   [INSTALL.md](../INSTALL.md).


### PR DESCRIPTION
## Summary

- The admission gate's refusal read `RAM too low`, which users on big-GPU / small-RAM boxes (a 16 GB-RAM cloud VM with a 24 GB L4) took to mean GPU memory. The message now names the resource explicitly, says swap does not count, and points at the two ways out: a lighter model or more system RAM.
- `docs/HARDWARE.md` documents the same case under "System RAM, swap, and disk": Z-Image and Krea2 always run with CPU offload, so their system-RAM footprint applies regardless of VRAM; `g2-standard-4` (16 GB) cannot admit them, `g2-standard-8` (32 GB) can; on 16 GB pick SDXL / SD 1.5 explicitly since Auto resolves to Z-Image.

Closes the first two checkboxes on #59. The third (a fully-resident path on ≥22 GB cards) stays open there — it needs an L4 / A10G to verify.

New message as rendered for a 16 GB box:

```
system RAM too low (not VRAM): 13.2 GB available (reserved 0.0 GB), need 21.0 GB + 1.6 GB floor. Swap does not count; pick a lighter model or add system RAM
```

## Test plan

- [x] `backend/tests/services/test_gpu_load_gates.py` — 21 passed. `test_run_storyboard_artist_uses_gpu_gate` fails identically on untouched `main`; it probes the host's real free VRAM and is unrelated to this change.
- [x] `scripts/check_portable.sh` clean.
- [x] Grepped for consumers matching on the old `RAM too low` text — none.

Refs #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)