### PR TITLE
fix(chat): stop pasted descriptions triggering image generation

### DIFF
--- a/backend/services/unified_chat_engine.py
+++ b/backend/services/unified_chat_engine.py
@@ -165,11 +165,40 @@ IMAGE_TOOLS = ["generate_image", "generate_animation", "generate_video"]
 # "image of X on the website" references that falsely triggered direct generate_image.
 IMAGE_GEN_INTENT_KEYWORDS = [
     "generate image", "generate an image", "create image", "draw", "make a picture",
-    "make an image", "generate a photo", "render image", "animate", "animation", "gif",
-    "moving image", "video of", "make a video", "create a video", "generate video",
-    "generate a gif", "animated", "generate_image", "use the generate_image tool",
+    "make an image", "generate a photo", "render image", "animate",
+    "make a video", "create a video", "generate video",
+    "generate a gif", "generate_image", "use the generate_image tool",
     "/imagine",
 ]
+
+# Matched on word boundaries, never as substrings: "withdrawal" contains "draw"
+# and "animated reflections" contains "animate". A pasted visual description is
+# not a request to render it — bare nouns ("gif", "animation", "video of") only
+# count via the create-verb rule below.
+_IMAGE_GEN_INTENT_RE = re.compile(
+    r"generate\s+(an?\s+)?image|create\s+(an?\s+)?image|make\s+an?\s+image"
+    r"|make\s+a\s+picture|generate\s+a\s+photo|render\s+(an?\s+)?image"
+    r"|make\s+a\s+video|create\s+a\s+video|generate\s+(a\s+)?video"
+    r"|generate\s+a\s+gif|generate_image|/imagine|\bdraw\b|\banimate\b",
+    re.IGNORECASE,
+)
+
+# An explicit slash command is always honoured, even in command-only mode.
+_SLASH_MEDIA_RE = re.compile(r"^\s*/(imagine|image|video)\b", re.IGNORECASE)
+
+
+def _media_requires_explicit_command() -> bool:
+    """True when chat may only create media via an explicit command such as /imagine.
+
+    Off by default: natural-language requests ("generate an image of a cat") keep
+    working. Turn on to guarantee that pasted prompts and scene descriptions are
+    never rendered, whatever they happen to contain.
+    """
+    try:
+        from backend.utils.settings_utils import get_setting
+        return bool(get_setting("chat_media_requires_command", default=False, cast=bool))
+    except Exception:
+        return False
 
 _IMAGE_GEN_NEGATIVE_PATTERNS = (
     r"\bthere is an image\b",
@@ -327,7 +356,7 @@ TOOL_CONTEXT_KEYWORDS = {
 
 def _has_explicit_image_gen_intent(msg_lower: str) -> bool:
     """True when the message explicitly asks to create new image/video media."""
-    if any(kw in msg_lower for kw in IMAGE_GEN_INTENT_KEYWORDS):
+    if _IMAGE_GEN_INTENT_RE.search(msg_lower):
         return True
     if re.search(r"\b(generate|draw|make|create|render|visuali[sz]e)\b", msg_lower):
         if re.search(r"\b(image|picture|photo|illustration|gif|animation|video)\b", msg_lower):
@@ -340,6 +369,10 @@ def user_wants_image_generation(message: str) -> bool:
     if not message or not message.strip():
         return False
     msg_lower = message.lower()
+    if _SLASH_MEDIA_RE.match(msg_lower):
+        return True
+    if _media_requires_explicit_command():
+        return False
     if not _has_explicit_image_gen_intent(msg_lower):
         return False
     for pat in _IMAGE_GEN_NEGATIVE_PATTERNS:
@@ -368,6 +401,10 @@ def user_wants_video_generation(message: str) -> bool:
     if not message or not message.strip():
         return False
     msg_lower = message.lower()
+    if _SLASH_MEDIA_RE.match(msg_lower):
+        return True
+    if _media_requires_explicit_command():
+        return False
     if not (_VIDEO_INTENT_RE.search(msg_lower) or msg_lower.startswith("video of ")):
         return False
     if any(w in msg_lower for w in ("gif", "animate", "animation", "animated")):

--- a/backend/tests/test_image_gen_tool_selection.py
+++ b/backend/tests/test_image_gen_tool_selection.py
@@ -159,3 +159,76 @@ class TestUserWantsImageGeneration:
             "sess", lambda *a, **k: None, "req", {},
         )
         assert result is None
+
+
+class TestPastedDescriptionsDoNotGenerate:
+    """A pasted prompt or scene description is not a request to render it.
+
+    These all reached generate_image through substring matching: "withdrawal"
+    contains "draw", "animated reflections" contains "animate". The direct
+    natural-language path bypasses the LLM, so a match here rendered an image
+    with nothing to veto it.
+    """
+
+    @pytest.mark.parametrize("message", [
+        "A cinematic wide shot of a rain-soaked alley, neon signs, "
+        "animated reflections on wet asphalt",
+        "Here's the prompt I want to save for later: lone astronaut on a red "
+        "dune, drawn in ink wash",
+        "Can you review this description? Slow push-in on a lighthouse, gulls "
+        "wheeling, moving image quality",
+        "The client asked for a withdrawal form redesign",
+        "The animation industry uses a lot of GPU time",
+    ])
+    def test_pasted_description_does_not_want_generation(self, message):
+        from backend.services.unified_chat_engine import user_wants_image_generation
+        assert user_wants_image_generation(message) is False
+
+    @pytest.mark.parametrize("message", [
+        "The client asked for a withdrawal form redesign",
+        "A cinematic wide shot with animated reflections on wet asphalt",
+    ])
+    def test_pasted_description_does_not_pin_generate_image(self, message):
+        from backend.services.unified_chat_engine import _pin_image_generation_tools
+        selected = _pin_image_generation_tools(message, [], ["web_search", "generate_image"])
+        assert "generate_image" not in selected
+
+
+class TestCommandOnlyMode:
+    """chat_media_requires_command: only an explicit command may create media."""
+
+    @staticmethod
+    def _force(monkeypatch, enabled):
+        import backend.services.unified_chat_engine as uce
+        monkeypatch.setattr(uce, "_media_requires_explicit_command", lambda: enabled)
+        return uce
+
+    @pytest.mark.parametrize("message", [
+        "generate an image of a cat",
+        "draw me a duck",
+        "make a picture of a sunset",
+    ])
+    def test_natural_language_suppressed_when_on(self, monkeypatch, message):
+        uce = self._force(monkeypatch, True)
+        assert uce.user_wants_image_generation(message) is False
+
+    @pytest.mark.parametrize("message", [
+        "/imagine a fox in tall grass",
+        "  /imagine a fox",
+    ])
+    def test_slash_command_still_honoured_when_on(self, monkeypatch, message):
+        uce = self._force(monkeypatch, True)
+        assert uce.user_wants_image_generation(message) is True
+
+    def test_natural_language_works_when_off(self, monkeypatch):
+        uce = self._force(monkeypatch, False)
+        assert uce.user_wants_image_generation("generate an image of a cat") is True
+
+    def test_video_suppressed_when_on_but_slash_survives(self, monkeypatch):
+        uce = self._force(monkeypatch, True)
+        assert uce.user_wants_video_generation("generate a video of a fox") is False
+        assert uce.user_wants_video_generation("/video a fox") is True
+
+    def test_defaults_off_so_existing_behaviour_is_unchanged(self):
+        from backend.services.unified_chat_engine import _media_requires_explicit_command
+        assert _media_requires_explicit_command() is False


### PR DESCRIPTION
## The bug

Image-generation intent was decided by **substring** matching against a keyword list, so a keyword appearing as a fragment of an unrelated word counted as a request to render. Reproduced against the shipped logic:

| Message | Fired? | Why |
|---|---|---|
| `The client asked for a withdrawal form redesign` | **yes** | `withdrawal` contains `draw` |
| `…neon signs, animated reflections on wet asphalt` | **yes** | `animated` |
| `…lone astronaut on a red dune, drawn in ink wash` | **yes** | `drawn` contains `draw` |
| `…gulls wheeling, moving image quality` | **yes** | `moving image` |

The first one has nothing to do with images at all.

**This wasn't just a bad tool suggestion.** `_try_image_generate_direct` gates on the same predicate and bypasses the LLM entirely (`unified_chat_engine.py:2885`), so a false match went straight to `generate_image` — GPU spent, image produced, nothing in the loop able to veto it. Pasting a prompt to discuss it rendered it instead.

## The fix

**Word boundaries, not substrings.** `\bdraw\b` no longer matches `withdrawal` or `drawn`; `\banimate\b` no longer matches `animated`.

**Bare nouns are no longer create-intent on their own.** `gif`, `animation`, `moving image` and `video of` described media rather than requesting it. They still count through the pre-existing create-verb-plus-noun rule, so `make a gif of a bouncing ball` is unaffected.

**New setting `chat_media_requires_command`** for the hard guarantee: when on, only an explicit command creates media, regardless of what a pasted description contains. **Off by default** — natural-language requests keep working, and the existing product contract is unchanged.

`/imagine` is honoured either way. It is intercepted at step 0 by `_try_direct_tool` before this predicate is ever consulted, and is short-circuited to `True` here as well, so command-only mode cannot break it.

## Tests

The existing suite already encoded the right contract — explicit fires, descriptive doesn't — so this restores its intent rather than changing it. All ten must-fire and ten must-not-fire cases still pass unchanged.

Added: the four pasted-description regressions above, and the command-only contract (natural language suppressed, `/imagine` and `/video` still honoured, default verified off).

```
backend/tests/test_image_gen_tool_selection.py            45 passed
+ has_text_intent, slash_direct_tool, unified_chat_abort,
  unified_chat_session_mode, image_prompt_sanitize,
  chat_tools_e2e                                          62 passed, 6 skipped
```

No GPU suites were run locally — another session holds the card on this box. GPU memory was unchanged across the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)