### PR TITLE
docs(security): make the pre-commit install line worktree-safe

### DIFF
--- a/scripts/check_portable.sh
+++ b/scripts/check_portable.sh
@@ -15,8 +15,9 @@
 #   scripts/check_portable.sh            scan every tracked file (CI, lint)
 #   scripts/check_portable.sh --staged   scan lines about to be committed
 #
-# Install as a pre-commit hook:
-#   ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
+# Install as a pre-commit hook (works from a worktree, where .git is a file and
+# every worktree shares the main repo's one hooks directory):
+#   ln -sf ../../scripts/pre-commit "$(git rev-parse --git-common-dir)/hooks/pre-commit"
 #
 # Exits non-zero on a finding.
 set -uo pipefail

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,8 +4,9 @@
 # or secrets. A push cannot be taken back, so this is the last cheap place to
 # catch them.
 #
-# Install:
-#   ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
+# Install. Worktrees share the main repo's single hooks directory, and their
+# .git is a file, so resolve the target rather than writing .git/hooks directly:
+#   ln -sf ../../scripts/pre-commit "$(git rev-parse --git-common-dir)/hooks/pre-commit"
 #
 # Bypass for a commit you are certain about:
 #   git commit --no-verify


### PR DESCRIPTION
Field report from a session working in a git worktree, verified here before changing anything.

`ln -sf ../../scripts/pre-commit .git/hooks/pre-commit` — the line #92 documented in three places — is wrong from inside a worktree. Two reasons, both confirmed on this machine:

- A worktree's `.git` is a **regular file**, not a directory, so `.git/hooks/pre-commit` is not a writable path there.
- Worktrees **share the main repo's single hooks directory**. `git rev-parse --git-path hooks` from the worktree returns `/…/GX1/.git/hooks`, the main clone's.

Together those mean an install attempt from a worktree quietly rewrites the *main* clone's hook. That is exactly what happened: the shared hook briefly pointed at a script inside a disposable worktree and would have dangled the moment that worktree was removed.

The fix resolves the target instead:

```
ln -sf ../../scripts/pre-commit "$(git rev-parse --git-common-dir)/hooks/pre-commit"
```

`--git-common-dir` returns `.git` from the main clone and the absolute main `.git` from a worktree, and the relative link body resolves to `<repo>/scripts/pre-commit` in both cases — verified from both locations.

Docs only; no behaviour change to the guard itself.

## Verification

- The new command run in a fresh `git clone` installs a working hook that executes and exits 0.
- `--git-common-dir` resolves to the same `scripts/pre-commit` from the main clone and from a worktree.
- `check_portable.sh` clean; both scripts pass `bash -n`.
- GX1's own hook was confirmed intact and untouched throughout.

`CLAUDE.md` carries the same correction locally; it is gitignored, so it is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)