### PR TITLE
Media workspace tabs, image upscaling, scoped ComfyUI cancel, theme-aware system map

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Flask (~90+ API modules, auto-discovered) + GraphQL + Socket.IO
     +-- AgentBrain (3-tier routing: Reflex → Instinct → Deliberation)
     |
 Service Layer (many modules; plugin sidecars for heavy GPU work)
-|-- Agent Executor (ReACT + ~70 tool classes + BrainState)
+|-- Agent Executor (ReACT + ~60 tool classes + BrainState)
 |-- Screen Control (See-Think-Act-Verify + live reasoning stream)
 |-- RAG + Autoresearch + Entity extraction
 |-- Self-Improvement (detect/fix/verify/broadcast + guardian)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
   <img src="docs/screenshots/og-image.jpg" alt="Guaardvark — Secure Offline AI Platform" width="480">
 </p>
 
+> **The aardvark** (/ˈɑːrd.vɑːrk/; *Orycteropus afer*) is a medium-sized, burrowing, nocturnal mammal native to Africa. The aardvark is the only living member of the genus *Orycteropus*, the family Orycteropodidae and the order Tubulidentata. It is found over much of the southern two-thirds of the African continent, avoiding areas that are mainly rocky. A nocturnal feeder, the aardvark subsists on ants and termites (myrmecophagy) by using its sharp claws and powerful legs to dig the insects out of their hills, and its long snout to sniff out food. It digs a burrow in which to live and rear its young.
+>
+> — [Wikipedia](https://en.wikipedia.org/wiki/Aardvark), CC BY-SA
+
+**The Guaardvark** (/ˈɡwɑːrd.vɑːrk/; *Workstationus selfhosticus*) is a badass, burrowing, nocturnal AI system native to consumer hardware. The Guaardvark is the only living member of the repository [github.com/guaardvark/guaardvark](https://github.com/guaardvark/guaardvark), the family LocalAI, and the order AutonomousAgents.
+
+The Guaardvark is a local-first platform, a clade that also includes Ollama, Llama, and ComfyUI.
+
+It is found across most of the modern desktop, avoiding regions that are mainly cloud. A nocturnal feeder, the Guaardvark subsists on prompts and unstructured data (promptophagy) by using its sixty-odd tools and a swarm of parallel coding agents to dig bugs out of their codebases, and a retrieval index to sniff out knowledge in the dark. It is fiercely territorial about its single GPU, admitting one process to the card at a time and evicting any language model found loitering there. It digs isolated git worktrees in which to work, and rears its images, video, music, and cloned voices entirely on your own machine.
+
 # Guaardvark
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/backend/api/upscaling_api.py
+++ b/backend/api/upscaling_api.py
@@ -8,10 +8,13 @@ Auth token is fetched from the plugin's /health endpoint and cached.
 import io
 import logging
 import os
+import uuid
 from pathlib import Path
+from typing import Optional
 
 import requests
 from flask import Blueprint, request as flask_request, send_file
+from werkzeug.security import safe_join
 from werkzeug.utils import secure_filename
 
 from backend.utils.response_utils import success_response, error_response
@@ -281,7 +284,193 @@ def _get_upload_dir() -> Path:
     return upload_dir
 
 
+def _proxy_error(data, fallback: str) -> str:
+    """Pull a message out of a plugin error body (FastAPI uses ``detail``)."""
+    if isinstance(data, dict):
+        message = data.get("error") or data.get("detail")
+        if isinstance(message, list):
+            return "; ".join(
+                str(item.get("msg", item)) if isinstance(item, dict) else str(item)
+                for item in message
+            )
+        if message:
+            return str(message)
+    return fallback
+
+
+def _contained_file(base_dir: Path, name: str) -> Optional[Path]:
+    """Resolve ``name`` as a direct child of ``base_dir``.
+
+    Returns None when the name is empty, carries a path separator, or resolves
+    (through ``..`` or a symlink) anywhere other than directly inside ``base_dir``.
+    """
+    if not name or name in (".", "..") or "/" in name or "\\" in name or "\x00" in name:
+        return None
+    base = base_dir.resolve()
+    joined = safe_join(str(base), name)
+    if joined is None:
+        return None
+    candidate = Path(joined).resolve()
+    return candidate if candidate.parent == base else None
+
+
 ALLOWED_VIDEO_EXTENSIONS = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".flv", ".wmv"}
+ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tif", ".tiff"}
+
+# A single still is seconds of GPU work; the request is held open for the result.
+UPSCALING_IMAGE_TIMEOUT = 300  # seconds
+
+IMAGE_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+}
+
+
+def _image_input_dir() -> Path:
+    """Staging directory for uploaded images awaiting upscale."""
+    path = _get_upload_dir() / "input" / "images"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _image_output_dir() -> Path:
+    """Directory the plugin writes upscaled stills into."""
+    path = _get_upload_dir() / "output" / "images"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _stage_image(file) -> Path:
+    """Save one uploaded image into the staging directory.
+
+    The stored name is derived from ``secure_filename`` plus a short random
+    token, so nothing the caller sends reaches the filesystem as a path and two
+    uploads of the same name never collide. Raises ValueError on a rejected file.
+    """
+    if not file.filename:
+        raise ValueError("No filename")
+    safe_name = secure_filename(file.filename)
+    ext = os.path.splitext(safe_name)[1].lower()
+    if ext not in ALLOWED_IMAGE_EXTENSIONS:
+        raise ValueError(f"Unsupported image type: {ext or file.filename}")
+    stem = os.path.splitext(safe_name)[0] or "image"
+    staged = _image_input_dir() / f"{stem}_{uuid.uuid4().hex[:8]}{ext}"
+    file.save(str(staged))
+    return staged
+
+
+def _image_options_from_form(form) -> dict:
+    """Collect the shared upscale knobs out of a multipart form."""
+    options = {}
+    model = form.get("model")
+    if model:
+        options["model"] = model
+    scale = form.get("scale")
+    if scale:
+        options["scale"] = float(scale)
+    sharpen = form.get("sharpen")
+    if sharpen is not None:
+        options["sharpen"] = float(sharpen)
+    denoise = form.get("denoise_strength")
+    if denoise is not None:
+        options["denoise_strength"] = float(denoise)
+    for flag in ("two_pass", "face_enhance"):
+        value = form.get(flag)
+        if value and value.lower() in ("true", "1", "yes"):
+            options[flag] = True
+    return options
+
+
+@upscaling_bp.route("/upscale/image", methods=["POST"])
+def upscale_image():
+    """Upload one image and upscale it synchronously.
+
+    A still finishes in seconds, so this returns the finished file rather than
+    a job id; batches go through ``/upscale/images`` and the job queue instead.
+    """
+    if "file" not in flask_request.files:
+        return error_response("No file uploaded", 400)
+
+    try:
+        staged = _stage_image(flask_request.files["file"])
+    except ValueError as exc:
+        return error_response(str(exc), 400)
+
+    output_path = _image_output_dir() / f"{staged.stem}_upscaled.png"
+    payload = {
+        "input_path": str(staged),
+        "output_path": str(output_path),
+        **_image_options_from_form(flask_request.form),
+    }
+
+    data, status = _proxy_post("/upscale/image", payload, timeout=UPSCALING_IMAGE_TIMEOUT)
+    if status == 200:
+        return success_response(
+            data={
+                "output_file": output_path.name,
+                "url": f"/api/upscaling/output/image/{output_path.name}",
+            },
+            message="Image upscaled",
+        )
+    return error_response(_proxy_error(data, "Failed to upscale image"), status)
+
+
+@upscaling_bp.route("/upscale/images", methods=["POST"])
+def upscale_images():
+    """Upload N images and queue them as one job on the plugin's GPU worker."""
+    files = flask_request.files.getlist("files")
+    if not files:
+        return error_response("No files uploaded", 400)
+
+    staged = []
+    rejected = []
+    for file in files:
+        try:
+            staged.append(_stage_image(file))
+        except ValueError as exc:
+            rejected.append(str(exc))
+
+    if not staged:
+        return error_response(rejected[0] if rejected else "No usable images", 400)
+
+    payload = {
+        "inputs": [str(p) for p in staged],
+        "output_dir": str(_image_output_dir()),
+        "suffix": "upscaled",
+        **_image_options_from_form(flask_request.form),
+    }
+
+    data, status = _proxy_post("/upscale/images", payload, timeout=30)
+    if status in (200, 202):
+        return success_response(
+            data={
+                **(data if isinstance(data, dict) else {}),
+                "queued": len(staged),
+                "rejected": rejected,
+            },
+            message=f"Queued {len(staged)} image(s) for upscaling",
+        )
+    return error_response(_proxy_error(data, "Failed to submit image batch"), status)
+
+
+@upscaling_bp.route("/output/image/<path:filename>", methods=["GET"])
+def serve_image_output(filename):
+    """Serve an upscaled still out of the plugin's image output directory."""
+    output_dir = _image_output_dir()
+    file_path = _contained_file(output_dir, filename)
+    if file_path is None:
+        return error_response("Invalid path", 400)
+    if not file_path.exists():
+        return error_response("File not found", 404)
+
+    mimetype = IMAGE_MIME_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
+    return send_file(str(file_path), mimetype=mimetype)
+
 
 
 @upscaling_bp.route("/upload", methods=["POST"])
@@ -360,12 +549,9 @@ def upload_and_upscale():
 def serve_output(filename):
     """Serve an upscaled output video."""
     output_dir = _get_upload_dir() / "output"
-    file_path = (output_dir / filename).resolve()
-    try:
-        file_path.relative_to(output_dir.resolve())
-    except ValueError:
+    file_path = _contained_file(output_dir, filename)
+    if file_path is None:
         return error_response("Invalid path", 400)
-
     if not file_path.exists():
         return error_response("File not found", 404)
 

--- a/backend/services/comfyui_video_generator.py
+++ b/backend/services/comfyui_video_generator.py
@@ -1,12 +1,14 @@
 
 import logging
 import json
+import threading
 import subprocess
 import time
 import os
 import shutil
 import urllib.request
 import urllib.parse
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -135,6 +137,32 @@ class VideoGenerationResult:
 
 
 class ComfyUIVideoGenerator(ComfyUIVideoWorkflowMixin):
+
+    # Prompt ids this process has queued, newest last. Class-level because
+    # generate and cancel do not always hold the same generator: the batch
+    # runner uses the module singleton, the router keeps its own instance and
+    # replaces it on every get_active_generator(). Bounded, and a stale id
+    # costs nothing — ComfyUI matches it against what is actually running.
+    _queued_prompts: deque = deque(maxlen=16)
+    _queued_prompts_lock = threading.Lock()
+
+    @classmethod
+    def _track_prompt(cls, prompt_id: str) -> None:
+        with cls._queued_prompts_lock:
+            cls._queued_prompts.append(prompt_id)
+
+    @classmethod
+    def _forget_prompt(cls, prompt_id: str) -> None:
+        with cls._queued_prompts_lock:
+            try:
+                cls._queued_prompts.remove(prompt_id)
+            except ValueError:
+                pass
+
+    @classmethod
+    def _known_prompts(cls) -> List[str]:
+        with cls._queued_prompts_lock:
+            return list(cls._queued_prompts)
 
     def __init__(self):
         project_root = Path(__file__).parent.parent.parent
@@ -526,23 +554,55 @@ class ComfyUIVideoGenerator(ComfyUIVideoWorkflowMixin):
 
 
 
-    def interrupt(self) -> bool:
-        """Force-stop whatever ComfyUI is currently sampling.
+    def interrupt(self, prompt_id: Optional[str] = None) -> bool:
+        """Stop the named prompt, or every prompt this process queued.
 
-        Yells "ABORT!" at the kitchen — ComfyUI bails on the current sampler,
-        history gets a partial entry, and our wait loop returns.
+        ComfyUI is a shared sidecar: a bare ``/interrupt`` stops whatever is
+        sampling no matter who queued it, and ``/queue {"clear": true}`` drops
+        other clients' pending work with it. Both are scoped here — ComfyUI
+        matches the id against what is actually running and no-ops otherwise,
+        so a stale id is free.
+
+        Falls back to the unscoped interrupt when this process queued nothing
+        it knows of, which is how a cancel raised in Flask still reaches a clip
+        queued by the Celery worker. The fallback skips the queue clear, and
+        goes away once cancellation is a flag both processes can see.
         """
-        try:
-            requests.post(f"{self.comfy_url}/interrupt", timeout=5)
+        targets = [prompt_id] if prompt_id else self._known_prompts()
+        if not targets:
+            return self._interrupt_unscoped()
+
+        acked = False
+        for pid in targets:
+            try:
+                requests.post(
+                    f"{self.comfy_url}/interrupt",
+                    json={"prompt_id": pid},
+                    timeout=5,
+                )
+                acked = True
+            except Exception as e:
+                logger.warning(f"Failed to interrupt ComfyUI prompt {pid}: {e}")
+                continue
             try:
                 requests.post(
                     f"{self.comfy_url}/queue",
-                    json={"clear": True},
+                    json={"delete": [pid]},
                     timeout=5,
                 )
-            except Exception as clear_err:
-                logger.debug(f"Queue clear failed (non-fatal): {clear_err}")
-            logger.info("Sent interrupt + queue-clear to ComfyUI")
+            except Exception as delete_err:
+                logger.debug(f"Queue delete for {pid} failed (non-fatal): {delete_err}")
+            self._forget_prompt(pid)
+
+        if acked:
+            logger.info(f"Sent scoped interrupt to ComfyUI for {len(targets)} prompt(s)")
+        return acked
+
+    def _interrupt_unscoped(self) -> bool:
+        """Stop whatever ComfyUI is sampling, whoever queued it."""
+        try:
+            requests.post(f"{self.comfy_url}/interrupt", timeout=5)
+            logger.info("Sent unscoped interrupt to ComfyUI (no prompt of ours tracked)")
             return True
         except Exception as e:
             logger.warning(f"Failed to interrupt ComfyUI: {e}")
@@ -565,6 +625,8 @@ class ComfyUIVideoGenerator(ComfyUIVideoWorkflowMixin):
 
             result = response.json()
             prompt_id = result.get("prompt_id")
+            if prompt_id:
+                self._track_prompt(prompt_id)
             logger.info(f"Queued workflow in ComfyUI: {prompt_id}")
             return prompt_id
 
@@ -1585,6 +1647,7 @@ class ComfyUIVideoGenerator(ComfyUIVideoWorkflowMixin):
             outputs = self._wait_for_completion(
                 prompt_id, timeout=gen_timeout, hard_ceiling_s=hard_ceiling
             )
+            self._forget_prompt(prompt_id)
             progress_bridge.stop()  # /history poll owns completion; bridge is done
 
             if not outputs:

--- a/backend/services/video_generation_router.py
+++ b/backend/services/video_generation_router.py
@@ -125,16 +125,18 @@ class VideoGenerationRouter:
             "ComfyUI is not running and Offline generator is not installed."
         )
 
-    def interrupt(self) -> bool:
+    def interrupt(self, prompt_id: Optional[str] = None) -> bool:
         """Tell whichever backend is currently sampling to abort.
 
         Returns True if a backend acknowledged the interrupt. ComfyUI honours
         this immediately; the offline generator can only stop between items.
+        ``prompt_id`` narrows it to one ComfyUI prompt; without it every prompt
+        this process queued is stopped.
         """
         if self._check_comfyui():
             try:
                 comfy = self._get_comfyui()
-                return comfy.interrupt()
+                return comfy.interrupt(prompt_id)
             except Exception as e:
                 logger.warning(f"Router interrupt to ComfyUI failed: {e}")
                 return False

--- a/backend/tests/api/test_upscaling_image_api.py
+++ b/backend/tests/api/test_upscaling_image_api.py
@@ -1,0 +1,174 @@
+"""Tests for the image-upscale proxy routes.
+
+Covers the staging rules for uploaded images (nothing the caller sends reaches
+the filesystem as a path), the containment of the output route, and the payload
+the proxy hands to the plugin.
+"""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+import backend.api.upscaling_api as m
+from backend.api.upscaling_api import _contained_file
+
+
+# ---- _contained_file -------------------------------------------------------
+def test_contained_file_accepts_plain_name(tmp_path):
+    (tmp_path / "still_upscaled.png").write_bytes(b"\x89PNG")
+    assert _contained_file(tmp_path, "still_upscaled.png") is not None
+
+
+@pytest.mark.parametrize("bad", ["", ".", "..", "../x", "a/b", "a\\b", "/etc/passwd", "x\x00y"])
+def test_contained_file_rejects_escapes(tmp_path, bad):
+    assert _contained_file(tmp_path, bad) is None
+
+
+def test_contained_file_rejects_symlink_escape(tmp_path):
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    images = tmp_path / "images"
+    images.mkdir()
+    os.symlink(outside, images / "link.png")
+    assert _contained_file(images, "link.png") is None
+
+
+# ---- routes ----------------------------------------------------------------
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "_get_upload_dir", lambda: tmp_path)
+    (tmp_path / "secret.txt").write_text("TOPSECRET-CONTENT-7731")
+
+    app = Flask(__name__)
+    app.register_blueprint(m.upscaling_bp)
+    return app.test_client(), tmp_path
+
+
+def _png(name="shot.png"):
+    return (io.BytesIO(b"\x89PNG\r\n\x1a\n"), name)
+
+
+def test_single_upscale_stages_upload_and_returns_output_url(client, monkeypatch):
+    c, root = client
+    captured = {}
+
+    def fake_post(path, payload, timeout=None):
+        captured["path"] = path
+        captured["payload"] = payload
+        Path(payload["output_path"]).write_bytes(b"\x89PNG")
+        return {"status": "completed", "output_path": payload["output_path"]}, 200
+
+    monkeypatch.setattr(m, "_proxy_post", fake_post)
+
+    resp = c.post(
+        "/api/upscaling/upscale/image",
+        data={"file": _png(), "model": "4x-UltraSharp", "scale": "2"},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()["data"]
+    assert body["url"] == f"/api/upscaling/output/image/{body['output_file']}"
+
+    assert captured["path"] == "/upscale/image"
+    payload = captured["payload"]
+    assert payload["model"] == "4x-UltraSharp"
+    assert payload["scale"] == 2.0
+    # Both sides of the job stay inside the plugin's own directories.
+    assert Path(payload["input_path"]).parent == (root / "input" / "images")
+    assert Path(payload["output_path"]).parent == (root / "output" / "images")
+
+
+def test_single_upscale_rejects_non_image(client):
+    c, _ = client
+    resp = c.post(
+        "/api/upscaling/upscale/image",
+        data={"file": (io.BytesIO(b"MZ"), "payload.exe")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 400
+
+
+def test_upload_name_cannot_traverse(client, monkeypatch):
+    c, root = client
+    monkeypatch.setattr(
+        m, "_proxy_post",
+        lambda path, payload, timeout=None: ({"status": "completed"}, 200),
+    )
+    resp = c.post(
+        "/api/upscaling/upscale/image",
+        data={"file": (io.BytesIO(b"\x89PNG"), "../../secret.png")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    staged = list((root / "input" / "images").iterdir())
+    assert len(staged) == 1
+    assert staged[0].parent == (root / "input" / "images")
+    assert (root / "secret.txt").read_text() == "TOPSECRET-CONTENT-7731"
+
+
+def test_batch_upscale_submits_one_job_for_every_file(client, monkeypatch):
+    c, root = client
+    captured = {}
+
+    def fake_post(path, payload, timeout=None):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"job_id": "abc123", "status": "pending"}, 202
+
+    monkeypatch.setattr(m, "_proxy_post", fake_post)
+
+    resp = c.post(
+        "/api/upscaling/upscale/images",
+        data={"files": [_png("a.png"), _png("b.jpg")]},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["data"]["queued"] == 2
+
+    assert captured["path"] == "/upscale/images"
+    payload = captured["payload"]
+    assert len(payload["inputs"]) == 2
+    assert payload["output_dir"] == str(root / "output" / "images")
+
+
+def test_batch_upscale_reports_rejected_files(client, monkeypatch):
+    c, _ = client
+    monkeypatch.setattr(
+        m, "_proxy_post",
+        lambda path, payload, timeout=None: ({"job_id": "abc123"}, 202),
+    )
+    resp = c.post(
+        "/api/upscaling/upscale/images",
+        data={"files": [_png("a.png"), (io.BytesIO(b"MZ"), "payload.exe")]},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()["data"]
+    assert data["queued"] == 1
+    assert len(data["rejected"]) == 1
+
+
+def test_batch_upscale_without_usable_files_is_rejected(client):
+    c, _ = client
+    resp = c.post(
+        "/api/upscaling/upscale/images",
+        data={"files": [(io.BytesIO(b"MZ"), "payload.exe")]},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 400
+
+
+def test_serve_image_output_is_contained(client):
+    c, root = client
+    out = root / "output" / "images"
+    out.mkdir(parents=True)
+    (out / "ok.png").write_bytes(b"\x89PNG")
+
+    assert c.get("/api/upscaling/output/image/ok.png").status_code == 200
+    escape = c.get("/api/upscaling/output/image/..%252F..%252Fsecret.txt")
+    assert escape.status_code == 404
+    assert b"TOPSECRET-CONTENT-7731" not in escape.data

--- a/backend/tests/services/test_comfyui_interrupt_scope.py
+++ b/backend/tests/services/test_comfyui_interrupt_scope.py
@@ -1,0 +1,147 @@
+"""Cancel must stop this process's ComfyUI prompts and nobody else's.
+
+ComfyUI is a shared sidecar: an unscoped ``/interrupt`` stops whatever is
+sampling regardless of who queued it, and ``/queue {"clear": true}`` drops
+other clients' pending work with it. These tests pin the scoped behaviour and
+the one case that still falls back.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.comfyui_video_generator import ComfyUIVideoGenerator
+
+
+@pytest.fixture
+def gen():
+    """A generator with no real ComfyUI behind it and an empty prompt registry."""
+    with ComfyUIVideoGenerator._queued_prompts_lock:
+        ComfyUIVideoGenerator._queued_prompts.clear()
+    instance = ComfyUIVideoGenerator.__new__(ComfyUIVideoGenerator)
+    instance.comfy_url = "http://comfy.test"
+    yield instance
+    with ComfyUIVideoGenerator._queued_prompts_lock:
+        ComfyUIVideoGenerator._queued_prompts.clear()
+
+
+def _calls(post: MagicMock):
+    """(url, json-body) for every POST the code made."""
+    return [(c.args[0], c.kwargs.get("json")) for c in post.call_args_list]
+
+
+def test_interrupt_targets_only_our_prompts(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        assert gen.interrupt() is True
+
+    assert _calls(post) == [
+        ("http://comfy.test/interrupt", {"prompt_id": "ours-1"}),
+        ("http://comfy.test/queue", {"delete": ["ours-1"]}),
+    ]
+
+
+def test_interrupt_never_clears_the_shared_queue(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        gen.interrupt()
+
+    bodies = [body for _url, body in _calls(post)]
+    assert {"clear": True} not in bodies
+
+
+def test_interrupt_accepts_an_explicit_prompt_id(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+    ComfyUIVideoGenerator._track_prompt("ours-2")
+
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        assert gen.interrupt("ours-2") is True
+
+    assert _calls(post) == [
+        ("http://comfy.test/interrupt", {"prompt_id": "ours-2"}),
+        ("http://comfy.test/queue", {"delete": ["ours-2"]}),
+    ]
+    # The one we did not name is still ours to cancel later.
+    assert ComfyUIVideoGenerator._known_prompts() == ["ours-1"]
+
+
+def test_interrupt_falls_back_to_unscoped_when_nothing_is_tracked(gen):
+    """A cancel raised in Flask for a clip the Celery worker queued."""
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        assert gen.interrupt() is True
+
+    # Unscoped stop, but still no queue clear — other clients keep their pending work.
+    assert _calls(post) == [("http://comfy.test/interrupt", None)]
+
+
+def test_a_completed_prompt_is_no_longer_a_target(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+    ComfyUIVideoGenerator._forget_prompt("ours-1")
+
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        gen.interrupt()
+
+    assert _calls(post) == [("http://comfy.test/interrupt", None)]
+
+
+def test_interrupt_reports_failure_when_comfyui_is_unreachable(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+
+    with patch(
+        "backend.services.comfyui_video_generator.requests.post",
+        side_effect=OSError("connection refused"),
+    ):
+        assert gen.interrupt() is False
+
+
+def test_registry_is_shared_across_instances(gen):
+    """The router replaces its generator on every get_active_generator()."""
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+
+    other = ComfyUIVideoGenerator.__new__(ComfyUIVideoGenerator)
+    other.comfy_url = "http://comfy.test"
+
+    with patch("backend.services.comfyui_video_generator.requests.post") as post:
+        assert other.interrupt() is True
+
+    assert ("http://comfy.test/interrupt", {"prompt_id": "ours-1"}) in _calls(post)
+
+
+def test_queue_delete_failure_does_not_sink_the_interrupt(gen):
+    ComfyUIVideoGenerator._track_prompt("ours-1")
+
+    def post(url, **_kwargs):
+        if url.endswith("/queue"):
+            raise OSError("queue endpoint angry")
+        return MagicMock()
+
+    with patch("backend.services.comfyui_video_generator.requests.post", side_effect=post):
+        assert gen.interrupt() is True
+
+
+def test_queueing_a_workflow_registers_it_for_cancel(gen):
+    gen._last_queue_error = None
+    response = MagicMock()
+    response.json.return_value = {"prompt_id": "fresh-1"}
+    response.raise_for_status.return_value = None
+
+    with patch("backend.services.comfyui_video_generator.requests.post", return_value=response):
+        assert gen._queue_prompt({"1": {}}) == "fresh-1"
+
+    assert ComfyUIVideoGenerator._known_prompts() == ["fresh-1"]
+
+
+def test_a_refused_queue_registers_nothing(gen):
+    gen._last_queue_error = None
+    response = MagicMock()
+    response.json.return_value = {}
+    response.raise_for_status.return_value = None
+
+    with patch("backend.services.comfyui_video_generator.requests.post", return_value=response):
+        gen._queue_prompt({"1": {}})
+
+    assert ComfyUIVideoGenerator._known_prompts() == []
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,7 +41,6 @@ const UploadPage = lazy(() => import("./pages/UploadPage"));
 const TrainingPage = lazy(() => import("./pages/TrainingPage"));
 const ImagesPage = lazy(() => import("./pages/ImagesPage"));
 const AudioFoundryPage = lazy(() => import("./pages/AudioFoundryPage"));
-const VideoGeneratorPage = lazy(() => import("./pages/VideoGeneratorPage"));
 const VideoTextOverlayPage = lazy(() => import("./pages/VideoTextOverlayPage"));
 const VideoEditorPage = lazy(() => import("./pages/VideoEditorPage"));
 const BulkImportDocumentsPage = lazy(() => import("./pages/BulkImportDocumentsPage"));
@@ -337,7 +336,27 @@ const AppContainer = () => {
                         element={
                           <AppLayout>
                             <ErrorBoundary>
-                              <VideoGeneratorPage />
+                              <ImagesPage />
+                            </ErrorBoundary>
+                          </AppLayout>
+                        }
+                      />
+                      <Route
+                        path="/infographic"
+                        element={
+                          <AppLayout>
+                            <ErrorBoundary>
+                              <ImagesPage />
+                            </ErrorBoundary>
+                          </AppLayout>
+                        }
+                      />
+                      <Route
+                        path="/upscaling"
+                        element={
+                          <AppLayout>
+                            <ErrorBoundary>
+                              <ImagesPage />
                             </ErrorBoundary>
                           </AppLayout>
                         }

--- a/frontend/src/api/upscalingService.js
+++ b/frontend/src/api/upscalingService.js
@@ -43,6 +43,43 @@ export const uploadAndUpscale = async (file, options = {}) => {
   return handleResponse(response);
 };
 
+const appendImageOptions = (formData, options) => {
+  if (options.model) formData.append("model", options.model);
+  if (options.scale) formData.append("scale", String(options.scale));
+  if (options.sharpen !== undefined) formData.append("sharpen", String(options.sharpen));
+  if (options.denoise_strength !== undefined) {
+    formData.append("denoise_strength", String(options.denoise_strength));
+  }
+  if (options.two_pass) formData.append("two_pass", "true");
+  if (options.face_enhance) formData.append("face_enhance", "true");
+};
+
+// Single still — the backend holds the request open and returns the finished file.
+export const upscaleImage = async (file, options = {}) => {
+  const formData = new FormData();
+  formData.append("file", file);
+  appendImageOptions(formData, options);
+
+  const response = await fetch(`${BASE_URL}/upscale/image`, {
+    method: "POST",
+    body: formData,
+  });
+  return handleResponse(response);
+};
+
+// Batch — one queued job covering every file, tracked alongside video jobs.
+export const upscaleImages = async (files, options = {}) => {
+  const formData = new FormData();
+  files.forEach((file) => formData.append("files", file));
+  appendImageOptions(formData, options);
+
+  const response = await fetch(`${BASE_URL}/upscale/images`, {
+    method: "POST",
+    body: formData,
+  });
+  return handleResponse(response);
+};
+
 export const previewImage = async (blob, options = {}) => {
   const formData = new FormData();
   formData.append("file", blob, "preview.png");
@@ -113,6 +150,8 @@ export default {
   getModels,
   downloadModel,
   uploadAndUpscale,
+  upscaleImage,
+  upscaleImages,
   upscaleVideo,
   listJobs,
   getJob,

--- a/frontend/src/components/systemmap/SystemMapCanvas.jsx
+++ b/frontend/src/components/systemmap/SystemMapCanvas.jsx
@@ -7,8 +7,9 @@
 // keep it cohesive), lifecycle drives alpha, importer count drives size.
 //
 // Wheel zooms. Drag pans (left, middle, or shift+left — all the same).
-// R resets the view. The canvas itself is transparent — the page
-// background shows through, so theme changes propagate automatically.
+// R resets the view. The canvas itself is transparent — the page background
+// shows through — and every stroke comes from ./palette, so light and dark
+// themes both get ink with enough contrast to read.
 //
 // Inputs: a SystemMap dict (see backend/services/system_mapper).
 // Notifies parent of hover/click via onNodeHover / onNodeClick.
@@ -25,6 +26,7 @@ import {
   forceY,
 } from "d3-force";
 import { pathToSection, moduleNameToPath } from "./pathUtils";
+import { createMapPalette, useMapPalette } from "./palette";
 
 // ────────────────────────────────────────────────────────────────────────
 // Color palette
@@ -74,21 +76,11 @@ const LIFECYCLE = {
   skip:        { alpha: 0.20, sat: 20, light: 65 },
 };
 
-const PALETTE = {
-  // Canvas is transparent — page bg shows through, so we never paint our
-  // own background. Edges and effects only.
-  edge: "rgba(168, 216, 255, 0.18)",
-  cycleEdge: "rgba(255, 110, 110, 0.55)",
-  highFinding: "rgba(255, 170, 80, 0.95)",
-  mediumFinding: "rgba(255, 220, 130, 0.7)",
-};
-
-// HSLA string from a hue with lifecycle bias.
-function nodeColor(section, lifecycle, alphaMult = 1) {
+// HSLA string from a hue with lifecycle bias, toned for the active theme.
+function nodeColor(palette, section, lifecycle, alphaMult = 1) {
   const hue = SECTION_HUE[section] ?? SECTION_HUE.other;
   const lc = LIFECYCLE[lifecycle] || LIFECYCLE.active;
-  const a = lc.alpha * alphaMult;
-  return `hsla(${hue}, ${lc.sat}%, ${lc.light}%, ${a})`;
+  return palette.hue(hue, lc.sat, lc.light, lc.alpha * alphaMult);
 }
 
 // Higher-importer modules render bigger. Log-scaled, clamped.
@@ -327,8 +319,14 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
     highlightedPrefixes: null, // mirror of prop, read inside the render loop
     showGhostEndpoints: false, // mirror of prop (overlay toggle, default OFF)
     showToolGraph: false,      // mirror of prop (overlay toggle, default OFF)
+    palette: createMapPalette("dark"), // mirror of the theme palette
     pulseClockMs: performance.now(),
   });
+
+  const palette = useMapPalette();
+  useEffect(() => {
+    stateRef.current.palette = palette;
+  }, [palette]);
 
   // Reflect highlightedPrefixes into the ref so the render loop sees updates
   // without re-binding the loop on every prop change.
@@ -607,6 +605,7 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
     function tick(now) {
       const dt = Math.min(48, now - (st.pulseClockMs || now)) / 16.666;
       st.pulseClockMs = now;
+      const pal = st.palette;
 
       const w = st.width;
       const h = st.height;
@@ -654,9 +653,9 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
           if (!aIn && !bIn) alpha *= 0.18;
         }
         if (l.cycle) {
-          ctx.strokeStyle = `rgba(255, 110, 110, ${Math.max(0.18, alpha * 1.2)})`;
+          ctx.strokeStyle = pal.danger(Math.max(0.18, alpha * 1.2));
         } else {
-          ctx.strokeStyle = `rgba(168, 216, 255, ${alpha * 0.4})`;
+          ctx.strokeStyle = pal.ink(alpha * pal.edgeAlpha);
         }
         ctx.beginPath();
         ctx.moveTo(a.sx, a.sy);
@@ -670,7 +669,7 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
       if (st.showToolGraph && st.graph.toolEdges && st.graph.toolEdges.length) {
         ctx.save();
         ctx.setLineDash([4, 4]);
-        ctx.strokeStyle = "rgba(120, 220, 180, 0.35)";
+        ctx.strokeStyle = pal.ghost(0.35);
         ctx.lineWidth = 1;
         for (const te of st.graph.toolEdges) {
           const a = st.graph.nodeIndex[te.source];
@@ -706,19 +705,19 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
         if (inHl === false) alpha *= 0.22;       // fade non-matching when highlight active
         // (inHl === true or null → no penalty)
 
-        const baseColor = nodeColor(n.section, n.lifecycle, alpha);
+        const baseColor = nodeColor(pal, n.section, n.lifecycle, alpha);
 
         // Soft glow on pulse
         if (n.pulse > 0.05) {
           const glow = ctx.createRadialGradient(n.sx, n.sy, 0, n.sx, n.sy, r * 4);
           const glowColor =
             n.topSeverity === "high"
-              ? PALETTE.highFinding
+              ? pal.finding(0.95)
               : n.topSeverity === "medium"
-                ? PALETTE.mediumFinding
-                : "rgba(168, 216, 255, 0.55)";
+                ? pal.findingSoft(0.7)
+                : pal.ink(0.55);
           glow.addColorStop(0, glowColor);
-          glow.addColorStop(1, "rgba(168, 216, 255, 0)");
+          glow.addColorStop(1, pal.ink(0));
           ctx.globalAlpha = n.pulse * 0.5;
           ctx.fillStyle = glow;
           ctx.beginPath();
@@ -731,8 +730,8 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
         if (inHl === true) {
           const auraR = r * 3;
           const aura = ctx.createRadialGradient(n.sx, n.sy, 0, n.sx, n.sy, auraR);
-          aura.addColorStop(0, "rgba(255, 255, 255, 0.18)");
-          aura.addColorStop(1, "rgba(168, 216, 255, 0)");
+          aura.addColorStop(0, pal.halo(pal.haloAlpha));
+          aura.addColorStop(1, pal.ink(0));
           ctx.fillStyle = aura;
           ctx.beginPath();
           ctx.arc(n.sx, n.sy, auraR, 0, Math.PI * 2);
@@ -745,7 +744,7 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
         if (st.showGhostEndpoints && n.isGhostEndpoint) {
           ctx.save();
           ctx.setLineDash([3, 3]);
-          ctx.strokeStyle = "rgba(255, 170, 80, 0.9)";
+          ctx.strokeStyle = pal.finding(0.9);
           ctx.lineWidth = 1.5;
           ctx.beginPath();
           ctx.arc(n.sx, n.sy, r + 4, 0, Math.PI * 2);
@@ -756,7 +755,7 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
         // Tool-node overlay ring (default OFF). Solid green ring marking a
         // module a registered LLM tool resolves to.
         if (st.showToolGraph && n.isToolNode) {
-          ctx.strokeStyle = "rgba(120, 220, 180, 0.85)";
+          ctx.strokeStyle = pal.ghost(0.85);
           ctx.lineWidth = 1.5;
           ctx.beginPath();
           ctx.arc(n.sx, n.sy, r + 2.5, 0, Math.PI * 2);
@@ -765,7 +764,7 @@ const SystemMapCanvas = forwardRef(function SystemMapCanvas(
 
         // Hover ring
         if (st.hover === n.id) {
-          ctx.strokeStyle = `rgba(255, 255, 255, 0.75)`;
+          ctx.strokeStyle = pal.halo(pal.ringAlpha);
           ctx.lineWidth = 1;
           ctx.beginPath();
           ctx.arc(n.sx, n.sy, r + 3, 0, Math.PI * 2);

--- a/frontend/src/components/systemmap/__tests__/palette.test.js
+++ b/frontend/src/components/systemmap/__tests__/palette.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { createMapPalette } from "../palette";
+
+const PAGE_BG = { light: [250, 250, 250], dark: [18, 18, 18] };
+
+function parseRgba(value) {
+  const [r, g, b, alpha] = value.match(/[0-9.]+/g).map(Number);
+  return { rgb: [r, g, b], alpha };
+}
+
+function composite([r, g, b], alpha, bg) {
+  return [r, g, b].map((channel, i) => channel * alpha + bg[i] * (1 - alpha));
+}
+
+function luminance(rgb) {
+  const [r, g, b] = rgb.map((channel) => {
+    const c = channel / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(mode, alpha) {
+  const bg = PAGE_BG[mode];
+  const { rgb, alpha: applied } = parseRgba(createMapPalette(mode).ink(alpha));
+  const lFg = luminance(composite(rgb, applied, bg));
+  const lBg = luminance(bg);
+  const [hi, lo] = lFg > lBg ? [lFg, lBg] : [lBg, lFg];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("system map palette", () => {
+  // The map was authored against the dark theme; the light theme is only
+  // "fixed" if its ink is at least as readable at every level the page uses.
+  it.each([0.4, 0.55, 0.7, 0.85, 0.95])("light ink at %s reads at least as well as dark", (alpha) => {
+    expect(contrast("light", alpha)).toBeGreaterThanOrEqual(contrast("dark", alpha));
+  });
+
+  it("clears AA for body-weight ink", () => {
+    expect(contrast("light", 0.85)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast("light", 0.95)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps faint washes faint", () => {
+    expect(parseRgba(createMapPalette("light").ink(0.04)).alpha).toBeLessThan(0.2);
+  });
+
+  it("keeps a fully transparent gradient stop transparent", () => {
+    // The canvas fades glows out with ink(0); a lifted alpha would leave a halo.
+    expect(parseRgba(createMapPalette("light").ink(0)).alpha).toBe(0);
+    expect(parseRgba(createMapPalette("dark").ink(0)).alpha).toBe(0);
+  });
+
+  it("brings section hues down the lightness scale for a light page", () => {
+    const [, , lightness] = createMapPalette("light").hue(207, 75, 78, 0.85).match(/[0-9.]+/g).map(Number);
+    const [, , darkLightness] = createMapPalette("dark").hue(207, 75, 78, 0.85).match(/[0-9.]+/g).map(Number);
+    expect(lightness).toBeLessThan(50);
+    expect(darkLightness).toBe(78);
+  });
+});

--- a/frontend/src/components/systemmap/palette.js
+++ b/frontend/src/components/systemmap/palette.js
@@ -1,0 +1,124 @@
+// Theme-aware palette for the system map.
+//
+// The map paints ink over the page background rather than over a surface of
+// its own, so every colour here is an "r, g, b" triplet plus an alpha chosen
+// at the call site. Only the triplets and the node lightness flip between
+// modes; alphas keep their meaning in both (low = faint wash, high = solid).
+
+import { useMemo } from "react";
+import { useTheme } from "@mui/material";
+
+const rgba = (triplet, alpha) => `rgba(${triplet}, ${alpha})`;
+
+// Compositing toward black gains contrast faster than toward white, so these
+// alphas need lifting on a light page. 0 stays 0: canvas gradients fade out
+// through ink(0) and a lifted alpha would leave a halo.
+const boostAlpha = (alpha) => (alpha === 0 ? 0 : Math.min(1, alpha * 1.2 + 0.06));
+
+const TRIPLETS = {
+  dark: {
+    ink: "168, 216, 255",
+    danger: "255, 110, 110",
+    warn: "255, 184, 77",
+    ghost: "120, 220, 180",
+    finding: "255, 170, 80",
+    findingSoft: "255, 220, 130",
+    halo: "255, 255, 255",
+  },
+  light: {
+    ink: "13, 38, 66",
+    danger: "198, 40, 40",
+    warn: "176, 96, 0",
+    ghost: "13, 118, 90",
+    finding: "199, 106, 0",
+    findingSoft: "173, 128, 0",
+    halo: "13, 38, 66",
+  },
+};
+
+const SURFACES = {
+  dark: {
+    panelBg: "rgba(14, 22, 40, 0.10)",
+    fieldBg: "rgba(20, 30, 50, 0.6)",
+    tooltipBg: "rgba(20, 40, 60, 0.95)",
+    tooltipInk: "rgba(200, 230, 255, 0.95)",
+    errorBg: "rgba(255, 100, 100, 0.15)",
+    errorInk: "rgba(255, 200, 200, 0.95)",
+    errorBorder: "rgba(255, 100, 100, 0.3)",
+    haloAlpha: 0.18,
+    ringAlpha: 0.75,
+    // Multiplier on the distance-derived edge alpha in the canvas.
+    edgeAlpha: 0.4,
+  },
+  light: {
+    panelBg: "rgba(255, 255, 255, 0.72)",
+    fieldBg: "rgba(255, 255, 255, 0.9)",
+    tooltipBg: "rgba(255, 255, 255, 0.98)",
+    tooltipInk: "rgba(13, 38, 66, 0.95)",
+    errorBg: "rgba(198, 40, 40, 0.10)",
+    errorInk: "rgba(140, 20, 20, 0.95)",
+    errorBorder: "rgba(198, 40, 40, 0.35)",
+    haloAlpha: 0.14,
+    ringAlpha: 0.85,
+    edgeAlpha: 0.24,
+  },
+};
+
+// Section hues are authored against the dark map, where nodes sit at ~78%
+// lightness. On a light page the same hue has to come down the scale and up in
+// saturation to stay legible, so both the canvas and the legend route their
+// hues through this one transform.
+function toneFor(isLight) {
+  return (saturation, lightness, alpha) =>
+    isLight
+      ? {
+          saturation: Math.min(90, saturation + 12),
+          lightness: Math.max(26, lightness - 36),
+          alpha: Math.min(1, alpha * 1.15 + 0.08),
+        }
+      : { saturation, lightness, alpha };
+}
+
+export function createMapPalette(mode) {
+  const isLight = mode === "light";
+  const triplets = isLight ? TRIPLETS.light : TRIPLETS.dark;
+  const surfaces = isLight ? SURFACES.light : SURFACES.dark;
+  const tone = toneFor(isLight);
+
+  const a = isLight ? boostAlpha : (alpha) => alpha;
+
+  return {
+    isLight,
+    ...surfaces,
+    inkRGB: triplets.ink,
+    dangerRGB: triplets.danger,
+    warnRGB: triplets.warn,
+    ghostRGB: triplets.ghost,
+    haloRGB: triplets.halo,
+    ink: (alpha) => rgba(triplets.ink, a(alpha)),
+    danger: (alpha) => rgba(triplets.danger, a(alpha)),
+    warn: (alpha) => rgba(triplets.warn, a(alpha)),
+    ghost: (alpha) => rgba(triplets.ghost, a(alpha)),
+    finding: (alpha) => rgba(triplets.finding, a(alpha)),
+    findingSoft: (alpha) => rgba(triplets.findingSoft, a(alpha)),
+    halo: (alpha) => rgba(triplets.halo, a(alpha)),
+    severity: {
+      high: rgba(triplets.danger, 1),
+      medium: rgba(triplets.warn, 1),
+      low: rgba(triplets.ink, a(0.7)),
+      info: rgba(triplets.ink, a(0.4)),
+    },
+    boostAlpha: a,
+    /** Section hue, expressed in dark-map terms and remapped for the mode. */
+    hue: (h, saturation, lightness, alpha = 1) => {
+      const t = tone(saturation, lightness, alpha);
+      return `hsla(${h}, ${t.saturation}%, ${t.lightness}%, ${t.alpha})`;
+    },
+    tone,
+  };
+}
+
+export function useMapPalette() {
+  const theme = useTheme();
+  return useMemo(() => createMapPalette(theme.palette.mode), [theme.palette.mode]);
+}

--- a/frontend/src/config/brand.jsx
+++ b/frontend/src/config/brand.jsx
@@ -38,6 +38,8 @@ import BubbleChartIcon from "@mui/icons-material/BubbleChart";
 import ScienceIcon from "@mui/icons-material/Science";
 import PhotoLibraryIcon from "@mui/icons-material/PhotoLibrary";
 import VideoCameraBackIcon from "@mui/icons-material/VideoCameraBack";
+import InsertChartOutlinedIcon from "@mui/icons-material/InsertChartOutlined";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 
 const env = import.meta.env;
 
@@ -70,6 +72,8 @@ const navGroups = [
       { text: "Video Editor", icon: <MovieFilterIcon />, path: "/video-editor" },
       { text: "Video Gen", icon: <VideoCameraBackIcon />, path: "/video" },
       { text: "Image Gen", icon: <ImageIcon />, path: "/batch-images" },
+      { text: "Infographic", icon: <InsertChartOutlinedIcon />, path: "/infographic" },
+      { text: "Upscaling", icon: <AutoFixHighIcon />, path: "/upscaling" },
       { text: "Audio Studio", icon: <GraphicEqIcon />, path: "/audio" },
       { text: "Video Text", icon: <TextFieldsIcon />, path: "/video-text-overlay" },
     ],

--- a/frontend/src/constants/__tests__/mediaTabs.test.js
+++ b/frontend/src/constants/__tests__/mediaTabs.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { MEDIA_TABS, MEDIA_LIBRARY_TAB, mediaTabIndexForPath } from "../mediaTabs";
+
+describe("mediaTabIndexForPath", () => {
+  it("maps every tab route to its own index", () => {
+    MEDIA_TABS.forEach((tab, index) => {
+      expect(mediaTabIndexForPath(tab.path)).toBe(index);
+    });
+  });
+
+  it("does not let /images swallow /batch-images", () => {
+    expect(mediaTabIndexForPath("/batch-images")).toBe(
+      MEDIA_TABS.findIndex((t) => t.path === "/batch-images"),
+    );
+  });
+
+  it("keeps nested routes on their tab", () => {
+    expect(mediaTabIndexForPath("/video/abc")).toBe(
+      MEDIA_TABS.findIndex((t) => t.path === "/video"),
+    );
+  });
+
+  it("falls back to the media library for anything else", () => {
+    expect(mediaTabIndexForPath("/settings")).toBe(MEDIA_LIBRARY_TAB);
+  });
+});

--- a/frontend/src/constants/mediaTabs.js
+++ b/frontend/src/constants/mediaTabs.js
@@ -1,0 +1,21 @@
+// The media workspace is one page with five tabs. Each tab owns a route so it
+// is linkable and reachable from the sidebar, and so the tab strip stays on
+// screen no matter which of them the user landed on.
+
+export const MEDIA_TABS = [
+  { path: "/images", label: "Media Library" },
+  { path: "/batch-images", label: "Image Gen" },
+  { path: "/infographic", label: "Infographic" },
+  { path: "/video", label: "Video Gen" },
+  { path: "/upscaling", label: "Upscaling" },
+];
+
+export const MEDIA_LIBRARY_TAB = 0;
+
+/** Index of the tab owning `pathname`, defaulting to the Media Library. */
+export function mediaTabIndexForPath(pathname) {
+  const index = MEDIA_TABS.findIndex(
+    (tab) => pathname === tab.path || pathname.startsWith(`${tab.path}/`),
+  );
+  return index === -1 ? MEDIA_LIBRARY_TAB : index;
+}

--- a/frontend/src/pages/ImagesPage.jsx
+++ b/frontend/src/pages/ImagesPage.jsx
@@ -4,12 +4,13 @@
 // - Desktop icons for folders and root-level images (thumbnails)
 // - ImageThumbnailGrid inside folder windows
 // - ImageLightbox for full-size viewing with prev/next
-// - Tabs: Image Library + Image Gen
+// - Hosts the five media-workspace tabs (see constants/mediaTabs.js); each
+//   tab is a route, so the strip is present whichever one you arrive on
 // - No upload action (images come from generation only)
 // - Root path scoped to /Images/
 
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Box,
   Typography,
@@ -59,6 +60,7 @@ import ImagesContextMenu from '../components/images/ImagesContextMenu';
 import ImageLightbox from '../components/images/ImageLightbox';
 import PublishModal from '../components/modals/PublishModal';
 import PageLayout from '../components/layout/PageLayout';
+import { MEDIA_TABS, MEDIA_LIBRARY_TAB, mediaTabIndexForPath } from '../constants/mediaTabs';
 import { useLayout } from '../contexts/LayoutContext';
 import { useSnackbar } from '../components/common/SnackbarProvider';
 import { ContextualLoader } from '../components/common/LoadingStates';
@@ -94,19 +96,12 @@ const ImagesPage = () => {
   const { _activeModel, _isLoadingModel, _modelError } = useStatus();
   const theme = useTheme();
 
-  // Tabs — the /batch-images route is the "Image Gen" sidebar entry; it shares
-  // this page with the Media Library (/images) but must open on the Image Gen
-  // tab (index 1), not the library. Drive the initial tab from the route.
+  // Every tab is its own route, so the route is the single source of truth for
+  // which one is showing — no local tab state to drift out of sync.
   const location = useLocation();
-  const [activeTab, setActiveTab] = useState(
-    location.pathname.startsWith('/batch-images') ? 1 : 0
-  );
-
-  // Keep the tab in sync if the route changes while the page stays mounted
-  // (e.g. clicking Media then Image Gen without a full remount).
-  useEffect(() => {
-    setActiveTab(location.pathname.startsWith('/batch-images') ? 1 : 0);
-  }, [location.pathname]);
+  const navigate = useNavigate();
+  const activeTab = mediaTabIndexForPath(location.pathname);
+  const activeTabPath = MEDIA_TABS[activeTab].path;
 
   // Data
   const [rootFolders, setRootFolders] = useState([]);
@@ -240,8 +235,12 @@ const ImagesPage = () => {
     }
   }, []);
 
-  // Initialize: load data + saved window state
+  // Initialize: load data + saved window state. Only the Media Library tab
+  // needs either, and all five tabs share this page, so it waits for that tab.
+  const libraryInitStartedRef = useRef(false);
   useEffect(() => {
+    if (activeTab !== MEDIA_LIBRARY_TAB || libraryInitStartedRef.current) return;
+    libraryInitStartedRef.current = true;
     const init = async () => {
       const { folders } = await fetchData();
 
@@ -322,7 +321,7 @@ const ImagesPage = () => {
       setLoading(false);
     };
     init();
-  }, [fetchData]);
+  }, [activeTab, fetchData]);
 
   // Refresh data without page reload
   const refreshData = useCallback(async () => {
@@ -446,7 +445,7 @@ const ImagesPage = () => {
 
   // Load video batches when switching to Video Library tab
   useEffect(() => {
-    if (activeTab === 0) {
+    if (activeTab === MEDIA_LIBRARY_TAB) {
       fetchVideoBatches();
     }
   }, [activeTab, fetchVideoBatches]);
@@ -1357,7 +1356,7 @@ const ImagesPage = () => {
   useEffect(() => {
     const handleKeyDown = (e) => {
       // Only handle when Image Library tab is active
-      if (activeTab !== 0) return;
+      if (activeTab !== MEDIA_LIBRARY_TAB) return;
       if (e.defaultPrevented) return;
       const targetTag = e.target?.tagName;
       if (targetTag === 'INPUT' || targetTag === 'TEXTAREA' || e.target?.isContentEditable) return;
@@ -1521,7 +1520,7 @@ const ImagesPage = () => {
 
   // ──────────────────── Render ────────────────────
 
-  if (loading) {
+  if (loading && activeTab === MEDIA_LIBRARY_TAB) {
     return (
       <PageLayout title="Images">
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
@@ -1536,7 +1535,7 @@ const ImagesPage = () => {
       title="Media"
       variant="grid"
       noPadding
-      actions={activeTab === 0 ? (
+      actions={activeTab === MEDIA_LIBRARY_TAB ? (
         <>
           <Tooltip title={desktopViewMode === 'icons' ? 'List View' : 'Icon View'}>
             <IconButton
@@ -1566,17 +1565,20 @@ const ImagesPage = () => {
     >
       {/* Tab bar */}
       <Box sx={{ borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
-        <Tabs value={activeTab} onChange={(e, v) => setActiveTab(v)}>
-          <Tab label="Media Library" />
-          <Tab label="Image Gen" />
-          <Tab label="Infographic" />
-          <Tab label="Video Gen" />
-          <Tab label="Upscaling" />
+        <Tabs
+          value={activeTab}
+          onChange={(e, v) => navigate(MEDIA_TABS[v].path)}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          {MEDIA_TABS.map((tab) => (
+            <Tab key={tab.path} label={tab.label} />
+          ))}
         </Tabs>
       </Box>
 
       {/* Media Library Tab */}
-      {activeTab === 0 && (<>
+      {activeTab === MEDIA_LIBRARY_TAB && (<>
         <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
           {/* Toolbar */}
           <Box sx={{
@@ -2102,7 +2104,7 @@ const ImagesPage = () => {
         </Box>
 
         {/* Video Batches Section — stacked thumbnails within Media Library */}
-        {/* (still inside activeTab === 0 conditional) */}
+        {/* (still inside activeTab === MEDIA_LIBRARY_TAB conditional) */}
         {videoBatches.length > 0 && (
           <Box sx={{ px: 2, pb: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}>
@@ -2246,27 +2248,27 @@ const ImagesPage = () => {
       </>)}
 
       {/* Image Gen Tab */}
-      {activeTab === 1 && (
+      {activeTabPath === '/batch-images' && (
         <Box sx={{ flexGrow: 1, overflow: 'auto', display: 'flex', flexDirection: 'column', gap: 2, p: 1 }}>
           <BatchImageGeneratorPage embedded />
         </Box>
       )}
 
       {/* Infographic Tab */}
-      {activeTab === 2 && (
+      {activeTabPath === '/infographic' && (
         <Box sx={{ flexGrow: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
           <InfographicGenerator />
         </Box>
       )}
 
       {/* Video Gen Tab */}
-      {activeTab === 3 && (
+      {activeTabPath === '/video' && (
         <Box sx={{ flexGrow: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
           <VideoGeneratorPage embedded />
         </Box>
       )}
 
-      {activeTab === 4 && (
+      {activeTabPath === '/upscaling' && (
         <Box sx={{ flexGrow: 1, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
           <UpscalingPage embedded />
         </Box>

--- a/frontend/src/pages/SystemMapPage.jsx
+++ b/frontend/src/pages/SystemMapPage.jsx
@@ -42,6 +42,7 @@ import { io } from "socket.io-client";
 import PageLayout from "../components/layout/PageLayout";
 import { SystemMapCanvas } from "../components/systemmap";
 import { pathToSection, moduleNameToPath } from "../components/systemmap/pathUtils";
+import { useMapPalette } from "../components/systemmap/palette";
 import {
   fetchSystemMap,
   fetchFindings,
@@ -49,13 +50,6 @@ import {
   dismissFinding,
 } from "../api/systemMapService";
 import { SOCKET_URL } from "../api/apiClient";
-
-const SEVERITY_COLOR = {
-  high: "#ff6e6e",
-  medium: "#ffb84d",
-  low: "rgba(168, 216, 255, 0.7)",
-  info: "rgba(168, 216, 255, 0.4)",
-};
 
 // Mirror of the SECTION_HUE in SystemMapCanvas — keep these in sync.
 // `prefix` is what the canvas matches each node's section against
@@ -106,6 +100,7 @@ function findModuleForTool(toolName, moduleNames) {
 // primitive as the section legend; `activeColor` is an "r, g, b" triplet so the
 // active state tints to the overlay's render color.
 function OverlayChip({ label, active, activeColor, onToggle }) {
+  const P = useMapPalette();
   return (
     <Box
       role="button"
@@ -129,11 +124,11 @@ function OverlayChip({ label, active, activeColor, onToggle }) {
         userSelect: "none",
         border: active
           ? `1px solid rgba(${activeColor}, 0.85)`
-          : "1px solid rgba(168, 216, 255, 0.12)",
-        bgcolor: active ? `rgba(${activeColor}, 0.18)` : "rgba(168, 216, 255, 0.04)",
+          : `1px solid ${P.ink(0.12)}`,
+        bgcolor: active ? `rgba(${activeColor}, 0.18)` : P.ink(0.04),
         transition: "all 160ms ease",
         "&:hover": {
-          bgcolor: active ? `rgba(${activeColor}, 0.26)` : "rgba(168, 216, 255, 0.10)",
+          bgcolor: active ? `rgba(${activeColor}, 0.26)` : P.ink(0.10),
           borderColor: `rgba(${activeColor}, 0.55)`,
         },
       }}
@@ -150,7 +145,7 @@ function OverlayChip({ label, active, activeColor, onToggle }) {
       <Typography
         variant="caption"
         sx={{
-          color: active ? `rgba(${activeColor}, 0.95)` : "rgba(168, 216, 255, 0.55)",
+          color: active ? `rgba(${activeColor}, 0.95)` : P.ink(0.55),
           fontSize: "0.65rem",
           letterSpacing: 0.5,
           textTransform: "uppercase",
@@ -163,6 +158,8 @@ function OverlayChip({ label, active, activeColor, onToggle }) {
 }
 
 export default function SystemMapPage() {
+  const P = useMapPalette();
+  const SEVERITY_COLOR = P.severity;
   const [map, setMap] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -437,11 +434,11 @@ export default function SystemMapPage() {
           }}
         >
           <Stack direction="row" spacing={1} alignItems="center" sx={{ pointerEvents: "auto" }}>
-            <BubbleChartIcon sx={{ color: "rgba(168, 216, 255, 0.85)", fontSize: 28 }} />
+            <BubbleChartIcon sx={{ color: P.ink(0.85), fontSize: 28 }} />
             <Typography
               variant="h6"
               sx={{
-                color: "rgba(168, 216, 255, 0.95)",
+                color: P.ink(0.95),
                 fontWeight: 300,
                 letterSpacing: 1.5,
               }}
@@ -449,7 +446,7 @@ export default function SystemMapPage() {
               System Map
             </Typography>
             {map && (
-              <Typography variant="caption" sx={{ color: "rgba(168, 216, 255, 0.55)", ml: 1 }}>
+              <Typography variant="caption" sx={{ color: P.ink(0.55), ml: 1 }}>
                 {map.file_count} modules ·{" "}
                 {map.dependency_graph
                   ? Object.values(map.dependency_graph).reduce(
@@ -470,9 +467,9 @@ export default function SystemMapPage() {
                   size="small"
                   label={`${sev.high} critical`}
                   sx={{
-                    bgcolor: "rgba(255, 110, 110, 0.18)",
+                    bgcolor: P.danger(0.18),
                     color: SEVERITY_COLOR.high,
-                    border: "1px solid rgba(255, 110, 110, 0.4)",
+                    border: `1px solid ${P.danger(0.4)}`,
                   }}
                 />
               )}
@@ -481,9 +478,9 @@ export default function SystemMapPage() {
                   size="small"
                   label={`${sev.medium} medium`}
                   sx={{
-                    bgcolor: "rgba(255, 184, 77, 0.15)",
+                    bgcolor: P.warn(0.15),
                     color: SEVERITY_COLOR.medium,
-                    border: "1px solid rgba(255, 184, 77, 0.35)",
+                    border: `1px solid ${P.warn(0.35)}`,
                   }}
                 />
               )}
@@ -491,9 +488,9 @@ export default function SystemMapPage() {
                 size="small"
                 label={`${sev.low} hygiene`}
                 sx={{
-                  bgcolor: "rgba(168, 216, 255, 0.10)",
+                  bgcolor: P.ink(0.10),
                   color: SEVERITY_COLOR.low,
-                  border: "1px solid rgba(168, 216, 255, 0.25)",
+                  border: `1px solid ${P.ink(0.25)}`,
                 }}
               />
             </Stack>
@@ -514,21 +511,21 @@ export default function SystemMapPage() {
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
-                    <SearchIcon sx={{ color: "rgba(168, 216, 255, 0.5)", fontSize: 18 }} />
+                    <SearchIcon sx={{ color: P.ink(0.5), fontSize: 18 }} />
                   </InputAdornment>
                 ),
                 endAdornment: search && (
                   <InputAdornment position="end">
                     <IconButton size="small" onClick={() => setSearch("")}>
-                      <CloseIcon sx={{ color: "rgba(168, 216, 255, 0.5)", fontSize: 16 }} />
+                      <CloseIcon sx={{ color: P.ink(0.5), fontSize: 16 }} />
                     </IconButton>
                   </InputAdornment>
                 ),
                 sx: {
-                  bgcolor: "rgba(20, 30, 50, 0.6)",
-                  color: "rgba(168, 216, 255, 0.85)",
-                  "& fieldset": { borderColor: "rgba(168, 216, 255, 0.2)" },
-                  "&:hover fieldset": { borderColor: "rgba(168, 216, 255, 0.4)" },
+                  bgcolor: P.fieldBg,
+                  color: P.ink(0.85),
+                  "& fieldset": { borderColor: P.ink(0.2) },
+                  "&:hover fieldset": { borderColor: P.ink(0.4) },
                   fontFamily: "monospace",
                   fontSize: "0.8rem",
                 },
@@ -540,9 +537,9 @@ export default function SystemMapPage() {
             <IconButton
               onClick={() => canvasRef.current?.resetView()}
               sx={{
-                color: "rgba(168, 216, 255, 0.7)",
+                color: P.ink(0.7),
                 pointerEvents: "auto",
-                "&:hover": { color: "rgba(168, 216, 255, 1)" },
+                "&:hover": { color: P.ink(1) },
               }}
             >
               <RestartAltIcon />
@@ -563,13 +560,13 @@ export default function SystemMapPage() {
               }}
               disabled={loading}
               sx={{
-                color: "rgba(168, 216, 255, 0.7)",
+                color: P.ink(0.7),
                 pointerEvents: "auto",
-                "&:hover": { color: "rgba(168, 216, 255, 1)" },
+                "&:hover": { color: P.ink(1) },
               }}
             >
               {loading ? (
-                <CircularProgress size={20} sx={{ color: "rgba(168, 216, 255, 0.7)" }} />
+                <CircularProgress size={20} sx={{ color: P.ink(0.7) }} />
               ) : (
                 <RefreshIcon />
               )}
@@ -617,17 +614,17 @@ export default function SystemMapPage() {
                   cursor: "pointer",
                   userSelect: "none",
                   border: active
-                    ? `1px solid hsla(${s.hue}, 80%, 78%, 0.85)`
-                    : "1px solid rgba(168, 216, 255, 0.12)",
+                    ? `1px solid ${P.hue(s.hue, 80, 78, 0.85)}`
+                    : `1px solid ${P.ink(0.12)}`,
                   bgcolor: active
-                    ? `hsla(${s.hue}, 70%, 70%, 0.18)`
-                    : "rgba(168, 216, 255, 0.04)",
+                    ? P.hue(s.hue, 70, 70, 0.18)
+                    : P.ink(0.04),
                   transition: "all 160ms ease",
                   "&:hover": {
                     bgcolor: active
-                      ? `hsla(${s.hue}, 70%, 72%, 0.26)`
-                      : "rgba(168, 216, 255, 0.10)",
-                    borderColor: `hsla(${s.hue}, 80%, 78%, 0.55)`,
+                      ? P.hue(s.hue, 70, 72, 0.26)
+                      : P.ink(0.10),
+                    borderColor: P.hue(s.hue, 80, 78, 0.55),
                   },
                 }}
               >
@@ -636,18 +633,18 @@ export default function SystemMapPage() {
                     width: 8,
                     height: 8,
                     borderRadius: "50%",
-                    bgcolor: `hsla(${s.hue}, 75%, 78%, ${active ? 1 : 0.85})`,
-                    boxShadow: `0 0 ${active ? 12 : 8}px hsla(${s.hue}, 75%, 78%, ${
-                      active ? 0.7 : 0.45
-                    })`,
+                    bgcolor: P.hue(s.hue, 75, 78, active ? 1 : 0.85),
+                    boxShadow: `0 0 ${active ? 12 : 8}px ${P.hue(
+                      s.hue, 75, 78, active ? 0.7 : 0.45,
+                    )}`,
                   }}
                 />
                 <Typography
                   variant="caption"
                   sx={{
                     color: active
-                      ? `hsla(${s.hue}, 90%, 90%, 0.95)`
-                      : "rgba(168, 216, 255, 0.55)",
+                      ? P.hue(s.hue, 90, 90, 0.95)
+                      : P.ink(0.55),
                     fontSize: "0.65rem",
                     letterSpacing: 0.5,
                     textTransform: "uppercase",
@@ -671,11 +668,11 @@ export default function SystemMapPage() {
                 borderRadius: "999px",
                 cursor: "pointer",
                 userSelect: "none",
-                color: "rgba(168, 216, 255, 0.55)",
+                color: P.ink(0.55),
                 fontSize: "0.65rem",
                 letterSpacing: 0.5,
                 textTransform: "uppercase",
-                "&:hover": { color: "rgba(168, 216, 255, 0.9)" },
+                "&:hover": { color: P.ink(0.9) },
               }}
             >
               clear
@@ -691,20 +688,20 @@ export default function SystemMapPage() {
                 sx={{
                   width: "1px",
                   alignSelf: "stretch",
-                  bgcolor: "rgba(168, 216, 255, 0.15)",
+                  bgcolor: P.ink(0.15),
                   mx: 0.5,
                 }}
               />
               <OverlayChip
                 label={`Ghost endpoints${ghostEndpointCount ? ` (${ghostEndpointCount})` : ""}`}
                 active={showGhostEndpoints}
-                activeColor="255, 170, 80"
+                activeColor={P.warnRGB}
                 onToggle={() => setShowGhostEndpoints((v) => !v)}
               />
               <OverlayChip
                 label={`Tool graph${toolCount ? ` (${toolCount})` : ""}`}
                 active={showToolGraph}
-                activeColor="120, 220, 180"
+                activeColor={P.ghostRGB}
                 onToggle={() => setShowToolGraph((v) => !v)}
               />
             </>
@@ -720,9 +717,9 @@ export default function SystemMapPage() {
               left: 16,
               right: 16,
               zIndex: 10,
-              bgcolor: "rgba(255, 100, 100, 0.15)",
-              color: "rgba(255, 200, 200, 0.95)",
-              border: "1px solid rgba(255, 100, 100, 0.3)",
+              bgcolor: P.errorBg,
+              color: P.errorInk,
+              border: `1px solid ${P.errorBorder}`,
             }}
           >
             {error}
@@ -753,7 +750,7 @@ export default function SystemMapPage() {
             bottom: 16,
             left: 16,
             zIndex: 8,
-            color: "rgba(168, 216, 255, 0.45)",
+            color: P.ink(0.45),
             fontSize: "0.7rem",
             fontFamily: "monospace",
             letterSpacing: 0.4,
@@ -775,11 +772,11 @@ export default function SystemMapPage() {
             p: 0,
             // 90% transparent, glass effect via heavier blur + saturate.
             // Text inside stays opaque (set on individual elements).
-            bgcolor: "rgba(14, 22, 40, 0.10)",
+            bgcolor: P.panelBg,
             backdropFilter: "blur(20px) saturate(1.4)",
             WebkitBackdropFilter: "blur(20px) saturate(1.4)",
-            border: "1px solid rgba(168, 216, 255, 0.15)",
-            color: "rgba(168, 216, 255, 0.85)",
+            border: `1px solid ${P.ink(0.15)}`,
+            color: P.ink(0.85),
             zIndex: 9,
             display: "flex",
             flexDirection: "column",
@@ -792,7 +789,7 @@ export default function SystemMapPage() {
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography
                     variant="overline"
-                    sx={{ color: "rgba(168, 216, 255, 0.5)", letterSpacing: 1.2 }}
+                    sx={{ color: P.ink(0.5), letterSpacing: 1.2 }}
                   >
                     {hovered ? "Hovered" : "Selected"}
                   </Typography>
@@ -802,7 +799,7 @@ export default function SystemMapPage() {
                       fontFamily: "monospace",
                       fontSize: "0.85rem",
                       wordBreak: "break-all",
-                      color: "rgba(168, 216, 255, 0.95)",
+                      color: P.ink(0.95),
                     }}
                   >
                     {activeNodeId}
@@ -810,7 +807,7 @@ export default function SystemMapPage() {
                 </Box>
                 {selected && !hovered && (
                   <IconButton size="small" onClick={() => setSelected(null)}>
-                    <CloseIcon sx={{ color: "rgba(168, 216, 255, 0.5)", fontSize: 18 }} />
+                    <CloseIcon sx={{ color: P.ink(0.5), fontSize: 18 }} />
                   </IconButton>
                 )}
               </Stack>
@@ -821,8 +818,8 @@ export default function SystemMapPage() {
                     size="small"
                     label={activeNode.section}
                     sx={{
-                      bgcolor: "rgba(168, 216, 255, 0.10)",
-                      color: "rgba(168, 216, 255, 0.85)",
+                      bgcolor: P.ink(0.10),
+                      color: P.ink(0.85),
                       fontSize: "0.7rem",
                       height: 22,
                       mr: 0.5,
@@ -834,8 +831,8 @@ export default function SystemMapPage() {
                     size="small"
                     label={activeNode.lifecycle}
                     sx={{
-                      bgcolor: "rgba(168, 216, 255, 0.10)",
-                      color: "rgba(168, 216, 255, 0.85)",
+                      bgcolor: P.ink(0.10),
+                      color: P.ink(0.85),
                       fontSize: "0.7rem",
                       height: 22,
                       mr: 0.5,
@@ -847,8 +844,8 @@ export default function SystemMapPage() {
                     size="small"
                     label={`${activeNode.importers} importer${activeNode.importers === 1 ? "" : "s"}`}
                     sx={{
-                      bgcolor: "rgba(168, 216, 255, 0.06)",
-                      color: "rgba(168, 216, 255, 0.7)",
+                      bgcolor: P.ink(0.06),
+                      color: P.ink(0.7),
                       fontSize: "0.7rem",
                       height: 22,
                       mr: 0.5,
@@ -861,7 +858,7 @@ export default function SystemMapPage() {
                 <Box sx={{ mt: 2 }}>
                   <Typography
                     variant="overline"
-                    sx={{ color: "rgba(168, 216, 255, 0.5)", letterSpacing: 1.2 }}
+                    sx={{ color: P.ink(0.5), letterSpacing: 1.2 }}
                   >
                     Findings ({activeFindings.length})
                   </Typography>
@@ -872,7 +869,7 @@ export default function SystemMapPage() {
                         mt: 0.5,
                         p: 1,
                         borderLeft: `2px solid ${SEVERITY_COLOR[f.severity] || SEVERITY_COLOR.low}`,
-                        bgcolor: "rgba(168, 216, 255, 0.04)",
+                        bgcolor: P.ink(0.04),
                       }}
                     >
                       <Typography
@@ -889,7 +886,7 @@ export default function SystemMapPage() {
                       <Typography
                         variant="body2"
                         sx={{
-                          color: "rgba(168, 216, 255, 0.8)",
+                          color: P.ink(0.8),
                           fontSize: "0.78rem",
                           mt: 0.25,
                         }}
@@ -901,7 +898,7 @@ export default function SystemMapPage() {
                   {activeFindings.length > 8 && (
                     <Typography
                       variant="caption"
-                      sx={{ color: "rgba(168, 216, 255, 0.4)", mt: 0.5, display: "block" }}
+                      sx={{ color: P.ink(0.4), mt: 0.5, display: "block" }}
                     >
                       … and {activeFindings.length - 8} more
                     </Typography>
@@ -912,7 +909,7 @@ export default function SystemMapPage() {
               {!hovered && selected && (
                 <Typography
                   variant="caption"
-                  sx={{ color: "rgba(168, 216, 255, 0.4)", mt: 2, display: "block" }}
+                  sx={{ color: P.ink(0.4), mt: 2, display: "block" }}
                 >
                   Press <code>Esc</code> to clear
                 </Typography>
@@ -951,9 +948,9 @@ export default function SystemMapPage() {
               right: 16,
               zIndex: 12,
               maxWidth: 360,
-              bgcolor: "rgba(20, 40, 60, 0.95)",
-              color: "rgba(200, 230, 255, 0.95)",
-              border: "1px solid rgba(168, 216, 255, 0.3)",
+              bgcolor: P.tooltipBg,
+              color: P.tooltipInk,
+              border: `1px solid ${P.ink(0.3)}`,
             }}
           >
             {toast}
@@ -973,11 +970,11 @@ export default function SystemMapPage() {
               gap: 2,
             }}
           >
-            <CircularProgress sx={{ color: "rgba(168, 216, 255, 0.7)" }} />
+            <CircularProgress sx={{ color: P.ink(0.7) }} />
             <Typography
               variant="caption"
               sx={{
-                color: "rgba(168, 216, 255, 0.5)",
+                color: P.ink(0.5),
                 letterSpacing: 2,
                 textTransform: "uppercase",
               }}
@@ -995,6 +992,7 @@ export default function SystemMapPage() {
 
 // Shared tab header for the right-side panel base views.
 function PanelTabs({ activeTab, onTab, badge }) {
+  const P = useMapPalette();
   const tab = (key, label) => (
     <Box
       role="button"
@@ -1013,10 +1011,10 @@ function PanelTabs({ activeTab, onTab, badge }) {
         py: 0.5,
         borderBottom:
           activeTab === key
-            ? "2px solid rgba(168, 216, 255, 0.85)"
+            ? `2px solid ${P.ink(0.85)}`
             : "2px solid transparent",
         color:
-          activeTab === key ? "rgba(168, 216, 255, 0.95)" : "rgba(168, 216, 255, 0.45)",
+          activeTab === key ? P.ink(0.95) : P.ink(0.45),
         fontSize: "0.7rem",
         letterSpacing: 1.2,
         textTransform: "uppercase",
@@ -1033,8 +1031,8 @@ function PanelTabs({ activeTab, onTab, badge }) {
             fontSize: "0.6rem",
             px: 0.6,
             borderRadius: "999px",
-            bgcolor: "rgba(255, 184, 77, 0.2)",
-            color: "#ffb84d",
+            bgcolor: P.warn(0.2),
+            color: P.severity.medium,
           }}
         >
           {badge}
@@ -1062,6 +1060,8 @@ function FindingsView({
   activeTab,
   onTab,
 }) {
+  const P = useMapPalette();
+  const SEVERITY_COLOR = P.severity;
   const filters = [
     { key: "high,medium", label: "Actionable" },
     { key: "high", label: "Critical" },
@@ -1072,8 +1072,8 @@ function FindingsView({
       <PanelTabs activeTab={activeTab} onTab={onTab} badge={openCount} />
       <Box sx={{ px: 1.5, pb: 1 }}>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <WarningAmberIcon sx={{ color: "rgba(255, 184, 77, 0.7)", fontSize: 16 }} />
-          <Typography variant="caption" sx={{ color: "rgba(168, 216, 255, 0.55)", fontSize: "0.7rem" }}>
+          <WarningAmberIcon sx={{ color: P.warn(0.7), fontSize: 16 }} />
+          <Typography variant="caption" sx={{ color: P.ink(0.55), fontSize: "0.7rem" }}>
             Ranked findings · click to locate · dispatch to fix
           </Typography>
         </Stack>
@@ -1101,12 +1101,12 @@ function FindingsView({
                 textTransform: "uppercase",
                 border:
                   sevFilter === f.key
-                    ? "1px solid rgba(168, 216, 255, 0.6)"
-                    : "1px solid rgba(168, 216, 255, 0.15)",
+                    ? `1px solid ${P.ink(0.6)}`
+                    : `1px solid ${P.ink(0.15)}`,
                 color:
                   sevFilter === f.key
-                    ? "rgba(168, 216, 255, 0.95)"
-                    : "rgba(168, 216, 255, 0.5)",
+                    ? P.ink(0.95)
+                    : P.ink(0.5),
               }}
             >
               {f.label}
@@ -1114,13 +1114,13 @@ function FindingsView({
           ))}
         </Stack>
       </Box>
-      <Divider sx={{ borderColor: "rgba(168, 216, 255, 0.08)" }} />
+      <Divider sx={{ borderColor: P.ink(0.08) }} />
       <Box sx={{ flex: 1, overflowY: "auto", p: 1.5, pt: 1 }}>
         {findings.length === 0 ? (
           <Typography
             variant="caption"
             sx={{
-              color: "rgba(168, 216, 255, 0.35)",
+              color: P.ink(0.35),
               fontStyle: "italic",
               display: "block",
               mt: 2,
@@ -1137,7 +1137,7 @@ function FindingsView({
                 mt: 0.8,
                 p: 1,
                 borderLeft: `2px solid ${SEVERITY_COLOR[f.severity] || SEVERITY_COLOR.low}`,
-                bgcolor: "rgba(168, 216, 255, 0.04)",
+                bgcolor: P.ink(0.04),
                 borderRadius: "2px",
               }}
             >
@@ -1164,7 +1164,7 @@ function FindingsView({
                 </Typography>
                 <Typography
                   variant="body2"
-                  sx={{ color: "rgba(168, 216, 255, 0.85)", fontSize: "0.78rem", mt: 0.25 }}
+                  sx={{ color: P.ink(0.85), fontSize: "0.78rem", mt: 0.25 }}
                 >
                   {f.summary}
                 </Typography>
@@ -1173,7 +1173,7 @@ function FindingsView({
                     key={p}
                     variant="caption"
                     sx={{
-                      color: "rgba(168, 216, 255, 0.4)",
+                      color: P.ink(0.4),
                       fontFamily: "monospace",
                       fontSize: "0.65rem",
                       display: "block",
@@ -1191,10 +1191,10 @@ function FindingsView({
                         size="small"
                         disabled={dispatchingId === f.id}
                         onClick={() => onDispatch(f)}
-                        sx={{ color: "rgba(120, 220, 180, 0.8)" }}
+                        sx={{ color: P.ghost(0.8) }}
                       >
                         {dispatchingId === f.id ? (
-                          <CircularProgress size={14} sx={{ color: "rgba(120, 220, 180, 0.8)" }} />
+                          <CircularProgress size={14} sx={{ color: P.ghost(0.8) }} />
                         ) : (
                           <SendIcon sx={{ fontSize: 15 }} />
                         )}
@@ -1206,7 +1206,7 @@ function FindingsView({
                   <IconButton
                     size="small"
                     onClick={() => onDismiss(f)}
-                    sx={{ color: "rgba(168, 216, 255, 0.5)" }}
+                    sx={{ color: P.ink(0.5) }}
                   >
                     <VisibilityOffIcon sx={{ fontSize: 15 }} />
                   </IconButton>
@@ -1221,15 +1221,16 @@ function FindingsView({
 }
 
 function ActivityLogView({ activity, activeTab, onTab }) {
+  const P = useMapPalette();
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       {onTab && <PanelTabs activeTab={activeTab} onTab={onTab} />}
       <Box sx={{ p: 2, pb: 1.5 }}>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <BoltIcon sx={{ color: "rgba(168, 216, 255, 0.7)", fontSize: 18 }} />
+          <BoltIcon sx={{ color: P.ink(0.7), fontSize: 18 }} />
           <Typography
             variant="overline"
-            sx={{ color: "rgba(168, 216, 255, 0.7)", letterSpacing: 1.5 }}
+            sx={{ color: P.ink(0.7), letterSpacing: 1.5 }}
           >
             Live activity
           </Typography>
@@ -1237,7 +1238,7 @@ function ActivityLogView({ activity, activeTab, onTab }) {
           <Typography
             variant="caption"
             sx={{
-              color: "rgba(168, 216, 255, 0.4)",
+              color: P.ink(0.4),
               fontFamily: "monospace",
               fontSize: "0.7rem",
             }}
@@ -1248,7 +1249,7 @@ function ActivityLogView({ activity, activeTab, onTab }) {
         <Typography
           variant="caption"
           sx={{
-            color: "rgba(168, 216, 255, 0.4)",
+            color: P.ink(0.4),
             fontSize: "0.7rem",
             display: "block",
             mt: 0.5,
@@ -1257,13 +1258,13 @@ function ActivityLogView({ activity, activeTab, onTab }) {
           Tool calls flowing through the chat appear here. Matched modules pulse in the constellation.
         </Typography>
       </Box>
-      <Divider sx={{ borderColor: "rgba(168, 216, 255, 0.08)" }} />
+      <Divider sx={{ borderColor: P.ink(0.08) }} />
       <Box sx={{ flex: 1, overflowY: "auto", p: 1.5, pt: 1 }}>
         {activity.length === 0 ? (
           <Typography
             variant="caption"
             sx={{
-              color: "rgba(168, 216, 255, 0.35)",
+              color: P.ink(0.35),
               fontStyle: "italic",
               display: "block",
               mt: 2,
@@ -1281,10 +1282,10 @@ function ActivityLogView({ activity, activeTab, onTab }) {
                 p: 0.8,
                 borderLeft: `2px solid ${
                   evt.kind === "result"
-                    ? "rgba(120, 220, 180, 0.6)"
-                    : "rgba(168, 216, 255, 0.55)"
+                    ? P.ghost(0.6)
+                    : P.ink(0.55)
                 }`,
-                bgcolor: "rgba(168, 216, 255, 0.03)",
+                bgcolor: P.ink(0.03),
                 borderRadius: "2px",
               }}
             >
@@ -1294,8 +1295,8 @@ function ActivityLogView({ activity, activeTab, onTab }) {
                   sx={{
                     color:
                       evt.kind === "result"
-                        ? "rgba(120, 220, 180, 0.85)"
-                        : "rgba(168, 216, 255, 0.8)",
+                        ? P.ghost(0.85)
+                        : P.ink(0.8),
                     fontFamily: "monospace",
                     fontSize: "0.72rem",
                   }}
@@ -1306,7 +1307,7 @@ function ActivityLogView({ activity, activeTab, onTab }) {
                 <Typography
                   variant="caption"
                   sx={{
-                    color: "rgba(168, 216, 255, 0.35)",
+                    color: P.ink(0.35),
                     fontFamily: "monospace",
                     fontSize: "0.65rem",
                   }}
@@ -1318,7 +1319,7 @@ function ActivityLogView({ activity, activeTab, onTab }) {
                 <Typography
                   variant="caption"
                   sx={{
-                    color: "rgba(168, 216, 255, 0.4)",
+                    color: P.ink(0.4),
                     fontFamily: "monospace",
                     fontSize: "0.65rem",
                     display: "block",

--- a/frontend/src/pages/UpscalingPage.jsx
+++ b/frontend/src/pages/UpscalingPage.jsx
@@ -1,5 +1,7 @@
 // frontend/src/pages/UpscalingPage.jsx
-// Dedicated upscaling page with video upload, model selection, and job tracking
+// Upscaling workspace for video and stills: upload, model selection, job tracking.
+// Videos and image batches queue on the plugin's single GPU worker; a single
+// still is upscaled inline and returned with the request.
 
 import React, { useEffect, useState, useRef, useCallback, Suspense } from "react";
 import {
@@ -38,6 +40,8 @@ import {
   ArrowBack as BackIcon,
   Close as CloseIcon,
   Visibility as PreviewIcon,
+  Movie as MovieIcon,
+  Image as ImageIcon,
 } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
 import * as upscalingService from "../api/upscalingService";
@@ -53,6 +57,21 @@ const TARGET_PRESETS = {
   "4k": { label: "4K (3840px)", width: 3840 },
   "8k": { label: "8K (7680px)", width: 7680 },
 };
+
+const VIDEO_EXTENSIONS = ["mp4", "mkv", "avi", "mov", "webm", "flv", "wmv"];
+const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff"];
+
+// null means "whatever the model's native factor is" — the plugin decides.
+const IMAGE_SCALES = [
+  { value: "", label: "Model default" },
+  { value: "2", label: "2x" },
+  { value: "3", label: "3x" },
+  { value: "4", label: "4x" },
+];
+
+const extensionOf = (name) => (name.split(".").pop() || "").toLowerCase();
+const isVideoFile = (name) => VIDEO_EXTENSIONS.includes(extensionOf(name));
+const isImageFile = (name) => IMAGE_EXTENSIONS.includes(extensionOf(name));
 
 const UpscalingPage = ({ embedded = false }) => {
   const navigate = useNavigate();
@@ -70,8 +89,13 @@ const UpscalingPage = ({ embedded = false }) => {
   const [selectedFiles, setSelectedFiles] = useState([]);
   const [uploadProgress, setUploadProgress] = useState(null); // { current, total, name }
 
+  // "video" or "image" — drives which files are accepted and which endpoint
+  // the Upscale button calls. Switching kinds drops the pending selection.
+  const [mediaKind, setMediaKind] = useState("video");
+
   // Settings
   const [selectedModel, setSelectedModel] = useState("");
+  const [imageScale, setImageScale] = useState("");
   const [targetResolution, setTargetResolution] = useState("4k");
   const [twoPass, setTwoPass] = useState(false);
   const [faceEnhance, setFaceEnhance] = useState(false);
@@ -83,6 +107,10 @@ const UpscalingPage = ({ embedded = false }) => {
   const [jobs, setJobs] = useState([]);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+
+  // Result of a single-image upscale: before/after pair shown on the right.
+  const [imageResult, setImageResult] = useState(null);
+  const imageResultRef = useRef(null);
 
   const [previewFile, setPreviewFile] = useState(null);
   const [previewOriginalUrl, setPreviewOriginalUrl] = useState(null);
@@ -120,6 +148,20 @@ const UpscalingPage = ({ embedded = false }) => {
       setServiceAvailable(false);
     }
   };
+
+  // The single-image "before" thumbnail is an object URL; release it when the
+  // page goes away so a long session doesn't leak every image it upscaled.
+  useEffect(() => {
+    return () => {
+      if (imageResultRef.current?.originalUrl) {
+        URL.revokeObjectURL(imageResultRef.current.originalUrl);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    imageResultRef.current = imageResult;
+  }, [imageResult]);
 
   const refreshModels = useCallback(
     async (options = {}) => {
@@ -230,31 +272,42 @@ const UpscalingPage = ({ embedded = false }) => {
     setDragActive(false);
   }, []);
 
+  const acceptsFile = useCallback(
+    (name) => (mediaKind === "image" ? isImageFile(name) : isVideoFile(name)),
+    [mediaKind],
+  );
+
+  const addFiles = useCallback(
+    (incoming) => {
+      const accepted = incoming.filter((f) => acceptsFile(f.name));
+      const rejected = incoming.length - accepted.length;
+      if (accepted.length > 0) {
+        setSelectedFiles((prev) => [...prev, ...accepted]);
+      }
+      if (rejected > 0) {
+        const allowed = (mediaKind === "image" ? IMAGE_EXTENSIONS : VIDEO_EXTENSIONS)
+          .map((ext) => `.${ext}`)
+          .join(", ");
+        setError(`Skipped ${rejected} unsupported file(s). Allowed: ${allowed}`);
+      }
+    },
+    [acceptsFile, mediaKind],
+  );
+
   const handleDrop = useCallback((e) => {
     e.preventDefault();
     e.stopPropagation();
     setDragActive(false);
     if (e.dataTransfer.files?.length > 0) {
-      const dropped = Array.from(e.dataTransfer.files);
-      const videos = dropped.filter((f) => isVideoFile(f.name));
-      const rejected = dropped.length - videos.length;
-      if (videos.length > 0) {
-        setSelectedFiles((prev) => [...prev, ...videos]);
-      }
-      if (rejected > 0) {
-        setError(`Skipped ${rejected} non-video file(s). Allowed: .mp4, .mkv, .avi, .mov, .webm`);
-      }
+      addFiles(Array.from(e.dataTransfer.files));
     }
-  }, []);
+  }, [addFiles]);
 
   const handleFileSelect = useCallback((e) => {
     if (e.target.files?.length > 0) {
-      const picked = Array.from(e.target.files).filter((f) => isVideoFile(f.name));
-      if (picked.length > 0) {
-        setSelectedFiles((prev) => [...prev, ...picked]);
-      }
+      addFiles(Array.from(e.target.files));
     }
-  }, []);
+  }, [addFiles]);
 
   const handleRemoveFile = useCallback((idx) => {
     setSelectedFiles((prev) => prev.filter((_, i) => i !== idx));
@@ -265,10 +318,21 @@ const UpscalingPage = ({ embedded = false }) => {
     if (fileInputRef.current) fileInputRef.current.value = "";
   }, []);
 
-  const isVideoFile = (name) => {
-    const ext = name.split(".").pop().toLowerCase();
-    return ["mp4", "mkv", "avi", "mov", "webm", "flv", "wmv"].includes(ext);
-  };
+  // A video selection means nothing in image mode (and vice versa), so the
+  // pending queue and any single-image result reset on every switch.
+  const handleKindChange = useCallback((_e, next) => {
+    if (!next) return;
+    setMediaKind(next);
+    setSelectedFiles([]);
+    setPreviewFile(null);
+    setImageResult((prev) => {
+      if (prev?.originalUrl) URL.revokeObjectURL(prev.originalUrl);
+      return null;
+    });
+    setError("");
+    setSuccess("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, []);
 
   // --- Submit upscale ---
   // Loops through every selected file and submits a job per file. The backend
@@ -318,6 +382,70 @@ const UpscalingPage = ({ embedded = false }) => {
     await Promise.all([fetchJobs(), refreshHealth()]);
     startPolling();
     setIsUploading(false);
+  };
+
+  // --- Submit image upscale ---
+  // One file returns the finished still with the response; more than one goes
+  // to the plugin queue as a single job so a folder of stills doesn't fight a
+  // running video render for VRAM.
+  const handleUpscaleImages = async () => {
+    if (selectedFiles.length === 0) return;
+    setIsUploading(true);
+    setError("");
+    setSuccess("");
+
+    const options = {
+      model: selectedModel || undefined,
+      scale: imageScale || undefined,
+      two_pass: twoPass,
+      face_enhance: faceEnhance,
+      sharpen,
+      denoise_strength: denoiseStrength,
+    };
+
+    try {
+      if (selectedFiles.length === 1) {
+        const file = selectedFiles[0];
+        setUploadProgress({ current: 1, total: 1, name: file.name });
+        const res = await upscalingService.upscaleImage(file, options);
+        const data = res.data || res;
+        setImageResult((prev) => {
+          if (prev?.originalUrl) URL.revokeObjectURL(prev.originalUrl);
+          return {
+            name: file.name,
+            originalUrl: URL.createObjectURL(file),
+            url: `${API_BASE}/upscaling/output/image/${encodeURIComponent(data.output_file)}`,
+          };
+        });
+        setSuccess(`Upscaled "${file.name}"`);
+        setSelectedFiles([]);
+      } else {
+        const res = await upscalingService.upscaleImages(selectedFiles, options);
+        const data = res.data || res;
+        setSuccess(`Queued ${data.queued ?? selectedFiles.length} images for upscaling`);
+        if (data.rejected?.length > 0) {
+          setError(`Skipped: ${data.rejected.join("; ")}`);
+        }
+        setSelectedFiles([]);
+        await Promise.all([fetchJobs(), refreshHealth()]);
+        startPolling();
+      }
+    } catch (e) {
+      setError(e.message || "Image upscale failed");
+    } finally {
+      setUploadProgress(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      setIsUploading(false);
+    }
+  };
+
+  const handleSubmit = () => (mediaKind === "image" ? handleUpscaleImages() : handleUpscale());
+
+  const closeImageResult = () => {
+    setImageResult((prev) => {
+      if (prev?.originalUrl) URL.revokeObjectURL(prev.originalUrl);
+      return null;
+    });
   };
 
   // --- Cancel job ---
@@ -409,9 +537,11 @@ const UpscalingPage = ({ embedded = false }) => {
   const vramTotal = serviceHealth?.vram_total_mb || 0;
   const modelLoaded = serviceHealth?.model_loaded;
 
+  const isImageMode = mediaKind === "image";
+
   const Wrapper = embedded ? React.Fragment : PageLayout;
   const wrapperProps = embedded ? {} : {
-    title: "Video Upscaling",
+    title: "Upscaling",
     variant: "standard",
     actions: (
       <Stack direction="row" spacing={1} alignItems="center">
@@ -452,8 +582,26 @@ const UpscalingPage = ({ embedded = false }) => {
           <Card sx={{ boxShadow: 2, borderRadius: 2, mb: 3 }}>
             <CardContent sx={{ p: 3 }}>
               <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-                Upload Video
+                {isImageMode ? "Upload Images" : "Upload Video"}
               </Typography>
+
+              <ToggleButtonGroup
+                value={mediaKind}
+                exclusive
+                onChange={handleKindChange}
+                size="small"
+                fullWidth
+                sx={{ mb: 2 }}
+              >
+                <ToggleButton value="video">
+                  <MovieIcon fontSize="small" sx={{ mr: 1 }} />
+                  Video
+                </ToggleButton>
+                <ToggleButton value="image">
+                  <ImageIcon fontSize="small" sx={{ mr: 1 }} />
+                  Image
+                </ToggleButton>
+              </ToggleButtonGroup>
 
               {/* Drop zone */}
               <Box
@@ -477,7 +625,7 @@ const UpscalingPage = ({ embedded = false }) => {
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept="video/*"
+                  accept={isImageMode ? "image/*" : "video/*"}
                   multiple
                   onChange={handleFileSelect}
                   style={{ display: "none" }}
@@ -485,7 +633,9 @@ const UpscalingPage = ({ embedded = false }) => {
                 <UploadIcon sx={{ fontSize: 48, color: "text.secondary", mb: 1 }} />
                 {selectedFiles.length === 0 ? (
                   <Typography variant="body1" color="text.secondary">
-                    Drag & drop videos here, or click to browse
+                    {isImageMode
+                      ? "Drag & drop images here, or click to browse"
+                      : "Drag & drop videos here, or click to browse"}
                   </Typography>
                 ) : (
                   <Stack spacing={0.5} sx={{ mt: 0.5 }} onClick={(e) => e.stopPropagation()}>
@@ -526,13 +676,15 @@ const UpscalingPage = ({ embedded = false }) => {
                           {(f.size / (1024 * 1024)).toFixed(1)} MB
                         </Typography>
                         <Stack direction="row">
-                          <IconButton
-                            size="small"
-                            onClick={() => setPreviewFile(f)}
-                            disabled={isUploading}
-                          >
-                            <PreviewIcon fontSize="inherit" />
-                          </IconButton>
+                          {!isImageMode && (
+                            <IconButton
+                              size="small"
+                              onClick={() => setPreviewFile(f)}
+                              disabled={isUploading}
+                            >
+                              <PreviewIcon fontSize="inherit" />
+                            </IconButton>
+                          )}
                           <IconButton
                             size="small"
                             onClick={() => handleRemoveFile(i)}
@@ -575,24 +727,41 @@ const UpscalingPage = ({ embedded = false }) => {
                   </Button>
                 </Stack>
 
-                <Box>
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    Target Resolution
-                  </Typography>
-                  <ToggleButtonGroup
-                    value={targetResolution}
-                    exclusive
-                    onChange={(_, v) => v && setTargetResolution(v)}
-                    size="small"
-                    fullWidth
-                  >
-                    {Object.entries(TARGET_PRESETS).map(([key, preset]) => (
-                      <ToggleButton key={key} value={key}>
-                        {preset.label}
-                      </ToggleButton>
-                    ))}
-                  </ToggleButtonGroup>
-                </Box>
+                {isImageMode ? (
+                  <FormControl fullWidth size="small">
+                    <InputLabel>Output Scale</InputLabel>
+                    <Select
+                      value={imageScale}
+                      label="Output Scale"
+                      onChange={(e) => setImageScale(e.target.value)}
+                    >
+                      {IMAGE_SCALES.map((option) => (
+                        <MenuItem key={option.value || "native"} value={option.value}>
+                          {option.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                ) : (
+                  <Box>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      Target Resolution
+                    </Typography>
+                    <ToggleButtonGroup
+                      value={targetResolution}
+                      exclusive
+                      onChange={(_, v) => v && setTargetResolution(v)}
+                      size="small"
+                      fullWidth
+                    >
+                      {Object.entries(TARGET_PRESETS).map(([key, preset]) => (
+                        <ToggleButton key={key} value={key}>
+                          {preset.label}
+                        </ToggleButton>
+                      ))}
+                    </ToggleButtonGroup>
+                  </Box>
+                )}
 
                 <FormControlLabel
                   control={
@@ -630,23 +799,25 @@ const UpscalingPage = ({ embedded = false }) => {
                   }
                 />
 
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={doubleFps}
-                      onChange={(e) => setDoubleFps(e.target.checked)}
-                      size="small"
-                    />
-                  }
-                  label={
-                    <Stack>
-                      <Typography variant="body2">Double Framerate</Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        Interpolates frames for smoother motion (slower)
-                      </Typography>
-                    </Stack>
-                  }
-                />
+                {!isImageMode && (
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={doubleFps}
+                        onChange={(e) => setDoubleFps(e.target.checked)}
+                        size="small"
+                      />
+                    }
+                    label={
+                      <Stack>
+                        <Typography variant="body2">Double Framerate</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Interpolates frames for smoother motion (slower)
+                        </Typography>
+                      </Stack>
+                    }
+                  />
+                )}
 
                 <Box>
                   <Stack direction="row" justifyContent="space-between">
@@ -686,7 +857,7 @@ const UpscalingPage = ({ embedded = false }) => {
                   variant="contained"
                   size="large"
                   startIcon={isUploading ? <CircularProgress size={20} color="inherit" /> : <EnhanceIcon />}
-                  onClick={handleUpscale}
+                  onClick={handleSubmit}
                   disabled={selectedFiles.length === 0 || isUploading || !serviceAvailable}
                   fullWidth
                   sx={{ mt: 1 }}
@@ -696,10 +867,8 @@ const UpscalingPage = ({ embedded = false }) => {
                       ? `Uploading ${uploadProgress.current}/${uploadProgress.total}...`
                       : "Uploading..."
                     : selectedFiles.length > 1
-                      ? `Upscale ${selectedFiles.length} Videos${twoPass ? " (2-Pass)" : ""}`
-                      : twoPass
-                        ? "Upscale Video (2-Pass)"
-                        : "Upscale Video"}
+                      ? `Upscale ${selectedFiles.length} ${isImageMode ? "Images" : "Videos"}${twoPass ? " (2-Pass)" : ""}`
+                      : `Upscale ${isImageMode ? "Image" : "Video"}${twoPass ? " (2-Pass)" : ""}`}
                 </Button>
               </Stack>
             </CardContent>
@@ -748,6 +917,64 @@ const UpscalingPage = ({ embedded = false }) => {
 
         {/* Right: Preview & Job History */}
         <Grid item xs={12} lg={7}>
+          {imageResult && (
+            <Card sx={{ boxShadow: 2, borderRadius: 2, mb: 3 }}>
+              <CardContent sx={{ p: 3 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                  <Typography variant="h6" sx={{ fontWeight: 600 }} noWrap>
+                    {imageResult.name}
+                  </Typography>
+                  <IconButton size="small" onClick={closeImageResult}>
+                    <CloseIcon />
+                  </IconButton>
+                </Stack>
+                <Grid container spacing={2}>
+                  <Grid item xs={6}>
+                    <Typography variant="subtitle2" align="center" gutterBottom>
+                      Original
+                    </Typography>
+                    <img
+                      src={imageResult.originalUrl}
+                      alt="Original"
+                      style={{ width: "100%", height: "auto", display: "block", borderRadius: "8px" }}
+                    />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Typography variant="subtitle2" align="center" gutterBottom>
+                      Upscaled
+                    </Typography>
+                    <img
+                      src={imageResult.url}
+                      alt="Upscaled"
+                      style={{ width: "100%", height: "auto", display: "block", borderRadius: "8px" }}
+                    />
+                  </Grid>
+                </Grid>
+                <Stack direction="row" spacing={1} justifyContent="center" sx={{ mt: 2 }}>
+                  <Button
+                    size="small"
+                    startIcon={<PreviewIcon />}
+                    component="a"
+                    href={imageResult.url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open full size
+                  </Button>
+                  <Button
+                    size="small"
+                    startIcon={<DownloadIcon />}
+                    component="a"
+                    href={imageResult.url}
+                    download
+                  >
+                    Download
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+          )}
+
           {previewFile && (
             <Card sx={{ boxShadow: 2, borderRadius: 2, mb: 3 }}>
               <CardContent sx={{ p: 3 }}>
@@ -846,17 +1073,23 @@ const UpscalingPage = ({ embedded = false }) => {
 
               {jobs.length === 0 ? (
                 <Typography variant="body2" color="text.secondary" sx={{ textAlign: "center", py: 4 }}>
-                  No upscale jobs yet. Upload a video to get started.
+                  No upscale jobs yet. Upload a video or a batch of images to get started.
                 </Typography>
               ) : (
                 <Stack spacing={2}>
-                  {jobs.map((job) => (
+                  {jobs.map((job) => {
+                    const isBatch = job.kind === "image_batch";
+                    const done = job.frames_done || 0;
+                    const total = job.frames_total || 0;
+                    return (
                     <Card key={job.job_id} variant="outlined">
                       <CardContent sx={{ pb: 1 }}>
                         <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
                           <Box sx={{ flex: 1, minWidth: 0 }}>
                             <Typography variant="subtitle2" noWrap>
-                              {job.input_path?.split("/").pop() || job.job_id}
+                              {isBatch
+                                ? `${job.item_count || total} image${(job.item_count || total) === 1 ? "" : "s"}`
+                                : job.input_path?.split("/").pop() || job.job_id}
                             </Typography>
                             <Stack direction="row" spacing={0.5} sx={{ mt: 0.5, flexWrap: "wrap" }}>
                               <Chip
@@ -884,17 +1117,15 @@ const UpscalingPage = ({ embedded = false }) => {
                           <Box sx={{ mt: 1.5 }}>
                             <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.5 }}>
                               <Typography variant="caption" color="text.secondary">
-                                Frame {job.current_frame || 0} / {job.total_frames || "?"}
+                                {isBatch ? "Image" : "Frame"} {done} / {total || "?"}
                               </Typography>
                               <Typography variant="caption" color="text.secondary">
-                                {job.total_frames > 0
-                                  ? `${Math.round(((job.current_frame || 0) / job.total_frames) * 100)}%`
-                                  : ""}
+                                {total > 0 ? `${Math.round((done / total) * 100)}%` : ""}
                               </Typography>
                             </Stack>
                             <LinearProgress
-                              variant={job.total_frames > 0 ? "determinate" : "indeterminate"}
-                              value={job.total_frames > 0 ? ((job.current_frame || 0) / job.total_frames) * 100 : 0}
+                              variant={total > 0 ? "determinate" : "indeterminate"}
+                              value={total > 0 ? (done / total) * 100 : 0}
                             />
                           </Box>
                         )}
@@ -906,8 +1137,27 @@ const UpscalingPage = ({ embedded = false }) => {
                           </Typography>
                         )}
                       </CardContent>
-                      <CardActions sx={{ pt: 0 }}>
-                        {job.status === "completed" && job.output_path && (
+                      <CardActions sx={{ pt: 0, flexWrap: "wrap" }}>
+                        {isBatch && job.outputs?.length > 0 && (
+                          <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+                            {job.outputs.map((outputPath) => {
+                              const name = outputPath.split("/").pop();
+                              return (
+                                <Button
+                                  key={outputPath}
+                                  size="small"
+                                  startIcon={<DownloadIcon />}
+                                  component="a"
+                                  href={`${API_BASE}/upscaling/output/image/${encodeURIComponent(name)}`}
+                                  download
+                                >
+                                  {name}
+                                </Button>
+                              );
+                            })}
+                          </Stack>
+                        )}
+                        {!isBatch && job.status === "completed" && job.output_path && (
                           <>
                             <Button
                               size="small"
@@ -942,7 +1192,8 @@ const UpscalingPage = ({ embedded = false }) => {
                         )}
                       </CardActions>
                     </Card>
-                  ))}
+                    );
+                  })}
                 </Stack>
               )}
             </CardContent>

--- a/plugins/upscaling/service/app.py
+++ b/plugins/upscaling/service/app.py
@@ -9,7 +9,7 @@ import queue
 import threading
 import time
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import List, Optional
 
 import cv2
 import numpy as np
@@ -68,6 +68,18 @@ class ImageUpscaleRequest(BaseModel):
     sharpen: Optional[float] = 0.3
     two_pass: Optional[bool] = False
     face_enhance: Optional[bool] = False
+
+
+class ImageBatchUpscaleRequest(BaseModel):
+    inputs: List[str]
+    output_dir: str
+    model: Optional[str] = None
+    scale: Optional[float] = None
+    denoise_strength: Optional[float] = 0.0
+    sharpen: Optional[float] = 0.3
+    two_pass: Optional[bool] = False
+    face_enhance: Optional[bool] = False
+    suffix: str = "upscaled"
 
 
 class VideoUpscaleRequest(BaseModel):
@@ -172,6 +184,23 @@ def _submit_watch_job(input_path: str):
 
 # --- Helpers ---
 
+def _atomic_imwrite(output_path: str, image) -> bool:
+    """Write ``image`` to ``output_path`` via a sibling temp file.
+
+    The temp name keeps the target extension: OpenCV chooses its encoder from
+    the final extension and refuses to write one it does not recognise.
+    """
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    root, ext = os.path.splitext(output_path)
+    tmp_path = f"{root}.tmp{ext}"
+    if not cv2.imwrite(tmp_path, image):
+        return False
+    os.replace(tmp_path, output_path)
+    return True
+
+
 def _ensure_model(model_name: Optional[str] = None) -> str:
     """Ensure the requested (or default) model is loaded. Returns model name."""
     name = model_name or _config.default_model
@@ -213,9 +242,74 @@ def _start_video_job(
         _job_manager.fail_job(job["job_id"], error="Job queue not initialized")
         return job
 
-    _job_queue.put(
-        (job["job_id"], input_path, output_path, name, scale, denoise_strength, sharpen, two_pass, face_enhance, double_fps, cancel_event)
+    _job_queue.put({
+        "kind": "video",
+        "job_id": job["job_id"],
+        "input_path": input_path,
+        "output_path": output_path,
+        "model_name": name,
+        "scale": scale,
+        "denoise_strength": denoise_strength,
+        "sharpen": sharpen,
+        "two_pass": two_pass,
+        "face_enhance": face_enhance,
+        "double_fps": double_fps,
+        "cancel_event": cancel_event,
+    })
+    return job
+
+
+def _start_image_batch_job(
+    inputs: list,
+    output_dir: str,
+    model_name: Optional[str],
+    scale: Optional[float],
+    denoise_strength: float,
+    sharpen: float,
+    two_pass: bool,
+    face_enhance: bool,
+    suffix: str,
+) -> dict:
+    """Create one job covering N images and drop it on the shared GPU queue.
+
+    Image batches ride the same single-consumer queue as video so a folder of
+    stills never competes with a running render for VRAM.
+    """
+    name = model_name or _config.default_model
+    job = _job_manager.create_job(
+        input_path=inputs[0] if inputs else output_dir,
+        output_path=output_dir,
+        model=name,
+        scale=scale or 0,
+        denoise_strength=denoise_strength,
+        sharpen=sharpen,
+        two_pass=two_pass,
+        face_enhance=face_enhance,
+        double_fps=False,
+        kind="image_batch",
+        item_count=len(inputs),
     )
+    cancel_event = threading.Event()
+    _cancel_flags[job["job_id"]] = cancel_event
+
+    if _job_queue is None:
+        _job_manager.fail_job(job["job_id"], error="Job queue not initialized")
+        return job
+
+    _job_queue.put({
+        "kind": "image_batch",
+        "job_id": job["job_id"],
+        "inputs": list(inputs),
+        "output_dir": output_dir,
+        "model_name": name,
+        "scale": scale,
+        "denoise_strength": denoise_strength,
+        "sharpen": sharpen,
+        "two_pass": two_pass,
+        "face_enhance": face_enhance,
+        "suffix": suffix,
+        "cancel_event": cancel_event,
+    })
     return job
 
 
@@ -226,12 +320,25 @@ def _job_worker():
         task = _job_queue.get()
         if task is None:
             break
-        job_id, input_path, output_path, model_name, scale, denoise, sharpen, two_pass, face_enhance, double_fps, cancel_event = task
+        job_id = task["job_id"]
         try:
-            _run_video_job(job_id, input_path, output_path, model_name, scale, denoise, sharpen, two_pass, face_enhance, double_fps, cancel_event)
+            if task["kind"] == "image_batch":
+                _run_image_batch_job(
+                    job_id, task["inputs"], task["output_dir"], task["model_name"],
+                    task["scale"], task["denoise_strength"], task["sharpen"],
+                    task["two_pass"], task["face_enhance"], task["suffix"],
+                    task["cancel_event"],
+                )
+            else:
+                _run_video_job(
+                    job_id, task["input_path"], task["output_path"], task["model_name"],
+                    task["scale"], task["denoise_strength"], task["sharpen"],
+                    task["two_pass"], task["face_enhance"], task["double_fps"],
+                    task["cancel_event"],
+                )
         except Exception as e:
-            # _run_video_job already records failure into the job manager;
-            # this is a last-resort log so a worker crash doesn't kill the loop.
+            # The runners already record failure into the job manager; this is a
+            # last-resort log so a worker crash doesn't kill the loop.
             logger.exception(f"Worker crashed processing {job_id}: {e}")
 
 
@@ -368,6 +475,119 @@ def _run_video_job(
             torch.cuda.empty_cache()
 
 
+def _run_image_batch_job(
+    job_id: str,
+    inputs: list,
+    output_dir: str,
+    model_name: str,
+    scale: Optional[float],
+    denoise_strength: float,
+    sharpen: float,
+    two_pass: bool,
+    face_enhance: bool,
+    suffix: str,
+    cancel_event: threading.Event,
+):
+    """Background worker for an image-batch upscale job.
+
+    Frame counters count images. A file that fails to decode or write is
+    recorded in ``error`` and skipped; the batch only fails outright when no
+    image succeeded.
+    """
+    start_time = time.time()
+    try:
+        if cancel_event.is_set():
+            _job_manager.cancel_job(job_id)
+            logger.info(f"Job {job_id} cancelled before start")
+            return
+
+        if torch.cuda.is_available():
+            free, _total = torch.cuda.mem_get_info(0)
+            free_mb = free / (1024 * 1024)
+            if free_mb < 500:
+                raise RuntimeError(f"Insufficient VRAM: {free_mb:.0f}MB free, need ~500MB minimum")
+
+        _ensure_model(model_name)
+        model = _model_manager.get_model()
+        model_scale = _model_manager.scale or 4
+
+        tile_size = 400
+        if _config.max_tile_size != "auto":
+            tile_size = int(_config.max_tile_size)
+
+        os.makedirs(output_dir, exist_ok=True)
+        _job_manager.start_job(job_id, total_frames=len(inputs))
+        _send_callback("upscale:job_started", {
+            "job_id": job_id,
+            "input_file": inputs[0] if inputs else output_dir,
+            "model": model_name,
+        })
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        done = 0
+        failures = []
+
+        for input_path in inputs:
+            if cancel_event.is_set():
+                raise InterruptedError("Job cancelled")
+
+            img = cv2.imread(input_path, cv2.IMREAD_UNCHANGED)
+            if img is None:
+                failures.append(f"{os.path.basename(input_path)}: unreadable")
+                done += 1
+                _job_manager.update_progress(job_id, done, 0.0)
+                continue
+
+            # Same lock the sync image endpoints take — model swap and upscale
+            # must not interleave with a concurrent request.
+            with _image_upscale_lock:
+                output = upscale_image(
+                    img, model, model_scale,
+                    outscale=scale, tile_size=tile_size,
+                    device=device, precision=_config.precision,
+                    sharpen=sharpen, denoise_strength=denoise_strength,
+                    two_pass=two_pass, face_enhance=face_enhance,
+                )
+
+            stem = os.path.splitext(os.path.basename(input_path))[0]
+            output_path = os.path.join(output_dir, f"{stem}_{suffix}.png")
+            if not _atomic_imwrite(output_path, output):
+                failures.append(f"{os.path.basename(input_path)}: write failed")
+                done += 1
+                _job_manager.update_progress(job_id, done, 0.0)
+                continue
+            _job_manager.add_output(job_id, output_path)
+
+            done += 1
+            elapsed = time.time() - start_time
+            _job_manager.update_progress(job_id, done, done / elapsed if elapsed > 0 else 0.0)
+
+        if failures and len(failures) == len(inputs):
+            raise RuntimeError("; ".join(failures[:5]))
+        if failures:
+            _job_manager.set_error(job_id, f"{len(failures)} skipped: " + "; ".join(failures[:5]))
+        _job_manager.complete_job(job_id)
+        logger.info(f"Job {job_id} completed: {done - len(failures)}/{len(inputs)} images -> {output_dir}")
+
+        _send_callback("upscale:job_completed", {
+            "job_id": job_id,
+            "output_file": output_dir,
+            "duration_seconds": round(time.time() - start_time, 1),
+        })
+
+    except InterruptedError as e:
+        _job_manager.cancel_job(job_id)
+        logger.info(f"Job {job_id} stopped: {e}")
+    except Exception as e:
+        logger.error(f"Job {job_id} failed: {e}", exc_info=True)
+        _job_manager.fail_job(job_id, error=str(e))
+        _send_callback("upscale:job_failed", {"job_id": job_id, "error": str(e)})
+    finally:
+        _cancel_flags.pop(job_id, None)
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+
 def _send_callback(event: str, payload: dict):
     """Send event callback to Guaardvark backend (best-effort)."""
     if not _config or not _config.callback_url:
@@ -454,14 +674,8 @@ def upscale_image_endpoint(req: ImageUpscaleRequest, request: Request):
             face_enhance=req.face_enhance if req.face_enhance is not None else False,
         )
 
-    # `os.path.dirname("foo.png")` returns "" — `os.makedirs("")` raises
-    # FileNotFoundError. Only call it when there's actually a directory part.
-    output_dir = os.path.dirname(req.output_path)
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-    tmp_path = req.output_path + ".tmp"
-    cv2.imwrite(tmp_path, output)
-    os.replace(tmp_path, req.output_path)
+    if not _atomic_imwrite(req.output_path, output):
+        raise HTTPException(500, f"Could not write image: {req.output_path}")
     return {"status": "completed", "output_path": req.output_path}
 
 
@@ -515,6 +729,31 @@ async def upscale_image_upload(
         filename=f"upscaled_{file.filename}",
         background=BackgroundTask(os.unlink, tmp_file.name),
     )
+
+
+@app.post("/upscale/images", status_code=202)
+def upscale_images_endpoint(req: ImageBatchUpscaleRequest, request: Request):
+    """Queue a batch of images as a single job on the shared GPU worker."""
+    verify_token(request)
+    if not req.inputs:
+        raise HTTPException(400, "inputs must not be empty")
+
+    missing = [p for p in req.inputs if not os.path.isfile(p)]
+    if missing:
+        raise HTTPException(400, f"Input file not found: {missing[0]}")
+
+    job = _start_image_batch_job(
+        inputs=req.inputs,
+        output_dir=req.output_dir,
+        model_name=req.model,
+        scale=req.scale,
+        denoise_strength=req.denoise_strength if req.denoise_strength is not None else 0.0,
+        sharpen=req.sharpen if req.sharpen is not None else 0.3,
+        two_pass=req.two_pass if req.two_pass is not None else False,
+        face_enhance=req.face_enhance if req.face_enhance is not None else False,
+        suffix=req.suffix,
+    )
+    return job
 
 
 @app.post("/upscale/video", status_code=202)

--- a/plugins/upscaling/service/jobs.py
+++ b/plugins/upscaling/service/jobs.py
@@ -1,4 +1,4 @@
-"""Job state machine and history for video upscaling jobs."""
+"""Job state machine and history for upscaling jobs (video and image batches)."""
 import threading
 import time
 import uuid
@@ -34,11 +34,21 @@ class JobManager:
         two_pass: bool = False,
         face_enhance: bool = False,
         double_fps: bool = False,
+        kind: str = "video",
+        item_count: int = 1,
     ) -> Dict[str, Any]:
+        """Register a PENDING job.
+
+        ``kind`` is ``"video"`` or ``"image_batch"``; for an image batch the
+        frame counters count images and ``outputs`` collects each written file.
+        """
         job_id = uuid.uuid4().hex[:12]
         job = {
             "job_id": job_id,
             "status": JobStatus.PENDING.value,
+            "kind": kind,
+            "item_count": item_count,
+            "outputs": [],
             "input_path": input_path,
             "output_path": output_path,
             "model": model,
@@ -88,6 +98,23 @@ class JobManager:
                 job["fps"] = fps
                 remaining = job["frames_total"] - frames_done
                 job["eta_seconds"] = round(remaining / fps) if fps > 0 else None
+
+    def add_output(self, job_id: str, output_path: str) -> None:
+        """Record one finished output file on a multi-item job."""
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is not None:
+                job["outputs"].append(output_path)
+
+    def set_error(self, job_id: str, error: str) -> None:
+        """Attach an error note without moving the job out of its current state.
+
+        Used for per-item failures inside a batch that still finishes.
+        """
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is not None:
+                job["error"] = error
 
     def complete_job(self, job_id: str) -> None:
         with self._lock:

--- a/plugins/upscaling/tests/test_app.py
+++ b/plugins/upscaling/tests/test_app.py
@@ -82,3 +82,50 @@ def test_job_not_found(client):
 def test_cancel_job_requires_auth(client):
     resp = client.delete("/jobs/someid")
     assert resp.status_code == 401
+
+
+def test_upscale_images_requires_auth(client):
+    resp = client.post(
+        "/upscale/images",
+        json={"inputs": ["/fake.png"], "output_dir": "/tmp/out"},
+    )
+    assert resp.status_code == 401
+
+
+def test_upscale_images_rejects_empty_input_list(client):
+    resp = client.post(
+        "/upscale/images",
+        json={"inputs": [], "output_dir": "/tmp/out"},
+        headers=AUTH_HEADER,
+    )
+    assert resp.status_code == 400
+
+
+def test_upscale_images_validates_inputs_exist(client):
+    resp = client.post(
+        "/upscale/images",
+        json={"inputs": ["/nonexistent/frame.png"], "output_dir": "/tmp/out"},
+        headers=AUTH_HEADER,
+    )
+    assert resp.status_code == 400
+
+
+def test_atomic_imwrite_keeps_the_target_extension(tmp_path):
+    """OpenCV picks its encoder off the final extension, so the temp file keeps it."""
+    import numpy as np
+    from service.app import _atomic_imwrite
+
+    target = tmp_path / "still_upscaled.png"
+    assert _atomic_imwrite(str(target), np.zeros((4, 4, 3), np.uint8)) is True
+    assert target.read_bytes().startswith(b"\x89PNG")
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_atomic_imwrite_creates_missing_directories(tmp_path):
+    import numpy as np
+    from service.app import _atomic_imwrite
+
+    target = tmp_path / "nested" / "out.png"
+    assert _atomic_imwrite(str(target), np.zeros((4, 4, 3), np.uint8)) is True
+    assert target.exists()
+

--- a/plugins/upscaling/tests/test_jobs.py
+++ b/plugins/upscaling/tests/test_jobs.py
@@ -96,3 +96,41 @@ def test_active_job_count():
     assert jm.active_job_count == 2  # both RUNNING
     jm.complete_job(job1["job_id"])
     assert jm.active_job_count == 1  # 1 RUNNING
+
+
+def test_create_job_defaults_to_a_video_job():
+    jm = JobManager(max_history=5)
+    job = jm.create_job("/tmp/in.mp4", "/tmp/out.mp4", "m", 4.0)
+    assert job["kind"] == "video"
+    assert job["item_count"] == 1
+    assert job["outputs"] == []
+
+
+def test_image_batch_job_collects_outputs():
+    jm = JobManager(max_history=5)
+    job = jm.create_job(
+        "/tmp/a.png", "/tmp/out", "m", 4.0, kind="image_batch", item_count=2,
+    )
+    jm.start_job(job["job_id"], total_frames=2)
+    jm.add_output(job["job_id"], "/tmp/out/a_upscaled.png")
+    jm.add_output(job["job_id"], "/tmp/out/b_upscaled.png")
+    jm.complete_job(job["job_id"])
+
+    updated = jm.get_job(job["job_id"])
+    assert updated["kind"] == "image_batch"
+    assert updated["item_count"] == 2
+    assert updated["outputs"] == ["/tmp/out/a_upscaled.png", "/tmp/out/b_upscaled.png"]
+    assert updated["status"] == JobStatus.COMPLETED.value
+
+
+def test_set_error_leaves_status_alone():
+    jm = JobManager(max_history=5)
+    job = jm.create_job("/tmp/a.png", "/tmp/out", "m", 4.0, kind="image_batch", item_count=2)
+    jm.start_job(job["job_id"], total_frames=2)
+    jm.set_error(job["job_id"], "1 skipped: b.png: unreadable")
+    jm.complete_job(job["job_id"])
+
+    updated = jm.get_job(job["job_id"])
+    assert updated["status"] == JobStatus.COMPLETED.value
+    assert "unreadable" in updated["error"]
+


### PR DESCRIPTION
Four changes plus two README corrections. Independent slices — reviewable commit by commit.

## Media workspace is one tabbed page with five routes

`constants/mediaTabs.js` is the single source of truth for `/images`, `/batch-images`, `/infographic`, `/video`, `/upscaling`. All five route to `ImagesPage`, which derives the active tab from `useLocation()` — no local tab state to drift. The strip is present whichever tab you land on, every tab is linkable, and Infographic and Upscaling get sidebar entries instead of being reachable only through that one strip.

`/video` now mounts `ImagesPage` → `<VideoGeneratorPage embedded />` rather than the standalone page. The `/Images` browse and window-state restore are gated on the Media Library tab and run once, so arriving on Video Gen no longer pays for a library load.

## Image upscaling, single and batch

The plugin could already upscale a still; nothing proxied or exposed it.

- **Single** — `POST /api/upscaling/upscale/image`, synchronous, returns the finished file; before/after with download.
- **Batch** — `POST /api/upscaling/upscale/images` creates one `kind: "image_batch"` job on the plugin's existing single-consumer queue, so a folder of stills serialises against video renders instead of racing them for VRAM. Frame counters count images; per-item failures are recorded without failing the batch.

Neither route accepts a caller-supplied path: both sides are derived server-side from `secure_filename` + a uuid under `data/outputs/upscaling/{input,output}/images`, and reads resolve through a `safe_join`-based `_contained_file`.

Two bugs fixed en route:
- The jobs progress bar read `job.current_frame`/`job.total_frames`; the service only emits `frames_done`/`frames_total`, so every running job rendered as 0% indeterminate.
- `/upscale/image` wrote through `output_path + ".tmp"`. `cv2.imwrite` picks its encoder from the final extension and **raises** on `.tmp`, so that endpoint had never worked. Both paths now use `_atomic_imwrite`.

## ComfyUI cancel is scoped to prompts we queued

Cancel posted a bare `/interrupt` and followed it with `/queue {"clear": true}` — stopping whatever was sampling regardless of owner and dropping every other client's pending work. ComfyUI already supports the scoped form (`/interrupt {"prompt_id": ...}` + atomic `interrupt_if_running`), and `_queue_prompt` was being handed the id and discarding it.

The registry is class-level because generate and cancel do not always hold the same generator: the batch runner uses the module singleton, the router keeps its own and replaces it on every `get_active_generator()`.

An unscoped fallback remains for the cross-process case (a cancel raised in Flask for a clip the Celery worker queued) — minus the queue clear, so it is strictly narrower than what it replaced. It goes away when cross-process cancel lands.

## System map reads in light themes

96 colour literals on the page and a `PALETTE` const in the canvas were hardcoded to the dark theme — pale blue ink and ~78% lightness nodes, invisible on white. Both now draw from `createMapPalette(mode)`.

A straight triplet swap was not enough: compositing toward black gains contrast faster than toward white, so the naive light palette measured 3.18:1 at alpha .55 against dark's 4.59:1. Light mode uses a darker ink and lifts alphas (`α → min(1, α·1.2 + .06)`, 0 pinned to 0 so canvas gradients still fade out). `palette.test.js` holds light ≥ dark at every alpha used, and AA for body ink.

## README

Opens with the aardvark species entry (quoted and attributed) rewritten for the repo — it doubles as a pronunciation guide. And the architecture diagram's "~70 tool classes" is now ~60, the number `tool_registry_init.py` actually registers (61 calls, 59 distinct); MCP-proxied tools push a live install past 70, which is what the description says.

## Testing

- vitest 118 pass; frontend build clean
- `backend/tests/api/test_upscaling_image_api.py` — 17, first backend coverage of `upscaling_api.py`
- `backend/tests/services/test_comfyui_interrupt_scope.py` — 10
- plugin `plugins/upscaling/tests` — 49
- `scripts/check_portable.sh` clean

Not verified on hardware: the System Map in Light by eye, and a real GPU image upscale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)