### PR TITLE
feat(release): publish to PyPI on tag, and stop the wheel shipping a stale version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Publish the CLI package to PyPI. Nothing about a git tag updates PyPI on its
+# own, so without this the repo VERSION and the installable version drift apart
+# silently — which is how `pip install guaardvark` ended up two minor versions
+# behind the repo.
+#
+# Trigger: push a tag matching the VERSION file, e.g.
+#   git tag v$(cat VERSION) && git push origin v$(cat VERSION)
+#
+# Or run it manually from the Actions tab with publish=false to build and check
+# the artefacts without spending a version number.
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload to PyPI (false = build and verify only)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      # PyPI trusted publishing exchanges this for a short-lived token, so no
+      # long-lived API secret is stored in the repository.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Refuse a tag that disagrees with VERSION
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          file_version="$(cat VERSION)"
+          tag_version="${GITHUB_REF_NAME#v}"
+          echo "VERSION file: $file_version"
+          echo "tag:          $tag_version"
+          if [ "$file_version" != "$tag_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match VERSION ($file_version)."
+            exit 1
+          fi
+
+      - name: Refuse a version already on PyPI
+        run: |
+          version="$(cat VERSION)"
+          if curl -sf "https://pypi.org/pypi/guaardvark/$version/json" > /dev/null; then
+            echo "::error::guaardvark $version is already on PyPI. Version numbers cannot be reused — bump VERSION."
+            exit 1
+          fi
+          echo "$version is free."
+
+      - name: Build
+        run: |
+          python -m pip install --upgrade build
+          # The version lives at the repo root, which an sdist cannot reach.
+          # Without this copy the wheel is built from the sdist with no VERSION
+          # in scope and setup.py raises rather than guessing.
+          cp VERSION cli/VERSION
+          python -m build --outdir dist cli/
+
+      - name: Verify both artefacts carry the expected version
+        run: |
+          version="$(cat VERSION)"
+          ls -1 dist
+          test -f "dist/guaardvark-${version}.tar.gz" \
+            || { echo "::error::sdist is not version ${version}"; exit 1; }
+          test -f "dist/guaardvark-${version}-py3-none-any.whl" \
+            || { echo "::error::wheel is not version ${version} — pip prefers the wheel, refusing to publish"; exit 1; }
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/') || inputs.publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,7 @@ data/demo_assets/*/README.md
 # which is itself ignored, so the whole directory stays local. To ship a hook or
 # skill deliberately, un-ignore that one path; never the directory.
 .claude/
+
+# Build-time copy of the repo-root VERSION, so an sdist can carry it. Generated
+# by the release workflow; the root VERSION file stays the source of truth.
+cli/VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,38 @@ refactor(api): extract indexing logic into dedicated service
 
 ---
 
+## Releasing (maintainers)
+
+`pip install guaardvark` serves a real package, not a placeholder page. It is built
+from `cli/setup.py`, which reads the repo-root `VERSION` file as the single source
+of truth for the version number.
+
+**Never announce a release without publishing it.** Bumping `VERSION`, tagging or
+posting a version while PyPI still serves the previous one means every `pip install`
+gets stale software while the README badge advertises the new number. The two drift
+apart silently, because nothing about a tag updates PyPI on its own.
+
+1. Bump `VERSION` — the package version follows automatically.
+2. Land everything on `main` and confirm CI is green.
+3. Tag it: `git tag v$(cat VERSION) && git push origin v$(cat VERSION)`.
+   The `release` workflow builds the package and publishes it to PyPI.
+4. Confirm what is actually live:
+   `curl -s https://pypi.org/pypi/guaardvark/json | jq -r .info.version`
+5. Only then announce.
+
+To publish by hand instead — or if the workflow is unavailable:
+
+```bash
+python -m build cli/
+twine upload cli/dist/*
+```
+
+A bad upload cannot be deleted and reused; the fix is `yank`, which leaves the
+version visible but stops `pip` installing it by default. Version numbers are never
+recycled, so a botched publish costs you the number.
+
+---
+
 ## Code of Conduct
 
 Be respectful, constructive, and kind. We're building something together. Harassment, trolling, and bad faith participation won't be tolerated.

--- a/cli/MANIFEST.in
+++ b/cli/MANIFEST.in
@@ -1,0 +1,5 @@
+# The version lives at the repo root, which an sdist cannot reach. The release
+# build copies it to cli/VERSION; include it so a wheel built from the sdist
+# reads the real number instead of failing.
+include VERSION
+include requirements.txt

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -8,9 +8,21 @@ from setuptools import setup, find_packages
 # render on PyPI, which does not serve repo-relative assets.
 _repo_root = Path(__file__).resolve().parent.parent
 
-# Single source of truth for the version: the repo-root VERSION file.
-_version_path = _repo_root / "VERSION"
-_version = _version_path.read_text(encoding="utf-8").strip() if _version_path.exists() else "2.6.2"
+# Single source of truth for the version: the repo-root VERSION file. An sdist
+# cannot carry a file from outside the package, so the release build copies it
+# to cli/VERSION (see MANIFEST.in) and that copy is what a wheel built from the
+# sdist reads. Never fall back to a literal: pip prefers the wheel, so a stale
+# default here publishes the wrong version under the right filename.
+_version = None
+for _candidate in (Path(__file__).resolve().parent / "VERSION", _repo_root / "VERSION"):
+    if _candidate.exists():
+        _version = _candidate.read_text(encoding="utf-8").strip()
+        break
+if not _version:
+    raise RuntimeError(
+        "VERSION not found. Expected cli/VERSION (created by the release build) "
+        "or VERSION at the repo root. Refusing to guess a version number."
+    )
 
 _readme_path = _repo_root / "README.md"
 _long_description = ""


### PR DESCRIPTION
## Why

`pip install guaardvark` serves **2.5.3**, uploaded 2026-05-07. The repo is on **2.7.0**. Nothing about a tag or a `VERSION` bump updates PyPI — uploads were manual and there is no publish workflow — so the installable version and the README badge drifted two minor versions apart. `2.6.0` is on PyPI but yanked, "superseded by 2.5.3", which is what version confusion looks like from the outside.

## The build was broken too

Worth flagging on its own, because a workflow would have shipped this faithfully:

```
$ python -m build cli/
Successfully built guaardvark-2.7.0.tar.gz and guaardvark-2.6.2-py3-none-any.whl
```

`cli/setup.py` reads the repo-root `VERSION`, but `python -m build` builds the wheel **from the sdist**, in a temp dir where `../VERSION` does not exist. It silently fell back to a hardcoded `"2.6.2"`. The sdist was right and the wheel was wrong — and pip prefers the wheel.

Fixed at the root:

- Copy `VERSION` into `cli/` at build time and ship it in the sdist via `MANIFEST.in`, so a wheel built from the sdist reads the real number. `cli/VERSION` is gitignored; the root file stays the single source of truth.
- **Replace the literal fallback with a hard failure.** A missing version file is an error, not a reason to guess — guessing publishes the wrong version under a plausible filename, which is the worst available outcome.

Both artefacts now build as `2.7.0`, verified locally, and the sdist carries `VERSION`.

## The workflow

Tag `vX.Y.Z` and it:

1. Refuses a tag that disagrees with `VERSION`.
2. Refuses a version already on PyPI — numbers cannot be reused, so a botched publish costs you the number.
3. Builds, then asserts **both** the sdist and the wheel carry the expected version before uploading. This is the check that would have caught the `2.6.2` wheel.
4. Runs `twine check`.
5. Publishes via **trusted publishing** (OIDC) — no long-lived API token in repo secrets.

`workflow_dispatch` with `publish=false` builds and verifies without spending a version number, so the workflow itself can be tested safely.

## One-time setup needed before the first tag

Trusted publishing must be configured once on PyPI, or step 5 fails:

**PyPI → guaardvark → Publishing → Add a new publisher (GitHub)**
- Owner `guaardvark`, repo `guaardvark`, workflow `release.yml`, environment `pypi`

If you would rather use an API token, drop the `id-token` permission and pass `password: ${{ secrets.PYPI_API_TOKEN }}` to the publish step instead.

## Docs

Releasing is now documented in `CONTRIBUTING.md`, under a maintainers heading — where someone about to cut a release will actually look. It includes the manual `build`/`twine` path as a fallback and the note that yanking, not deletion, is the fix for a bad upload.

Action versions match the rest of the repo (`checkout@v7`, `setup-python@v7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)