### PR TITLE
fix(interconnector): stable IP-independent node identity + server-side heartbeat daemon

### DIFF
--- a/backend/api/interconnector_api.py
+++ b/backend/api/interconnector_api.py
@@ -730,6 +730,88 @@ def debug_nodes():
         return error_response(f"Debug failed: {str(e)}", 500)
 
 
+def _safe_json(text):
+    """Parse a JSON text column into a dict; empty/invalid -> {}."""
+    try:
+        return json.loads(text) if text else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def _profile_fingerprint(profile) -> Optional[str]:
+    """A stable, IP-INDEPENDENT machine fingerprint from a hardware profile.
+
+    Uses hostname — which does not change with DHCP leases, VPN/Tailscale
+    routing, or which browser registered the node. Returns None when there's
+    nothing trustworthy to match on.
+    """
+    if isinstance(profile, dict):
+        host = profile.get("hostname")
+        if host:
+            return str(host).strip().lower()
+    return None
+
+
+def _prune_duplicate_nodes(keep_id: str, fingerprint: Optional[str]) -> int:
+    """Self-heal: delete other rows describing the SAME physical machine.
+
+    The old IP-coupled identity logic minted a fresh node_id whenever a node
+    reappeared from a different address, leaving a trail of stale duplicate
+    rows for one machine. Now that identity is machine-stable, any OTHER row
+    with the same hostname fingerprint is a leftover duplicate and is removed
+    (cascades to its sync history / conflicts). Runs on every registration, so
+    every install self-heals over time. Conservative: skips weak fingerprints.
+    """
+    if not fingerprint or fingerprint in ("", "localhost", "unknown", "guaardvark"):
+        return 0
+    try:
+        removed = 0
+        for other in db.session.query(InterconnectorNode).filter(
+            InterconnectorNode.node_id != keep_id
+        ).all():
+            if _profile_fingerprint(_safe_json(other.hardware_profile)) == fingerprint:
+                db.session.delete(other)
+                removed += 1
+        if removed:
+            db.session.commit()
+            logger.info(
+                "[SYNC] Pruned %d duplicate node row(s) for host '%s' (kept %s)",
+                removed, fingerprint, _redact_log_value(keep_id),
+            )
+        return removed
+    except Exception as exc:  # dedup must never break registration
+        db.session.rollback()
+        logger.warning("[SYNC] Duplicate-node prune failed (non-fatal): %s", exc)
+        return 0
+
+
+@interconnector_bp.route("/nodes/local-identity", methods=["GET"])
+def local_identity():
+    """Return THIS machine's stable, IP-independent node identity.
+
+    So the UI registers/heartbeats with the machine id (persisted at
+    ~/.guaardvark/node_id, exported as CLUSTER_NODE_ID) instead of a
+    browser-localStorage id that changes per browser/cache-clear. Works for
+    every install out of the box; needs no master mode (a node asking itself).
+    """
+    import socket
+    node_id = os.environ.get("CLUSTER_NODE_ID") or ""
+    hostname = None
+    try:
+        hostname = socket.gethostname()
+    except Exception:
+        pass
+    if not node_id:
+        try:
+            from backend.services.hardware_detector import HardwareDetector
+            prof = HardwareDetector().detect()
+            node_id = prof.get("node_id") or ""
+            hostname = prof.get("hostname") or hostname
+        except Exception as exc:
+            logger.debug("[SYNC] local-identity hardware detect failed: %s", exc)
+    return success_response({"node_id": node_id, "hostname": hostname}, "Local identity")
+
+
 @interconnector_bp.route("/nodes/register", methods=["POST"])
 def register_node():
     """Register a client node with the master."""
@@ -806,32 +888,45 @@ def register_node():
             port = default_port
             logger.debug(f"[SYNC] Using default port: {port}")
 
-        # Generate node ID — always generate fresh for new registrations to
-        # prevent collisions when Full Backups are restored to multiple machines.
-        # Only reuse a provided node_id if it already exists AND the IP matches.
+        # ---- Stable, IP-INDEPENDENT node identity -------------------------
+        # A node's identity is its machine-stable id (persisted at
+        # ~/.guaardvark/node_id on the worker and carried in
+        # hardware_profile["node_id"]), NOT its IP address. A node reachable via
+        # multiple paths (LAN, VPN, Tailscale) or with a changed DHCP lease is
+        # the SAME node — we update its row rather than minting a duplicate.
+        # Only trust the profile for identity when the CLIENT actually sent it.
+        # When the server fills it in via fallback detection, that profile carries
+        # the SERVER's node_id/hostname, which must never become the client's id.
+        profile_was_provided = bool(data.get("hardware_profile"))
+        profile_node_id = None
+        incoming_host = None
+        if profile_was_provided and isinstance(profile_from_payload, dict):
+            profile_node_id = profile_from_payload.get("node_id")
+            incoming_host = _profile_fingerprint(profile_from_payload)
         provided_id = data.get("node_id")
-        node_id = None
+        # Prefer the machine-stable id from the hardware profile; fall back to an
+        # explicitly provided node_id; only mint a UUID if we have neither.
+        node_id = profile_node_id or provided_id
 
-        if provided_id:
-            existing_node = db.session.get(InterconnectorNode, provided_id)
-            if existing_node and existing_node.host == client_ip:
-                # Same machine re-registering (e.g., after reboot) — safe to reuse
-                node_id = provided_id
-                logger.debug(
-                    f"[SYNC] Reusing node {_node_log_label(node_id)} "
-                    f"(IP matches {_redact_log_value(client_ip)})"
-                )
-            elif existing_node:
-                # COLLISION: Different machine using same node_id (backup restore scenario)
-                logger.warning(
-                    f"[SYNC] Node ID collision detected: {_redact_log_value(provided_id)} "
-                    f"registered to {_redact_log_value(existing_node.host)} but request "
-                    f"from {_redact_log_value(client_ip)}. Generating fresh ID."
-                )
-                node_id = str(uuid.uuid4())
-            else:
-                node_id = provided_id
-
+        if node_id:
+            existing_node = db.session.get(InterconnectorNode, node_id)
+            if existing_node:
+                existing_host = _profile_fingerprint(_safe_json(existing_node.hardware_profile))
+                # A genuine collision is a DIFFERENT physical machine claiming the
+                # same id (e.g. a Full Backup that copied ~/.guaardvark/node_id to
+                # another box). Detect it by hostname fingerprint — never by IP.
+                if existing_host and incoming_host and existing_host != incoming_host:
+                    logger.warning(
+                        "[SYNC] node_id %s is claimed by a different machine "
+                        "(existing host='%s', incoming host='%s') — minting a fresh id",
+                        _redact_log_value(node_id), existing_host, incoming_host,
+                    )
+                    node_id = str(uuid.uuid4())
+                else:
+                    logger.debug(
+                        "[SYNC] Reusing stable node %s (machine match; IP may differ)",
+                        _node_log_label(node_id),
+                    )
         if not node_id:
             node_id = str(uuid.uuid4())
         logger.debug(f"[SYNC] Using node: {_node_log_label(node_id, node_name)}")
@@ -846,6 +941,7 @@ def register_node():
             existing_node.port = port
             existing_node.node_mode = node_mode
             existing_node.status = "active"
+            existing_node.online = True
             existing_node.last_heartbeat = datetime.now()
             existing_node.hardware_profile = json.dumps(profile_from_payload, sort_keys=True)
             existing_node.sync_entities = json.dumps(sync_entities)
@@ -892,6 +988,10 @@ def register_node():
                 )
             else:
                 logger.error(f"[SYNC] CRITICAL: Node {node_id} was not saved to database!")
+
+        # Self-heal: collapse any duplicate rows left by the old IP-coupled
+        # identity logic for this same physical machine.
+        _prune_duplicate_nodes(node_id, incoming_host)
 
         # Return node ID
         return success_response(
@@ -1009,7 +1109,10 @@ def get_nodes():
                 f"[SYNC] Marking stale node disconnected: "
                 f"{_node_log_label(node.node_id, node.node_name)}"
             )
+            # Keep the two liveness fields in agreement — they used to disagree
+            # (status='disconnected' while online=True), which read as flapping.
             node.status = "disconnected"
+            node.online = False
         
         db.session.commit()
 

--- a/backend/api/interconnector_api.py
+++ b/backend/api/interconnector_api.py
@@ -785,6 +785,39 @@ def _prune_duplicate_nodes(keep_id: str, fingerprint: Optional[str]) -> int:
         return 0
 
 
+def _stable_local_node_id(config: dict, fallback: str = "local_node") -> str:
+    """This node's stable id for local records — the machine id (CLUSTER_NODE_ID),
+    falling back to the configured node_name for very old setups."""
+    return os.environ.get("CLUSTER_NODE_ID") or config.get("node_name") or fallback
+
+
+def _ensure_local_self_node(node_id: str, node_name: Optional[str],
+                            node_mode: str = "client"):
+    """Ensure a row exists for THIS node so local sync-history writes (which FK to
+    interconnector_nodes.node_id) and last_sync_time updates succeed.
+
+    Previously these used node_name as the id with no matching row, causing
+    ForeignKeyViolations that aborted the sync transaction. On a client this row
+    is never exposed — get_nodes is master-only.
+    """
+    node = db.session.get(InterconnectorNode, node_id)
+    if node:
+        return node
+    node = InterconnectorNode(
+        node_id=node_id,
+        node_name=node_name or "local",
+        host="127.0.0.1",
+        port=int(os.environ.get("FLASK_PORT", 5000)),
+        node_mode=node_mode or "client",
+        status="active",
+        last_heartbeat=datetime.now(),
+        hardware_profile="{}",
+    )
+    db.session.add(node)
+    db.session.flush()
+    return node
+
+
 @interconnector_bp.route("/nodes/local-identity", methods=["GET"])
 def local_identity():
     """Return THIS machine's stable, IP-independent node identity.
@@ -2427,8 +2460,11 @@ def trigger_manual_sync():
         }
         details = {}
 
-        # Get local node ID (use node_name as identifier for now)
-        local_node_id = config.get("node_name", "local_node")
+        # Local node identity = the machine-stable id; ensure a self-row exists
+        # so the sync-history FK and last_sync_time update below succeed.
+        local_node_id = _stable_local_node_id(config)
+        _ensure_local_self_node(local_node_id, config.get("node_name"),
+                                config.get("node_mode", "client"))
 
         try:
             # Pull sync
@@ -3762,7 +3798,9 @@ def apply_updates():
         # The files themselves are persisted on disk by apply_files_atomic (written + hash-matched
         # on future checks).
         try:
-            local_node_id = config.get("node_name") or "local_client"
+            local_node_id = _stable_local_node_id(config, fallback="local_client")
+            _ensure_local_self_node(local_node_id, config.get("node_name"),
+                                    config.get("node_mode", "client"))
             sync_history = InterconnectorSyncHistory(
                 node_id=local_node_id,
                 sync_direction="pull",

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -444,6 +444,20 @@ def create_celery_app():
         logger.warning(f"Could not import cluster heartbeat sweeper: {e}")
 
     try:
+        from backend.tasks import interconnector_client_heartbeat  # noqa: F401 - registers task
+        # Scheduled on EVERY node; the task early-returns cheaply unless this node
+        # is a configured, enabled client with a master URL. Makes a worker's
+        # liveness independent of whether a browser tab is open.
+        celery_app.conf.beat_schedule['interconnector-client-heartbeat'] = {
+            'task': 'interconnector.client_heartbeat',
+            'schedule': float(os.environ.get("INTERCONNECTOR_HEARTBEAT_INTERVAL_S", 60)),
+            'options': {'queue': 'health'},
+        }
+        logger.info("Interconnector client-heartbeat task registered and scheduled")
+    except ImportError as e:
+        logger.warning(f"Could not import interconnector client heartbeat: {e}")
+
+    try:
         from backend.tasks.plugin_tasks import reconcile_plugin_deps  # noqa: F401
         logger.info("Plugin dependency reconciler task imported successfully")
     except ImportError as e:

--- a/backend/tasks/cluster_heartbeat_sweeper.py
+++ b/backend/tasks/cluster_heartbeat_sweeper.py
@@ -14,7 +14,10 @@ from celery import shared_task
 
 log = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT_S = 15  # per spec §6.2
+# Must be comfortably LARGER than the heartbeat send interval (60s browser /
+# any daemon), or a healthy node merely *between* beats gets flapped offline on
+# nearly every sweep. 150s tolerates two missed 60s beats before declaring dead.
+DEFAULT_TIMEOUT_S = 150
 
 
 def _run_sweep(timeout_s: int) -> dict:
@@ -22,7 +25,11 @@ def _run_sweep(timeout_s: int) -> dict:
     from backend.models import db, InterconnectorNode
     from backend.services.fleet_map import get_fleet_map
 
-    threshold = datetime.utcnow() - timedelta(seconds=timeout_s)
+    # Use the SAME clock the heartbeat writer uses (interconnector_api writes
+    # last_heartbeat with datetime.now(), naive local). Comparing a UTC
+    # threshold against a local timestamp made the sweeper mark everything
+    # stale (or nothing) by the host's UTC offset. Match the writer here.
+    threshold = datetime.now() - timedelta(seconds=timeout_s)
 
     marked_offline: list[str] = []
     marked_online: list[str] = []
@@ -33,6 +40,7 @@ def _run_sweep(timeout_s: int) -> dict:
         is_stale = node.last_heartbeat < threshold
         if is_stale and node.online:
             node.online = False
+            node.status = "disconnected"  # keep the two liveness fields in sync
             marked_offline.append(node.node_id)
             fm = get_fleet_map()
             fm.set_online(node.node_id, False)
@@ -44,6 +52,7 @@ def _run_sweep(timeout_s: int) -> dict:
             )
         elif not is_stale and not node.online:
             node.online = True
+            node.status = "active"
             get_fleet_map().set_online(node.node_id, True)
             marked_online.append(node.node_id)
             log.info("[CLUSTER] node %s back online", node.node_id)

--- a/backend/tasks/interconnector_client_heartbeat.py
+++ b/backend/tasks/interconnector_client_heartbeat.py
@@ -1,0 +1,127 @@
+"""Server-side client heartbeat — keeps a worker node's liveness up to date
+WITHOUT depending on a browser tab being open.
+
+The React Interconnector settings page also sends heartbeats, but only while it
+is open and focused (browsers throttle background timers). This periodic task
+makes a client node self-register (once) and heartbeat to its master on a fixed
+cadence from the backend, so a node stays "online" as long as its backend runs
+— which is the behaviour every install expects.
+
+Runs on every node; it early-returns cheaply unless this node is a configured,
+enabled client with a master URL. Scheduled from celery_app beat_schedule.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import time
+
+import requests
+from celery import shared_task
+
+log = logging.getLogger(__name__)
+
+# HardwareDetector.detect() probes CPU/GPU/disk (~200ms). Cache it so a 60s
+# heartbeat doesn't re-probe every minute.
+_profile_cache: dict = {"profile": None, "expires": 0.0}
+_PROFILE_TTL_S = 600
+
+
+def _load_config() -> dict:
+    from backend.models import db, Setting
+    try:
+        setting = db.session.get(Setting, "interconnector_config")
+        if setting and setting.value:
+            return json.loads(setting.value) if isinstance(setting.value, str) else setting.value
+    except Exception as exc:  # never let config read crash the beat task
+        log.debug("[SYNC] client-heartbeat: config read failed: %s", exc)
+    return {}
+
+
+def _local_profile() -> dict:
+    now = time.time()
+    if _profile_cache["profile"] is not None and _profile_cache["expires"] > now:
+        return _profile_cache["profile"]
+    from backend.services.hardware_detector import HardwareDetector
+    profile = HardwareDetector().detect()
+    _profile_cache["profile"] = profile
+    _profile_cache["expires"] = now + _PROFILE_TTL_S
+    return profile
+
+
+def _local_node_id(profile: dict) -> str:
+    return os.environ.get("CLUSTER_NODE_ID") or (profile.get("node_id") if profile else "") or ""
+
+
+def _register(master_url: str, headers: dict, node_id: str, node_name: str,
+              profile: dict, config: dict) -> None:
+    """Self-register with the master. Idempotent: the master keys on the
+    machine-stable node_id (from hardware_profile), so this updates in place."""
+    requests.post(
+        f"{master_url}/api/interconnector/nodes/register",
+        json={
+            "node_id": node_id,
+            "node_name": node_name,
+            "node_mode": "client",
+            "hardware_profile": profile,
+            "port": int(os.environ.get("FLASK_PORT", 5000)),
+            "sync_entities": config.get("sync_entities", []),
+        },
+        headers=headers,
+        timeout=10,
+    )
+
+
+def _do_client_heartbeat() -> dict:
+    config = _load_config()
+    if not config.get("is_enabled") or config.get("node_mode") != "client":
+        return {"skipped": "not_enabled_client"}
+    master_url = (config.get("master_url") or "").rstrip("/")
+    if not master_url:
+        return {"skipped": "no_master_url"}
+
+    profile = _local_profile()
+    node_id = _local_node_id(profile)
+    if not node_id:
+        return {"skipped": "no_node_id"}
+
+    node_name = config.get("node_name") or socket.gethostname()
+    api_key = config.get("master_api_key") or ""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+
+    hb_url = f"{master_url}/api/interconnector/nodes/{node_id}/heartbeat"
+    payload = {"hardware_profile": profile, "sync_entities": config.get("sync_entities", [])}
+    try:
+        resp = requests.post(hb_url, json=payload, headers=headers, timeout=10)
+        if resp.status_code == 404:
+            # Master doesn't know this node yet — self-register, then heartbeat.
+            log.info("[SYNC] client-heartbeat: node not registered on master; registering")
+            _register(master_url, headers, node_id, node_name, profile, config)
+            resp = requests.post(hb_url, json=payload, headers=headers, timeout=10)
+        if resp.ok:
+            log.debug("[SYNC] client-heartbeat: ok (node %s -> %s)", node_id, master_url)
+            return {"ok": True, "node_id": node_id}
+        return {"error": f"master_status_{resp.status_code}", "node_id": node_id}
+    except requests.RequestException as exc:
+        # Master unreachable is normal/transient — don't spam ERROR.
+        log.debug("[SYNC] client-heartbeat: master unreachable: %s", exc)
+        return {"error": "master_unreachable"}
+
+
+@shared_task(name="interconnector.client_heartbeat")
+def interconnector_client_heartbeat() -> dict:
+    # Reuse the active app context in production; build a minimal one when
+    # called directly (tests/scripts). Mirrors cluster_heartbeat_sweeper.
+    try:
+        from flask import current_app
+        current_app._get_current_object()  # raises if no context
+        return _do_client_heartbeat()
+    except RuntimeError:
+        pass
+    from backend.celery_app import create_minimal_celery_flask_app
+    with create_minimal_celery_flask_app().app_context():
+        return _do_client_heartbeat()

--- a/backend/tests/test_cluster_heartbeat_sweeper.py
+++ b/backend/tests/test_cluster_heartbeat_sweeper.py
@@ -30,51 +30,55 @@ def test_sweeper_skips_when_not_master(app, monkeypatch):
     assert result.get("skipped") == "not_master"
 
 
-def test_sweeper_marks_stale_node_offline(app, monkeypatch):
-    from backend.tasks.cluster_heartbeat_sweeper import sweep_node_heartbeats
-    monkeypatch.setenv("CLUSTER_ROLE", "master")
+def test_sweeper_marks_stale_node_offline(app):
+    # Call the core sweep directly, inside the app context, so it operates on
+    # THIS test's in-memory DB (the entry point rebuilds a fresh app otherwise).
+    from backend.tasks.cluster_heartbeat_sweeper import _run_sweep, DEFAULT_TIMEOUT_S
 
     with app.app_context():
-        stale_ts = datetime.utcnow() - timedelta(seconds=30)
+        # Clock matches the heartbeat writer (datetime.now, local); age must
+        # exceed the 150s timeout to count as stale.
+        stale_ts = datetime.now() - timedelta(seconds=DEFAULT_TIMEOUT_S + 50)
         node = InterconnectorNode(node_id="stale-node", node_name="stale-node",
                                   node_mode="client", host="x", port=5002,
                                   online=True, last_heartbeat=stale_ts)
         db.session.add(node)
         db.session.commit()
 
-    with patch("backend.services.cluster_routing.recompute_and_broadcast", create=True):
-        result = sweep_node_heartbeats()
+        with patch("backend.services.cluster_routing.recompute_and_broadcast", create=True):
+            result = _run_sweep(DEFAULT_TIMEOUT_S)
 
-    with app.app_context():
         refreshed = InterconnectorNode.query.filter_by(node_id="stale-node").first()
         assert refreshed.online is False
-    assert "stale-node" in result.get("marked_offline", [])
+        assert refreshed.status == "disconnected"  # liveness fields kept in sync
+        assert "stale-node" in result.get("marked_offline", [])
 
 
-def test_sweeper_marks_recovered_node_online(app, monkeypatch):
-    from backend.tasks.cluster_heartbeat_sweeper import sweep_node_heartbeats
-    monkeypatch.setenv("CLUSTER_ROLE", "master")
+def test_sweeper_marks_recovered_node_online(app):
+    from backend.tasks.cluster_heartbeat_sweeper import _run_sweep, DEFAULT_TIMEOUT_S
 
     with app.app_context():
-        fresh_ts = datetime.utcnow()
+        fresh_ts = datetime.now()  # within the timeout → healthy
         node = InterconnectorNode(node_id="recovered-node", node_name="recovered-node",
                                   node_mode="client", host="x", port=5002,
                                   online=False, last_heartbeat=fresh_ts)
         db.session.add(node)
         db.session.commit()
 
-    with patch("backend.services.cluster_routing.recompute_and_broadcast", create=True):
-        result = sweep_node_heartbeats()
+        with patch("backend.services.cluster_routing.recompute_and_broadcast", create=True):
+            result = _run_sweep(DEFAULT_TIMEOUT_S)
 
-    with app.app_context():
         refreshed = InterconnectorNode.query.filter_by(node_id="recovered-node").first()
         assert refreshed.online is True
-    assert "recovered-node" in result.get("marked_online", [])
+        assert refreshed.status == "active"
+        assert "recovered-node" in result.get("marked_online", [])
 
 
-def test_sweeper_noop_when_no_changes(app, monkeypatch):
-    from backend.tasks.cluster_heartbeat_sweeper import sweep_node_heartbeats
-    monkeypatch.setenv("CLUSTER_ROLE", "master")
-    result = sweep_node_heartbeats()
-    assert result.get("marked_offline") == []
-    assert result.get("marked_online") == []
+def test_sweeper_noop_when_no_changes(app):
+    # In-context against this test's empty DB (the entry point would rebuild an
+    # app bound to the real database and pick up unrelated rows).
+    from backend.tasks.cluster_heartbeat_sweeper import _run_sweep, DEFAULT_TIMEOUT_S
+    with app.app_context():
+        result = _run_sweep(DEFAULT_TIMEOUT_S)
+        assert result.get("marked_offline") == []
+        assert result.get("marked_online") == []

--- a/backend/tests/test_interconnector_client_heartbeat.py
+++ b/backend/tests/test_interconnector_client_heartbeat.py
@@ -1,0 +1,117 @@
+"""Server-side client heartbeat daemon — keeps a worker online without a browser.
+
+Guards on config, heartbeats to the master with the stable node id, and
+self-registers on a 404 (first contact) before retrying.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from flask import Flask
+    from backend.models import db, Setting
+except Exception:
+    pytest.skip("Flask or backend modules not available", allow_module_level=True)
+
+import backend.tasks.interconnector_client_heartbeat as hb
+
+
+@pytest.fixture
+def app():
+    application = Flask(__name__)
+    application.config.update({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+    db.init_app(application)
+    with application.app_context():
+        db.create_all()
+        yield application
+        db.session.remove()
+        db.drop_all()
+
+
+def _set_config(cfg):
+    db.session.add(Setting(key="interconnector_config", value=json.dumps(cfg)))
+    db.session.commit()
+
+
+CLIENT_CFG = {
+    "is_enabled": True, "node_mode": "client",
+    "master_url": "http://master.local:5000/", "master_api_key": "secret-key",
+    "node_name": "alpaca",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stub_profile(monkeypatch):
+    # Avoid probing real hardware; give a deterministic profile.
+    monkeypatch.setattr(hb, "_local_profile", lambda: {"node_id": "prof-id", "hostname": "alpaca"})
+
+
+def test_skips_when_not_enabled(app):
+    with app.app_context():
+        _set_config({**CLIENT_CFG, "is_enabled": False})
+        assert hb._do_client_heartbeat()["skipped"] == "not_enabled_client"
+
+
+def test_skips_when_master_mode(app):
+    with app.app_context():
+        _set_config({**CLIENT_CFG, "node_mode": "master"})
+        assert hb._do_client_heartbeat()["skipped"] == "not_enabled_client"
+
+
+def test_skips_when_no_master_url(app):
+    with app.app_context():
+        _set_config({**CLIENT_CFG, "master_url": ""})
+        assert hb._do_client_heartbeat()["skipped"] == "no_master_url"
+
+
+def test_heartbeats_with_stable_id_and_api_key(app, monkeypatch):
+    monkeypatch.setenv("CLUSTER_NODE_ID", "stable-machine-id")
+    with app.app_context():
+        _set_config(CLIENT_CFG)
+        with patch.object(hb.requests, "post",
+                          return_value=MagicMock(status_code=200, ok=True)) as post:
+            result = hb._do_client_heartbeat()
+        assert result == {"ok": True, "node_id": "stable-machine-id"}
+        url, kwargs = post.call_args[0][0], post.call_args[1]
+        assert url == "http://master.local:5000/api/interconnector/nodes/stable-machine-id/heartbeat"
+        assert kwargs["headers"]["X-API-Key"] == "secret-key"
+
+
+def test_self_registers_on_404_then_heartbeats(app, monkeypatch):
+    monkeypatch.setenv("CLUSTER_NODE_ID", "stable-machine-id")
+    responses = [
+        MagicMock(status_code=404, ok=False),   # first heartbeat: unknown node
+        MagicMock(status_code=200, ok=True),     # register
+        MagicMock(status_code=200, ok=True),     # heartbeat retry
+    ]
+    with app.app_context():
+        _set_config(CLIENT_CFG)
+        with patch.object(hb.requests, "post", side_effect=responses) as post:
+            result = hb._do_client_heartbeat()
+        assert result["ok"] is True
+        called = [c[0][0] for c in post.call_args_list]
+        assert any(u.endswith("/nodes/register") for u in called), called
+        assert called[-1].endswith("/nodes/stable-machine-id/heartbeat")
+
+
+def test_master_unreachable_is_non_fatal(app, monkeypatch):
+    import requests as real_requests
+    monkeypatch.setenv("CLUSTER_NODE_ID", "stable-machine-id")
+    with app.app_context():
+        _set_config(CLIENT_CFG)
+        with patch.object(hb.requests, "post",
+                          side_effect=real_requests.ConnectionError("down")):
+            result = hb._do_client_heartbeat()
+        assert result == {"error": "master_unreachable"}
+
+
+def test_falls_back_to_profile_node_id_without_env(app, monkeypatch):
+    monkeypatch.delenv("CLUSTER_NODE_ID", raising=False)
+    with app.app_context():
+        _set_config(CLIENT_CFG)
+        with patch.object(hb.requests, "post",
+                          return_value=MagicMock(status_code=200, ok=True)) as post:
+            result = hb._do_client_heartbeat()
+        assert result["node_id"] == "prof-id"  # from the hardware profile
+        assert post.call_args[0][0].endswith("/nodes/prof-id/heartbeat")

--- a/backend/tests/test_interconnector_identity.py
+++ b/backend/tests/test_interconnector_identity.py
@@ -129,5 +129,18 @@ def test_local_identity_endpoint_returns_machine_id(app, monkeypatch):
     assert r.get_json()["data"]["node_id"] == "machine-stable-uuid"
 
 
+def test_ensure_local_self_node_creates_and_is_idempotent(app):
+    """The self-row that lets local sync-history FK writes succeed (previously a
+    ForeignKeyViolation) is created once and reused."""
+    from backend.api.interconnector_api import _ensure_local_self_node
+    with app.app_context():
+        n1 = _ensure_local_self_node("self-id", "myhost", "client")
+        db.session.commit()
+        assert n1.node_id == "self-id" and n1.node_name == "myhost"
+        n2 = _ensure_local_self_node("self-id", "myhost", "client")
+        assert n2.node_id == "self-id"
+        assert InterconnectorNode.query.filter_by(node_id="self-id").count() == 1
+
+
 def _hostname(node):
     return json.loads(node.hardware_profile or "{}").get("hostname")

--- a/backend/tests/test_interconnector_identity.py
+++ b/backend/tests/test_interconnector_identity.py
@@ -1,0 +1,133 @@
+"""Stable, IP-INDEPENDENT node identity for the interconnector.
+
+Regression guard for the "ALPACA keeps cutting out" bug: a node reachable via
+multiple paths (LAN / VPN / Tailscale) or with a changed DHCP lease used to
+register as a brand-new node each time, piling up duplicate stale rows. Identity
+is now keyed on the machine-stable node_id (hardware_profile["node_id"]) and
+matched by hostname fingerprint, never by IP.
+"""
+import json
+import pytest
+
+try:
+    from flask import Flask
+    from backend.models import db, InterconnectorNode, Setting
+except Exception:
+    pytest.skip("Flask or backend modules not available", allow_module_level=True)
+
+
+@pytest.fixture
+def app():
+    import backend.api.interconnector_api as ic_api
+
+    application = Flask(__name__)
+    application.config.update(
+        {"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"}
+    )
+    db.init_app(application)
+    from backend.api.interconnector_api import interconnector_bp
+    application.register_blueprint(interconnector_bp)
+
+    with application.app_context():
+        db.create_all()
+        setting = Setting(key="interconnector_config", value=json.dumps(
+            {"is_enabled": True, "node_mode": "master", "require_api_key": False}))
+        db.session.add(setting)
+        db.session.commit()
+        ic_api._config_cache["config"] = None
+        ic_api._config_cache["expires"] = 0
+        yield application
+        db.session.remove()
+        db.drop_all()
+        ic_api._config_cache["config"] = None
+        ic_api._config_cache["expires"] = 0
+
+
+def _register(client, *, stable_id, hostname, client_ip, name=None):
+    profile = {"node_id": stable_id, "hostname": hostname, "arch": "x86_64", "services": {}}
+    return client.post("/api/interconnector/nodes/register", json={
+        "node_id": stable_id, "node_name": name or hostname, "node_mode": "client",
+        "client_ip": client_ip, "port": 5002, "hardware_profile": profile,
+    })
+
+
+def test_same_machine_two_ips_yields_one_row(app):
+    """The core fix: same machine reachable at a different IP (LAN vs VPN) must
+    stay ONE node, not spawn a duplicate."""
+    client = app.test_client()
+    r1 = _register(client, stable_id="alpaca-stable", hostname="alpaca", client_ip="192.168.1.112")
+    assert r1.status_code in (200, 201), r1.get_data(as_text=True)
+    r2 = _register(client, stable_id="alpaca-stable", hostname="alpaca", client_ip="10.100.0.2")
+    assert r2.status_code in (200, 201), r2.get_data(as_text=True)
+    # Same node_id returned both times — identity is IP-independent.
+    assert r1.get_json()["data"]["node_id"] == "alpaca-stable"
+    assert r2.get_json()["data"]["node_id"] == "alpaca-stable"
+    with app.app_context():
+        rows = InterconnectorNode.query.all()
+        assert len(rows) == 1, f"expected 1 row, got {[n.node_id for n in rows]}"
+        assert rows[0].host == "10.100.0.2"  # address updated to the latest path
+        assert rows[0].online is True
+
+
+def test_different_machine_same_id_gets_fresh_id(app):
+    """Backup-restore protection: a DIFFERENT machine (different hostname)
+    presenting the same node_id must be given a fresh id, not hijack the row."""
+    client = app.test_client()
+    _register(client, stable_id="shared-id", hostname="boxA", client_ip="192.168.1.10")
+    r2 = _register(client, stable_id="shared-id", hostname="boxB", client_ip="192.168.1.11")
+    assert r2.status_code in (200, 201)
+    assigned = r2.get_json()["data"]["node_id"]
+    assert assigned != "shared-id", "different machine must not reuse the id"
+    with app.app_context():
+        by_id = {n.node_id: n for n in InterconnectorNode.query.all()}
+        assert "shared-id" in by_id
+        assert _hostname(by_id["shared-id"]).lower() == "boxa"
+        assert _hostname(by_id[assigned]).lower() == "boxb"
+
+
+def test_registration_prunes_leftover_duplicate_rows(app):
+    """Self-heal: rows left by the old IP-coupled logic for the same machine
+    are collapsed on the next registration."""
+    with app.app_context():
+        for old_id, ip in [("old-1", "192.168.1.112"), ("old-2", "10.100.0.2")]:
+            db.session.add(InterconnectorNode(
+                node_id=old_id, node_name="GX1-Alpaca", node_mode="client",
+                host=ip, port=5002, status="disconnected", online=True,
+                hardware_profile=json.dumps({"hostname": "alpaca"})))
+        db.session.commit()
+        assert InterconnectorNode.query.count() == 2
+
+    client = app.test_client()
+    r = _register(client, stable_id="alpaca-stable", hostname="alpaca", client_ip="192.168.1.112")
+    assert r.status_code in (200, 201)
+    with app.app_context():
+        rows = InterconnectorNode.query.all()
+        assert len(rows) == 1, f"duplicates not pruned: {[n.node_id for n in rows]}"
+        assert rows[0].node_id == "alpaca-stable"
+
+
+def test_prune_skips_weak_fingerprints(app):
+    """Two fresh installs both reporting a default/blank hostname must NOT be
+    merged into one another."""
+    with app.app_context():
+        db.session.add(InterconnectorNode(
+            node_id="other-node", node_name="other", node_mode="client",
+            host="192.168.1.50", port=5002, online=True,
+            hardware_profile=json.dumps({"hostname": "localhost"})))
+        db.session.commit()
+    client = app.test_client()
+    _register(client, stable_id="mine", hostname="localhost", client_ip="192.168.1.51")
+    with app.app_context():
+        assert InterconnectorNode.query.count() == 2  # not merged
+
+
+def test_local_identity_endpoint_returns_machine_id(app, monkeypatch):
+    monkeypatch.setenv("CLUSTER_NODE_ID", "machine-stable-uuid")
+    client = app.test_client()
+    r = client.get("/api/interconnector/nodes/local-identity")
+    assert r.status_code == 200
+    assert r.get_json()["data"]["node_id"] == "machine-stable-uuid"
+
+
+def _hostname(node):
+    return json.loads(node.hardware_profile or "{}").get("hostname")

--- a/frontend/src/components/settings/InterconnectorSettings.jsx
+++ b/frontend/src/components/settings/InterconnectorSettings.jsx
@@ -114,11 +114,35 @@ const InterconnectorSettings = () => {
   // Client simplified view mode - show simple update panel by default for clients
   const [showAdvancedClientView, setShowAdvancedClientView] = useState(false);
   
-  // Node ID for client registration (stored in localStorage for persistence)
+  // Node ID for client registration. Seeded from localStorage, but upgraded to
+  // this machine's STABLE, IP-independent id (~/.guaardvark/node_id) below so a
+  // node keeps one identity across browsers, cache clears, DHCP leases, and VPN
+  // paths — instead of registering as a brand-new node each time.
   const [nodeId, setNodeId] = useState(() => {
     const stored = localStorage.getItem('interconnector_node_id');
     return stored || null;
   });
+
+  // Prefer the machine-stable identity from this box's own backend.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch('/api/interconnector/nodes/local-identity');
+        if (!resp.ok) return;
+        const body = await resp.json();
+        const machineId = body?.data?.node_id || body?.node_id;
+        if (!cancelled && machineId) {
+          setNodeId(machineId);
+          localStorage.setItem('interconnector_node_id', machineId);
+        }
+      } catch (_e) {
+        // No local identity available (e.g. dev without hardware.json) —
+        // keep the localStorage id.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // Load initial data
   useEffect(() => {


### PR DESCRIPTION
Two commits from 2026-08-07 that were never pushed — they existed only on one machine's disk until now. Surfaced during a branch audit; opening for review rather than leaving them stranded.

**Verified against current `main` (2026-08-21):** merges clean, `main` has not drifted on any file they touch, and the branch's own tests pass — 13/13 for the new suites, 144 passed across the cluster/interconnector selection, matching the original commit message's claim.

## Why it matters

Node identity was tied to **IP address**: `register_node` reused a `node_id` only when `host == client_ip`, otherwise it minted a new UUID. A node reachable over more than one path (LAN / VPN / Tailscale) or with a changed DHCP lease re-registered as a brand-new node every time, piling up stale duplicate rows — the "nodes cutting out" symptom. Tying installs to a fixed IP is not shippable.

Identity now comes from the machine-stable id every install already has (`~/.guaardvark/node_id`, carried in `hardware_profile.node_id`, exported as `CLUSTER_NODE_ID`), keyed by hostname fingerprint, never by IP. A fresh id is minted only on a genuine machine collision.

## Also fixes

**Sync-history `ForeignKeyViolation`.** Local sync-history writes and `last_sync_time` updates used `node_name` as the `node_id`, which has no matching `interconnector_nodes` row — the FK violation aborted the whole sync transaction. Now keyed on `_stable_local_node_id()`, with `_ensure_local_self_node()` guaranteeing a client-only, unlisted self-row so both the FK and the timestamp update succeed.

**Liveness no longer depends on a browser tab.** A Celery-beat task (60s) has a client node self-register and heartbeat to its master from the backend. Scheduled unconditionally, but early-returns cheaply unless this node is an enabled client with a master URL, so master and solo installs pay nothing. Hardware profile cached for 10 minutes. First contact 404s → the daemon self-registers and retries; master-unreachable is treated as transient and never raises.

## Note on CI

`test_cluster_schema.py::test_no_capabilities_references_in_backend` fails, but **it is red on `main` already** and unrelated to this branch: it greps for `.capabilities` in `backend/` and trips on `backend/services/connections/` (publish/provider specs), which this merge does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)