### PR TITLE
Security: arithmetic-only calculator, exact Reddit host for the scout, CodeQL config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,23 @@
+name: "Guaardvark CodeQL config"
+
+# The repo vendors heavy runtime state; scanning it would drown the analysis
+# in third-party and generated code.
+paths-ignore:
+  - "**/venv"
+  - "**/node_modules"
+  - frontend/dist
+  - data
+  - backups
+  - logs
+
+# Accepted for a local-first, self-hosted application:
+#  - py/stack-trace-exposure: API errors return the exception text on purpose;
+#    the operator is the only audience and needs the detail. Revisit if a
+#    LAN-facing mode ever hides 5xx detail from non-local callers.
+#  - py/polynomial-redos: the flagged patterns run over short LLM/user text in
+#    a single-user process; no request-amplified input reaches them.
+query-filters:
+  - exclude:
+      id: py/stack-trace-exposure
+  - exclude:
+      id: py/polynomial-redos

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,16 +26,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          # The repo vendors heavy runtime state; scanning it would drown the
-          # analysis in third-party and generated code.
-          config: |
-            paths-ignore:
-              - "**/venv"
-              - "**/node_modules"
-              - frontend/dist
-              - data
-              - backups
-              - logs
+          config-file: ./.github/codeql/codeql-config.yml
       - uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/backend/api/social_outreach_api.py
+++ b/backend/api/social_outreach_api.py
@@ -477,6 +477,24 @@ def _suggest_platform_from_host(host: str) -> Optional[str]:
     return None
 
 
+_REDDIT_HOSTS = frozenset({"reddit.com", "www.reddit.com", "old.reddit.com", "new.reddit.com", "m.reddit.com"})
+
+
+def _reddit_thread_path(url: str) -> Optional[str]:
+    """Path of a reddit.com thread URL, or None when the host is not Reddit.
+
+    The host is matched exactly against ``_REDDIT_HOSTS`` so the JSON fetch can
+    be issued to a fixed host; a substring check would accept look-alikes such as
+    ``reddit.com.example.net``.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or (parsed.hostname or "").lower() not in _REDDIT_HOSTS:
+        return None
+    return parsed.path or "/"
+
+
 def _scout_reddit_url(url: str) -> Optional[Dict[str, Any]]:
     """For a Reddit thread URL, pull OP + top-5 comments via the public JSON API.
 
@@ -489,11 +507,13 @@ def _scout_reddit_url(url: str) -> Optional[Dict[str, Any]]:
 
     # Reddit's JSON endpoint accepts the same path with .json appended. Strip
     # any trailing slash + querystring before tacking it on.
-    base = url.split("?", 1)[0].split("#", 1)[0].rstrip("/")
-    json_url = base + ".json?limit=10&depth=1"
+    path = _reddit_thread_path(url)
+    if path is None:
+        return None
+    json_url = "https://www.reddit.com" + path.rstrip("/") + ".json?limit=10&depth=1"
     headers = {"User-Agent": "guaardvark-outreach/0.1 scout"}
     try:
-        resp = requests.get(json_url, headers=headers, timeout=10, allow_redirects=True)
+        resp = requests.get(json_url, headers=headers, timeout=10, allow_redirects=False)
         if not resp.ok:
             return None
         data = resp.json()
@@ -686,7 +706,7 @@ def scout_url():
         pass
 
     # Reddit JSON API — primary path unless caller forces DOM.
-    if "reddit.com" in parsed_host and not force_dom:
+    if _reddit_thread_path(url) is not None and not force_dom:
         scouted = _scout_reddit_url(url)
         if scouted:
             return jsonify(scouted)

--- a/backend/api/web_search_api.py
+++ b/backend/api/web_search_api.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 from flask import Blueprint, current_app, jsonify, request
 from backend.utils.response_utils import success_response, error_response
 from backend.utils.settings_utils import get_web_access
+from backend.utils.safe_math import evaluate_arithmetic
 
 web_search_bp = Blueprint("web_search_api", __name__, url_prefix="/api/web-search")
 logger = logging.getLogger(__name__)
@@ -305,7 +306,7 @@ def handle_special_queries(query: str) -> Dict[str, Any]:
             import re
             math_expr = re.sub(r'[^0-9+\-*/.() ]', '', query)
             if math_expr.strip():
-                result = eval(math_expr.strip())
+                result = evaluate_arithmetic(math_expr.strip())
                 return {
                     "query": query,
                     "strategy_used": "math_calculation",

--- a/backend/tests/test_reddit_scout_host.py
+++ b/backend/tests/test_reddit_scout_host.py
@@ -1,0 +1,32 @@
+"""Reddit scout only fetches from an exact Reddit host, never a look-alike."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+os.environ["GUAARDVARK_MODE"] = "test"
+
+from backend.api.social_outreach_api import _reddit_thread_path  # noqa: E402
+
+
+@pytest.mark.parametrize("url,path", [
+    ("https://www.reddit.com/r/LocalLLaMA/comments/abc123/title/", "/r/LocalLLaMA/comments/abc123/title/"),
+    ("https://old.reddit.com/r/x/comments/1/", "/r/x/comments/1/"),
+    ("http://reddit.com/r/x/comments/1?utm=1#top", "/r/x/comments/1"),
+])
+def test_accepts_reddit_hosts(url, path):
+    assert _reddit_thread_path(url) == path
+
+
+@pytest.mark.parametrize("url", [
+    "https://reddit.com.evil.example/r/x/comments/1/",
+    "https://evil.example/reddit.com/r/x/",
+    "https://169.254.169.254/latest/meta-data?reddit.com",
+    "ftp://www.reddit.com/r/x/",
+    "https://redditx.com/r/x/",
+    "not a url",
+])
+def test_rejects_lookalikes_and_other_hosts(url):
+    assert _reddit_thread_path(url) is None

--- a/backend/tests/test_safe_math.py
+++ b/backend/tests/test_safe_math.py
@@ -1,0 +1,53 @@
+"""evaluate_arithmetic: the calculator behind the search 'calculate' intent."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from backend.utils.safe_math import evaluate_arithmetic  # noqa: E402
+
+
+@pytest.mark.parametrize("expr,expected", [
+    ("2+2", 4),
+    ("(3 + 4) * 2", 14),
+    ("10 / 4", 2.5),
+    ("7 // 2", 3),
+    ("7 % 3", 1),
+    ("2 ** 10", 1024),
+    ("-3 + 5", 2),
+    ("1.5 * 4", 6.0),
+])
+def test_arithmetic(expr, expected):
+    assert evaluate_arithmetic(expr) == expected
+
+
+@pytest.mark.parametrize("expr", [
+    "__import__('os').system('id')",
+    "().__class__",
+    "abs(1)",
+    "x + 1",
+    "'a' * 3",
+    "",
+    "   ",
+    "2 +",
+    "9 ** 9 ** 9",
+    "10 ** 65",
+    "1e16 + 1",
+    "1 < 2",
+])
+def test_rejects_non_arithmetic_and_runaway(expr):
+    with pytest.raises(ValueError):
+        evaluate_arithmetic(expr)
+
+
+def test_division_by_zero_propagates():
+    with pytest.raises(ZeroDivisionError):
+        evaluate_arithmetic("1 / 0")
+
+
+def test_node_limit():
+    with pytest.raises(ValueError):
+        evaluate_arithmetic("+".join(["1"] * 300))

--- a/backend/utils/safe_math.py
+++ b/backend/utils/safe_math.py
@@ -1,0 +1,68 @@
+"""Arithmetic-only expression evaluation for chat/search "calculate" intents."""
+
+from __future__ import annotations
+
+import ast
+import operator
+from typing import Union
+
+Number = Union[int, float]
+
+_BINARY = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_UNARY = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+
+MAX_NODES = 200
+MAX_ABS_OPERAND = 1e15
+MAX_ABS_EXPONENT = 64
+MAX_ABS_RESULT = 1e100
+
+
+def evaluate_arithmetic(expression: str) -> Number:
+    """Evaluate ``expression`` using only numbers, + - * / // % ** and parentheses.
+
+    Raises ``ValueError`` for anything else (names, calls, attributes, strings),
+    for expressions large enough to stall the process (deep trees, huge
+    operands, large exponents), and ``ZeroDivisionError`` where Python would.
+    """
+    if not expression or not expression.strip():
+        raise ValueError("empty expression")
+    try:
+        tree = ast.parse(expression.strip(), mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"invalid arithmetic: {exc.msg}") from None
+    if sum(1 for _ in ast.walk(tree)) > MAX_NODES:
+        raise ValueError("expression too long")
+    return _eval(tree.body)
+
+
+def _check(value: Number) -> Number:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("non-numeric value")
+    if abs(value) > MAX_ABS_RESULT:
+        raise ValueError("result too large")
+    return value
+
+
+def _eval(node: ast.AST) -> Number:
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise ValueError("only numeric literals are allowed")
+        if abs(node.value) > MAX_ABS_OPERAND:
+            raise ValueError("operand too large")
+        return node.value
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY:
+        return _check(_UNARY[type(node.op)](_eval(node.operand)))
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINARY:
+        left, right = _eval(node.left), _eval(node.right)
+        if isinstance(node.op, ast.Pow) and abs(right) > MAX_ABS_EXPONENT:
+            raise ValueError("exponent too large")
+        return _check(_BINARY[type(node.op)](left, right))
+    raise ValueError(f"unsupported expression element: {type(node).__name__}")


### PR DESCRIPTION
## Summary

Follow-up to the first full CodeQL scan (956 alerts on `main`, all dated 2026-08-21). This PR fixes the two findings that are real, records the accepted-risk categories in a CodeQL config, and ships alongside a triage pass that dismissed 73 verified false positives with per-alert reasons.

**Real fixes**
- `web_search_api`: the "calculate" intent used `eval()` on a character-filtered string. Only digits/operators survived the filter, but `9**9**9` still stalls the backend. Replaced with `backend/utils/safe_math.evaluate_arithmetic` (AST walk; numbers, `+ - * / // % **`, parentheses; node/operand/exponent/result limits).
- `social_outreach_api`: the Reddit scout matched the host with `"reddit.com" in host` and followed redirects, so `reddit.com.example.net` could be fetched anywhere it redirected. Now an exact Reddit host allowlist, the JSON request goes to `www.reddit.com` + thread path, no automatic redirects; `/scout-url` uses the same check.

**CodeQL config** (`.github/codeql/codeql-config.yml`, wired via `config-file`)
- Keeps the existing path ignores.
- Excludes `py/stack-trace-exposure` (531 alerts: API errors return the exception text on purpose for the operator) and `py/polynomial-redos` (28: short LLM/user text in a single-user process). Rationale is in the file.

**Not in this PR (tracked)**
- 289 `py/path-injection` — needs a shared `safe_join`-based helper and per-file migration.
- 19 `py/incomplete-url-substring-sanitization`, `app.py` `enforce_https` redirect (Host-header derived), `code_execution_api` shell execution (feature by design; blueprint not registered), `cluster_proxy` passthrough, 9 JS sanitizer heuristics in `inputValidation.js`.

## Test plan
- [x] `backend/tests/test_safe_math.py` (22) and `backend/tests/test_reddit_scout_host.py` (9) green
- [x] `test_placebo_fixes.py`, `test_social_outreach/test_kill_switch_bypass.py` green
- [x] YAML parses; `scripts/check_portable.sh` clean
- [ ] CodeQL workflow on this PR picks up the config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)