### PR TITLE
feat(discord): /ask, channel chat and voice go through unified chat

### DIFF
--- a/plugins/discord/commands/channel_chat.py
+++ b/plugins/discord/commands/channel_chat.py
@@ -1,34 +1,23 @@
 """Channel chat cog — respond to regular messages in designated channels or when mentioned."""
-import io
 import logging
 
 import discord
 from discord.ext import commands
 
 from core.api_client import GuaardvarkClient, APIError
+from core.approvals import make_approval_handler
+from core.chat_reply import (
+    attachment_to_b64,
+    channel_session_id,
+    files_from_generated,
+    first_image_attachment,
+    send_chunks,
+    user_session_id,
+)
 from core.rate_limiter import RateLimiter
 from core.security import sanitize_input
 
 logger = logging.getLogger("discord_bot")
-DISCORD_MAX_LENGTH = 2000
-
-
-def split_message(text: str, max_length: int = DISCORD_MAX_LENGTH) -> list[str]:
-    if len(text) <= max_length:
-        return [text]
-    chunks = []
-    while text:
-        if len(text) <= max_length:
-            chunks.append(text)
-            break
-        split_at = text.rfind("\n", 0, max_length)
-        if split_at == -1:
-            split_at = text.rfind(" ", 0, max_length)
-        if split_at == -1:
-            split_at = max_length
-        chunks.append(text[:split_at])
-        text = text[split_at:].lstrip()
-    return chunks
 
 
 class ChannelChatCog(commands.Cog):
@@ -39,99 +28,130 @@ class ChannelChatCog(commands.Cog):
         self.rate_limiter = RateLimiter(
             max_requests=config["rate_limits"].get("ask", 10), window_seconds=60
         )
-        # In-memory conversation history per user
-        self._history: dict[int, list[dict]] = {}
-        self._max_history = 20
-        # Channels where the bot listens to all messages (configured in config.yaml)
         self._chat_channels: set[int] = set(
             config.get("channel_chat", {}).get("channel_ids", [])
         )
-        # Also respond when mentioned anywhere
-        self._respond_to_mentions = config.get("channel_chat", {}).get("respond_to_mentions", True)
+        self._respond_to_mentions = config.get("channel_chat", {}).get(
+            "respond_to_mentions", True
+        )
 
-    def _get_history(self, user_id: int) -> list[dict]:
-        return self._history.get(user_id, [])
+    def _auto_approve(self) -> bool:
+        return bool(self.config.get("tools", {}).get("auto_approve", False))
 
-    def _add_to_history(self, user_id: int, role: str, content: str):
-        if user_id not in self._history:
-            self._history[user_id] = []
-        self._history[user_id].append({"role": role, "content": content})
-        if len(self._history[user_id]) > self._max_history:
-            self._history[user_id] = self._history[user_id][-self._max_history:]
+    def _session_id(self, message: discord.Message, is_chat_channel: bool) -> str:
+        if is_chat_channel:
+            return channel_session_id(message.channel.id)
+        return user_session_id(message.author.id)
+
+    async def _image_from_message(self, message: discord.Message) -> str | None:
+        att = first_image_attachment(message.attachments)
+        if att is None and message.reference:
+            resolved = getattr(message.reference, "resolved", None)
+            att = first_image_attachment(getattr(resolved, "attachments", None))
+        return await attachment_to_b64(att) if att is not None else None
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        # Ignore own messages and other bots
         if message.author.bot:
             return
 
-        # Determine if we should respond
         is_chat_channel = message.channel.id in self._chat_channels
-        is_mention = self.bot.user in message.mentions if self.bot.user else False
-        is_reply_to_bot = (
-            message.reference
-            and message.reference.resolved
-            and isinstance(message.reference.resolved, discord.Message)
-            and message.reference.resolved.author == self.bot.user
+        bot_id = self.bot.user.id if self.bot.user else None
+        is_mention = bool(bot_id) and any(
+            getattr(m, "id", None) == bot_id for m in (message.mentions or [])
         )
+        resolved = getattr(message.reference, "resolved", None) if message.reference else None
+        is_reply_to_bot = bool(bot_id) and getattr(
+            getattr(resolved, "author", None), "id", None
+        ) == bot_id
 
-        if not (is_chat_channel or (self._respond_to_mentions and is_mention) or is_reply_to_bot):
+        if not (
+            is_chat_channel
+            or (self._respond_to_mentions and is_mention)
+            or is_reply_to_bot
+        ):
             return
 
-        # Strip the mention from the message content
         content = message.content
         if self.bot.user:
-            content = content.replace(f"<@{self.bot.user.id}>", "").replace(f"<@!{self.bot.user.id}>", "").strip()
+            content = (
+                content.replace(f"<@{self.bot.user.id}>", "")
+                .replace(f"<@!{self.bot.user.id}>", "")
+                .strip()
+            )
 
-        if not content:
+        has_image = first_image_attachment(message.attachments) is not None
+        if not has_image and message.reference:
+            resolved = getattr(message.reference, "resolved", None)
+            has_image = first_image_attachment(
+                getattr(resolved, "attachments", None)
+            ) is not None
+
+        if not content and not has_image:
+            return
+        # Image-only posts in a listen-all channel without a mention/reply are noise.
+        if not content and has_image and is_chat_channel and not is_mention and not is_reply_to_bot:
             return
 
-        # Rate limit
         allowed, _, retry_after = self.rate_limiter.check(message.author.id, "ask")
         if not allowed:
-            await message.reply(f"Rate limited. Try again in {retry_after:.0f}s.", mention_author=False)
+            await message.reply(
+                f"Rate limited. Try again in {retry_after:.0f}s.", mention_author=False
+            )
             return
 
-        # Sanitize
-        cleaned = sanitize_input(content, max_length=self.config["security"]["max_prompt_length"])
-        if not cleaned:
+        cleaned = sanitize_input(
+            content, max_length=self.config["security"]["max_prompt_length"]
+        )
+        if not cleaned and not has_image:
             return
+        if not cleaned:
+            cleaned = "Describe this image."
 
         logger.info("[channel] user=%s msg=%r", message.author, cleaned[:100])
 
-        # Show typing indicator while generating
+        first = {"sent": False}
+
+        async def send_fn(text, *, files=None, view=None):
+            kwargs = {"content": text, "mention_author": False}
+            if files:
+                kwargs["files"] = files
+            if view is not None:
+                kwargs["view"] = view
+            if not first["sent"]:
+                first["sent"] = True
+                return await message.reply(**kwargs)
+            extra = {"content": kwargs["content"]}
+            if kwargs.get("files"):
+                extra["files"] = kwargs["files"]
+            if kwargs.get("view") is not None:
+                extra["view"] = kwargs["view"]
+            return await message.channel.send(**extra)
+
         async with message.channel.typing():
             try:
-                history = self._get_history(message.author.id)
-                result = await self.api.chat_claude(cleaned, history=history)
+                image_b64 = await self._image_from_message(message)
+                result = await self.api.unified_chat(
+                    cleaned,
+                    session_id=self._session_id(message, is_chat_channel),
+                    image=image_b64,
+                    approval_handler=make_approval_handler(
+                        send_fn, message.author.id, auto_approve=self._auto_approve()
+                    ),
+                )
                 response_text = result.get("response", "No response received.")
-
-                self._add_to_history(message.author.id, "user", cleaned)
-                self._add_to_history(message.author.id, "assistant", response_text)
-
-                if len(response_text) > 4000:
-                    file = discord.File(
-                        io.BytesIO(response_text.encode()), filename="response.md"
-                    )
-                    await message.reply(
-                        content=f"Response too long ({len(response_text)} chars). See attached file.",
-                        file=file,
-                        mention_author=False,
-                    )
-                else:
-                    for i, chunk in enumerate(split_message(response_text)):
-                        if i == 0:
-                            await message.reply(content=chunk, mention_author=False)
-                        else:
-                            await message.channel.send(content=chunk)
+                files = await files_from_generated(
+                    self.api, result.get("generated_images") or []
+                )
+                await send_chunks(send_fn, response_text, files=files)
 
             except APIError as e:
                 logger.error("Channel chat API error: %s", e)
                 await message.reply(
-                    content=f"Failed to get a response. ({e})",
+                    content=f"Failed to get a response. Guaardvark may be offline. ({e})",
                     mention_author=False,
                 )
-            except Exception as e:
+            except Exception:
                 logger.exception("Unexpected error in channel chat")
                 await message.reply(
                     content="An unexpected error occurred.",

--- a/plugins/discord/commands/chat.py
+++ b/plugins/discord/commands/chat.py
@@ -1,5 +1,4 @@
-"""Chat cog — /ask command for LLM conversation."""
-import io
+"""Chat cog — /ask command for LLM conversation via Guaardvark unified chat."""
 import logging
 
 import discord
@@ -7,30 +6,17 @@ from discord import app_commands
 from discord.ext import commands
 
 from core.api_client import GuaardvarkClient, APIError
+from core.approvals import make_approval_handler
+from core.chat_reply import (
+    attachment_to_b64,
+    files_from_generated,
+    send_chunks,
+    user_session_id,
+)
 from core.rate_limiter import RateLimiter
 from core.security import sanitize_input, is_channel_allowed
 
 logger = logging.getLogger("discord_bot")
-DISCORD_MAX_LENGTH = 2000
-
-
-def split_message(text: str, max_length: int = DISCORD_MAX_LENGTH) -> list[str]:
-    """Split a long message into chunks that fit Discord's limit."""
-    if len(text) <= max_length:
-        return [text]
-    chunks = []
-    while text:
-        if len(text) <= max_length:
-            chunks.append(text)
-            break
-        split_at = text.rfind("\n", 0, max_length)
-        if split_at == -1:
-            split_at = text.rfind(" ", 0, max_length)
-        if split_at == -1:
-            split_at = max_length
-        chunks.append(text[:split_at])
-        text = text[split_at:].lstrip()
-    return chunks
 
 
 class ChatCog(commands.Cog):
@@ -41,27 +27,24 @@ class ChatCog(commands.Cog):
         self.rate_limiter = RateLimiter(
             max_requests=config["rate_limits"]["ask"], window_seconds=60
         )
-        # In-memory conversation history per user
-        self._history: dict[int, list[dict]] = {}
-        self._max_history = 20
 
-    def _get_history(self, user_id: int) -> list[dict]:
-        return self._history.get(user_id, [])
-
-    def _add_to_history(self, user_id: int, role: str, content: str):
-        if user_id not in self._history:
-            self._history[user_id] = []
-        self._history[user_id].append({"role": role, "content": content})
-        if len(self._history[user_id]) > self._max_history:
-            self._history[user_id] = self._history[user_id][-self._max_history:]
+    def _auto_approve(self) -> bool:
+        return bool(self.config.get("tools", {}).get("auto_approve", False))
 
     @app_commands.command(name="ask", description="Chat with Guaardvark AI")
-    @app_commands.describe(prompt="Your message or question")
-    async def ask(self, interaction: discord.Interaction, prompt: str):
-        await self._handle_ask(interaction, prompt)
+    @app_commands.describe(
+        prompt="Your message or question",
+        image="Optional image to send with the message",
+    )
+    async def ask(
+        self,
+        interaction: discord.Interaction,
+        prompt: str,
+        image: discord.Attachment | None = None,
+    ):
+        await self._handle_ask(interaction, prompt, image=image)
 
-    async def _handle_ask(self, interaction, prompt: str):
-        # Channel allowlist check
+    async def _handle_ask(self, interaction, prompt: str, image=None):
         if interaction.guild and not is_channel_allowed(
             interaction.channel.id, self.config["security"]["allowed_channels"]
         ):
@@ -70,8 +53,7 @@ class ChatCog(commands.Cog):
             )
             return
 
-        # Rate limit
-        allowed, remaining, retry_after = self.rate_limiter.check(
+        allowed, _, retry_after = self.rate_limiter.check(
             interaction.user.id, "ask"
         )
         if not allowed:
@@ -80,47 +62,61 @@ class ChatCog(commands.Cog):
             )
             return
 
-        # Sanitize
         cleaned = sanitize_input(
             prompt, max_length=self.config["security"]["max_prompt_length"]
         )
-        if not cleaned:
+        if not cleaned and image is None:
             await interaction.response.send_message(
                 "Your message was empty after sanitization.", ephemeral=True
             )
             return
+        if not cleaned:
+            cleaned = "Describe this image."
+
+        image_b64 = None
+        if image is not None:
+            image_b64 = await attachment_to_b64(image)
+            if image_b64 is None:
+                await interaction.response.send_message(
+                    "Could not read that image (missing or too large).",
+                    ephemeral=True,
+                )
+                return
 
         await interaction.response.defer()
 
+        async def send_fn(content, *, files=None, view=None):
+            kwargs = {"content": content}
+            if files:
+                kwargs["files"] = files
+            if view is not None:
+                kwargs["view"] = view
+            return await interaction.followup.send(**kwargs)
+
         try:
             logger.info("[/ask] user=%s msg=%r", interaction.user, cleaned[:100])
-            history = self._get_history(interaction.user.id)
-            result = await self.api.chat_claude(cleaned, history=history)
+            session_id = user_session_id(interaction.user.id)
+            result = await self.api.unified_chat(
+                cleaned,
+                session_id=session_id,
+                image=image_b64,
+                approval_handler=make_approval_handler(
+                    send_fn, interaction.user.id, auto_approve=self._auto_approve()
+                ),
+            )
             response_text = result.get("response", "No response received.")
             logger.info("[/ask] response=%r", response_text[:100])
-
-            # Update history
-            self._add_to_history(interaction.user.id, "user", cleaned)
-            self._add_to_history(interaction.user.id, "assistant", response_text)
-
-            if len(response_text) > 4000:
-                file = discord.File(
-                    io.BytesIO(response_text.encode()), filename="response.md"
-                )
-                await interaction.followup.send(
-                    content=f"Response too long ({len(response_text)} chars). See attached file.",
-                    file=file,
-                )
-            else:
-                for chunk in split_message(response_text):
-                    await interaction.followup.send(content=chunk)
+            files = await files_from_generated(
+                self.api, result.get("generated_images") or []
+            )
+            await send_chunks(send_fn, response_text, files=files)
 
         except APIError as e:
             logger.error("Chat API error: %s", e)
             await interaction.followup.send(
-                content=f"Failed to get a response. The backend may be offline. ({e})"
+                content=f"Failed to get a response. Guaardvark may be offline. ({e})"
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in /ask")
             await interaction.followup.send(
                 content="An unexpected error occurred. Please try again."

--- a/plugins/discord/commands/claude_chat.py
+++ b/plugins/discord/commands/claude_chat.py
@@ -7,30 +7,11 @@ from discord import app_commands
 from discord.ext import commands
 
 from core.api_client import GuaardvarkClient, APIError
+from core.chat_reply import split_message
 from core.rate_limiter import RateLimiter
 from core.security import sanitize_input
 
 logger = logging.getLogger(__name__)
-DISCORD_MAX_LENGTH = 2000
-
-
-def split_message(text: str, max_length: int = DISCORD_MAX_LENGTH) -> list[str]:
-    """Split a long message into chunks that fit Discord's limit."""
-    if len(text) <= max_length:
-        return [text]
-    chunks = []
-    while text:
-        if len(text) <= max_length:
-            chunks.append(text)
-            break
-        split_at = text.rfind("\n", 0, max_length)
-        if split_at == -1:
-            split_at = text.rfind(" ", 0, max_length)
-        if split_at == -1:
-            split_at = max_length
-        chunks.append(text[:split_at])
-        text = text[split_at:].lstrip()
-    return chunks
 
 
 class ClaudeChatCog(commands.Cog):

--- a/plugins/discord/config.yaml
+++ b/plugins/discord/config.yaml
@@ -49,7 +49,10 @@ vip:
   greeting: |
     Welcome to Guaardvark — a self-hosted AI platform you can make your own.
 
-    Try `/ask` to chat, `/claude` to talk to Claude directly, `/imagine` to generate images, or `/status` to see what's running.
+    Try `/ask` to chat with Guaardvark (whatever model and plugins are running), `/imagine` to generate images, or `/status` to see what's running. `/claude` is optional if an Anthropic key is configured.
+
+tools:
+  auto_approve: false  # Discord Approve/Deny buttons; true skips them (private servers only)
 
 outreach:
   enabled: false  # flip to true after seeding channel ids; backend kill switch is the master gate

--- a/plugins/discord/core/api_client.py
+++ b/plugins/discord/core/api_client.py
@@ -1,7 +1,10 @@
 """Async REST client wrapping all Guaardvark backend endpoints."""
 import logging
 from typing import Any, Optional
+from urllib.parse import urlparse
 import aiohttp
+
+from core.chat_streamer import StreamError, UnifiedChatStreamer
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +15,11 @@ class GuaardvarkClient:
     def __init__(self, base_url: str = "http://localhost:5000/api"):
         self.base_url = base_url.rstrip("/")
         self.session: Optional[aiohttp.ClientSession] = None
+
+    @property
+    def origin(self) -> str:
+        """Backend origin (scheme+host+port), with the /api suffix stripped."""
+        return self.base_url.rsplit("/api", 1)[0]
 
     async def setup(self):
         self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120))
@@ -30,14 +38,14 @@ class GuaardvarkClient:
         async with self.session.get(f"{self.base_url}{path}", **kwargs) as resp:
             data = await resp.json()
             if resp.status >= 400:
-                raise APIError(data.get("error", f"HTTP {resp.status}"), resp.status)
+                raise APIError(_error_message(data, resp.status), resp.status)
             return self._unwrap(data)
 
     async def _post(self, path: str, **kwargs) -> dict:
         async with self.session.post(f"{self.base_url}{path}", **kwargs) as resp:
             data = await resp.json()
             if resp.status >= 400:
-                raise APIError(data.get("error", f"HTTP {resp.status}"), resp.status)
+                raise APIError(_error_message(data, resp.status), resp.status)
             return self._unwrap(data)
 
     async def _get_raw(self, path: str, **kwargs) -> bytes:
@@ -47,6 +55,54 @@ class GuaardvarkClient:
             return await resp.read()
 
     # --- Chat ---
+    async def unified_chat(
+        self,
+        message: str,
+        session_id: str,
+        *,
+        image: str = None,
+        options: dict = None,
+        approval_handler=None,
+        is_voice_message: bool = False,
+        streamer=None,
+    ) -> dict:
+        """POST /chat/unified and wait for Socket.IO chat:complete.
+
+        Uses the same AgentBrain path as the web UI and CLI: active model,
+        tools, and plugins. ``image`` is optional base64. ``approval_handler``
+        is ``async (data) -> bool`` for tool-approval requests.
+        """
+        last_error = None
+        for attempt in range(2):
+            active = streamer or UnifiedChatStreamer(self.origin)
+
+            async def post_fn(body):
+                return await self._post("/chat/unified", json=body)
+
+            try:
+                return await active.run(
+                    session_id=session_id,
+                    message=message,
+                    post_fn=post_fn,
+                    image=image,
+                    options=options or {},
+                    approval_handler=approval_handler,
+                    is_voice_message=is_voice_message,
+                )
+            except StreamError as e:
+                raise APIError(str(e), e.status_code)
+            except APIError as e:
+                last_error = e
+                if e.status_code == 409 and attempt == 0:
+                    try:
+                        await self._post(f"/chat/unified/{session_id}/abort")
+                    except Exception:
+                        pass
+                    streamer = None
+                    continue
+                raise
+        raise last_error or APIError("Chat request failed", 502)
+
     SYSTEM_CONTEXT = (
         "You are the Guaardvark AI assistant — the built-in intelligence of the Guaardvark platform. "
         "You are running RIGHT NOW on a single self-hosted machine — the operator's own hardware, "
@@ -94,7 +150,7 @@ class GuaardvarkClient:
         return await self._post("/enhanced-chat", json=payload)
 
     async def chat_claude(self, message: str, history: list = None) -> dict:
-        """POST /claude/escalate — route chat through Uncle Claude."""
+        """POST /claude/escalate — explicit Uncle Claude path for /claude only."""
         return await self._post("/claude/escalate", json={
             "message": message,
             "history": history or [],
@@ -225,14 +281,32 @@ class GuaardvarkClient:
         return await self._get_raw(f"/voice/audio/{filename}")
 
     async def fetch_audio_by_url(self, audio_url: str) -> bytes:
-        """GET an /api-prefixed audio URL against the backend origin.
+        """GET an /api-prefixed audio URL against the backend origin."""
+        return await self.fetch_by_url(audio_url)
 
-        TTS returns audio_url as e.g. /api/voice/audio/<file> (audio_foundry) or
-        /api/voice/stream-tts/<id> (Piper) — both already carry the /api prefix,
-        so they must be resolved against the origin, not base_url.
-        """
-        origin = self.base_url.rsplit("/api", 1)[0]
-        async with self.session.get(f"{origin}{audio_url}") as resp:
+    def _resolve_fetch_url(self, url: str) -> str | None:
+        """Allow relative, origin, and loopback URLs only — no arbitrary SSRF."""
+        if not url:
+            return None
+        if url.startswith("/"):
+            return f"{self.origin}{url}"
+        parsed = urlparse(url)
+        if parsed.scheme in ("http", "https") and parsed.hostname in (
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        ):
+            return url
+        if url.startswith(self.origin):
+            return url
+        return None
+
+    async def fetch_by_url(self, url: str) -> bytes:
+        """GET a backend-relative or loopback URL. Rejects remote hosts."""
+        resolved = self._resolve_fetch_url(url)
+        if not resolved:
+            raise APIError(f"Refusing to fetch non-local URL: {url}", 400)
+        async with self.session.get(resolved) as resp:
             if resp.status >= 400:
                 raise APIError(await resp.text(), resp.status)
             return await resp.read()
@@ -241,6 +315,15 @@ class GuaardvarkClient:
     async def health_check(self) -> dict:
         """GET /health"""
         return await self._get("/health")
+
+
+def _error_message(data, status_code: int) -> str:
+    if not isinstance(data, dict):
+        return f"HTTP {status_code}"
+    err = data.get("error", f"HTTP {status_code}")
+    if isinstance(err, dict):
+        return str(err.get("message") or err)
+    return str(err)
 
 
 class APIError(Exception):

--- a/plugins/discord/core/approvals.py
+++ b/plugins/discord/core/approvals.py
@@ -1,0 +1,83 @@
+"""Discord Approve/Deny view for unified-chat tool approval requests."""
+import asyncio
+import logging
+
+import discord
+
+logger = logging.getLogger("discord_bot")
+
+APPROVAL_TIMEOUT_S = 280
+
+
+class ToolApprovalView(discord.ui.View):
+    """Two-button view; only ``user_id`` may click. Times out as deny."""
+
+    def __init__(self, user_id: int, timeout: float = APPROVAL_TIMEOUT_S):
+        super().__init__(timeout=timeout)
+        self.user_id = user_id
+        self.approved = False
+        self.message = None
+        self._done = asyncio.get_running_loop().create_future()
+
+    def _finish(self, approved: bool):
+        self.approved = approved
+        if not self._done.done():
+            self._done.set_result(approved)
+        self.stop()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message(
+                "Only the person who asked can approve this.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @discord.ui.button(label="Approve", style=discord.ButtonStyle.success)
+    async def approve(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        await interaction.response.edit_message(content="Approved.", view=None)
+        self._finish(True)
+
+    @discord.ui.button(label="Deny", style=discord.ButtonStyle.danger)
+    async def deny(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        await interaction.response.edit_message(content="Denied.", view=None)
+        self._finish(False)
+
+    async def on_timeout(self):
+        self.approved = False
+        if not self._done.done():
+            self._done.set_result(False)
+        if self.message is not None:
+            try:
+                await self.message.edit(content="Approval timed out.", view=None)
+            except Exception:
+                pass
+
+    async def wait_for_decision(self) -> bool:
+        try:
+            return bool(await self._done)
+        except Exception:
+            return False
+
+
+def make_approval_handler(send_fn, user_id: int, auto_approve: bool = False):
+    """Return ``async (data) -> bool`` for UnifiedChatStreamer.
+
+    ``send_fn`` is ``async (content, *, view=None) -> message``.
+    """
+
+    async def handler(data: dict) -> bool:
+        if auto_approve:
+            return True
+        tools = data.get("tools") or []
+        tools_str = ", ".join(str(t) for t in tools) if tools else "a tool"
+        view = ToolApprovalView(user_id=user_id)
+        message = await send_fn(
+            f"Guaardvark wants to run **{tools_str}**. Approve?",
+            view=view,
+        )
+        view.message = message
+        return await view.wait_for_decision()
+
+    return handler

--- a/plugins/discord/core/chat_reply.py
+++ b/plugins/discord/core/chat_reply.py
@@ -1,0 +1,134 @@
+"""Shared helpers for turning a unified-chat result into Discord messages."""
+import base64
+import io
+import logging
+import os
+from urllib.parse import urlparse
+
+import discord
+
+logger = logging.getLogger("discord_bot")
+
+DISCORD_MAX_LENGTH = 2000
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+MAX_OUTBOUND_BYTES = 8 * 1024 * 1024
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".gif")
+VIDEO_EXTENSIONS = (".mp4", ".webm", ".mov")
+
+
+def user_session_id(user_id: int) -> str:
+    return f"discord_user_{user_id}"
+
+
+def channel_session_id(channel_id: int) -> str:
+    return f"discord_channel_{channel_id}"
+
+
+def split_message(text: str, max_length: int = DISCORD_MAX_LENGTH) -> list[str]:
+    """Split a long message into chunks that fit Discord's limit."""
+    if text is None:
+        return [""]
+    if len(text) <= max_length:
+        return [text]
+    chunks = []
+    while text:
+        if len(text) <= max_length:
+            chunks.append(text)
+            break
+        split_at = text.rfind("\n", 0, max_length)
+        if split_at == -1:
+            split_at = text.rfind(" ", 0, max_length)
+        if split_at == -1:
+            split_at = max_length
+        chunks.append(text[:split_at])
+        text = text[split_at:].lstrip()
+    return chunks
+
+
+def is_image_attachment(attachment) -> bool:
+    content_type = (getattr(attachment, "content_type", None) or "").lower()
+    name = (getattr(attachment, "filename", None) or "").lower()
+    if content_type.startswith("image/"):
+        return True
+    return name.endswith(IMAGE_EXTENSIONS)
+
+
+def first_image_attachment(attachments) -> object | None:
+    for att in attachments or []:
+        if is_image_attachment(att):
+            return att
+    return None
+
+
+async def attachment_to_b64(attachment) -> str | None:
+    """Read a Discord attachment as base64, or None if missing/too large."""
+    if attachment is None:
+        return None
+    size = getattr(attachment, "size", 0) or 0
+    if size > MAX_IMAGE_BYTES:
+        logger.warning("Skipping oversized attachment %s (%s bytes)", getattr(attachment, "filename", "?"), size)
+        return None
+    data = await attachment.read()
+    if not data or len(data) > MAX_IMAGE_BYTES:
+        return None
+    return base64.b64encode(data).decode("ascii")
+
+
+def _filename_for_media(url: str, media_type: str) -> str:
+    name = os.path.basename(urlparse(url).path) if url else ""
+    name = name.split("?")[0]
+    if name:
+        return name
+    if media_type == "video":
+        return "video.mp4"
+    return "image.png"
+
+
+async def files_from_generated(api, images: list) -> list[discord.File]:
+    """Download generated media from the backend as Discord file attachments."""
+    files: list[discord.File] = []
+    for img in images or []:
+        if len(files) >= 10:
+            break
+        url = (img or {}).get("url") or (img or {}).get("image_url")
+        if not url:
+            continue
+        try:
+            raw = await api.fetch_by_url(url)
+        except Exception:
+            logger.warning("Failed to fetch generated media %s", url, exc_info=True)
+            continue
+        if not raw or len(raw) > MAX_OUTBOUND_BYTES:
+            continue
+        media_type = (img or {}).get("type") or "image"
+        name = _filename_for_media(url, media_type)
+        files.append(discord.File(io.BytesIO(raw), filename=name))
+    return files
+
+
+async def send_chunks(send_fn, text: str, files: list | None = None):
+    """Send text in Discord-sized chunks; attach files to the first message.
+
+    ``send_fn`` is ``async (content, *, files=None) -> message``.
+    Responses over 4000 chars go as a markdown file instead of many chunks.
+    """
+    files = files or []
+    if text and len(text) > 4000:
+        md = discord.File(io.BytesIO(text.encode("utf-8")), filename="response.md")
+        await send_fn(
+            f"Response too long ({len(text)} chars). See attached file.",
+            files=[md, *files][:10],
+        )
+        return
+    chunks = split_message(text or "") if text else [""]
+    if not chunks:
+        chunks = [""]
+    first_files = files or None
+    for i, chunk in enumerate(chunks):
+        kwargs = {}
+        if i == 0 and first_files:
+            kwargs["files"] = first_files
+        content = chunk or ("Here's what Guaardvark made." if first_files else "")
+        if not content and not kwargs:
+            continue
+        await send_fn(content or " ", **kwargs)

--- a/plugins/discord/core/chat_streamer.py
+++ b/plugins/discord/core/chat_streamer.py
@@ -1,0 +1,248 @@
+"""Async Socket.IO client for POST /api/chat/unified.
+
+Connect and join the session room before the HTTP POST — the backend can emit
+chat:thinking before join_room finishes. Approval requests are queued off the
+Socket.IO handler so a Discord button wait cannot stall the event stream.
+"""
+from engineio import payload as _engineio_payload
+_engineio_payload.Payload.max_decode_packets = 10000
+
+import asyncio
+import logging
+import time
+
+import socketio
+
+logger = logging.getLogger("discord_bot")
+
+IDLE_TIMEOUT = 300.0
+HARD_TIMEOUT = 1800.0
+JOIN_TIMEOUT = 10.0
+
+
+class StreamError(Exception):
+    """Raised when the unified-chat stream fails or times out."""
+
+    def __init__(self, message: str, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class UnifiedChatStreamer:
+    """One-shot Socket.IO listener for a single unified-chat turn."""
+
+    def __init__(self, server_url: str, sio=None):
+        self.server_url = server_url.rstrip("/")
+        self.sio = sio or socketio.AsyncClient(
+            reconnection=False, logger=False, engineio_logger=False
+        )
+        self._done = asyncio.Event()
+        self._joined = asyncio.Event()
+        self._tokens: list[str] = []
+        self._complete: dict = {}
+        self._error: str | None = None
+        self._images: list[dict] = []
+        self._session_id: str | None = None
+        self._approval_handler = None
+        self._approval_queue: asyncio.Queue = asyncio.Queue()
+        self._last_activity = time.monotonic()
+        self._closing = False
+        self._handlers_registered = False
+
+    def _touch(self):
+        self._last_activity = time.monotonic()
+
+    def _register_handlers(self):
+        if self._handlers_registered:
+            return
+        self._handlers_registered = True
+
+        @self.sio.on("chat:joined")
+        async def _joined(_data):
+            self._touch()
+            self._joined.set()
+
+        @self.sio.on("chat:token")
+        async def _token(data):
+            self._touch()
+            content = (data or {}).get("content", "")
+            if content:
+                self._tokens.append(content)
+
+        @self.sio.on("chat:image")
+        async def _image(data):
+            self._touch()
+            payload = data or {}
+            self._images.append({
+                "url": payload.get("image_url") or payload.get("url"),
+                "type": "image",
+                "alt": payload.get("alt") or "",
+            })
+
+        @self.sio.on("chat:video")
+        async def _video(data):
+            self._touch()
+            payload = data or {}
+            self._images.append({
+                "url": payload.get("video_url") or payload.get("url"),
+                "type": "video",
+                "alt": payload.get("alt") or "",
+            })
+
+        @self.sio.on("chat:complete")
+        async def _complete(data):
+            self._touch()
+            self._complete = data or {}
+            self._done.set()
+
+        @self.sio.on("chat:error")
+        async def _err(data):
+            self._touch()
+            self._error = (data or {}).get("error", "Unknown error")
+            self._done.set()
+
+        @self.sio.on("chat:aborted")
+        async def _aborted(_data):
+            self._touch()
+            self._error = "Chat aborted"
+            self._done.set()
+
+        @self.sio.on("chat:tool_approval_request")
+        async def _approval(data):
+            self._touch()
+            self._approval_queue.put_nowait(data or {})
+
+        @self.sio.event
+        async def disconnect():
+            if self._closing or self._done.is_set():
+                return
+            self._error = "Stream disconnected before completion"
+            self._done.set()
+
+    async def run(
+        self,
+        *,
+        session_id: str,
+        message: str,
+        post_fn,
+        image: str | None = None,
+        options: dict | None = None,
+        approval_handler=None,
+        is_voice_message: bool = False,
+    ) -> dict:
+        """Join the session, POST the turn, wait for chat:complete.
+
+        ``post_fn`` is an async callable that receives the JSON body and
+        performs the HTTP POST (so retries and unwrap live in the API client).
+        """
+        self._session_id = session_id
+        self._approval_handler = approval_handler
+        self._register_handlers()
+        try:
+            try:
+                await self.sio.connect(
+                    self.server_url,
+                    transports=["polling", "websocket"],
+                )
+            except Exception as e:
+                raise StreamError(f"Failed to connect to Guaardvark: {e}", 503) from e
+            await self.sio.emit("chat:join", {"session_id": session_id})
+            try:
+                await asyncio.wait_for(self._joined.wait(), timeout=JOIN_TIMEOUT)
+            except asyncio.TimeoutError:
+                raise StreamError(
+                    "Timed out joining Guaardvark chat session", 504
+                )
+
+            body = {
+                "session_id": session_id,
+                "message": message,
+                "options": options or {},
+            }
+            if image:
+                body["image"] = image
+            if is_voice_message:
+                body["is_voice_message"] = True
+
+            await post_fn(body)
+            completed = await self._wait_for_completion()
+            if not completed:
+                try:
+                    await self.sio.emit("chat:abort", {"session_id": session_id})
+                except Exception:
+                    pass
+                raise StreamError("Chat timed out waiting for Guaardvark", 504)
+
+            if self._error:
+                raise StreamError(self._error, 502)
+
+            response = self._complete.get("response") or "".join(self._tokens)
+            images = list(self._images)
+            for img in self._complete.get("generated_images") or []:
+                url = (img or {}).get("url") or (img or {}).get("image_url")
+                if url and not any((existing or {}).get("url") == url for existing in images):
+                    images.append(img)
+            return {
+                "response": response or "No response received.",
+                "session_id": session_id,
+                "generated_images": images,
+            }
+        finally:
+            await self.close()
+
+    async def _handle_approval(self, data: dict):
+        approved = False
+        if self._approval_handler:
+            try:
+                approved = bool(await self._approval_handler(data))
+            except Exception:
+                logger.exception("Approval handler failed; rejecting tool call")
+                approved = False
+        try:
+            await self.sio.emit("chat:tool_approval_response", {
+                "session_id": self._session_id,
+                "approved": approved,
+            })
+        except Exception:
+            logger.exception("Failed to send tool approval response")
+
+    async def _wait_for_completion(self) -> bool:
+        started = time.monotonic()
+        self._touch()
+        while True:
+            now = time.monotonic()
+            if now - started >= HARD_TIMEOUT:
+                return False
+            idle_for = now - self._last_activity
+            if idle_for >= IDLE_TIMEOUT:
+                return False
+            remaining = min(
+                0.25,
+                IDLE_TIMEOUT - idle_for,
+                HARD_TIMEOUT - (now - started),
+            )
+            if remaining <= 0:
+                return False
+
+            while True:
+                try:
+                    data = self._approval_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                await self._handle_approval(data)
+                self._touch()
+
+            try:
+                await asyncio.wait_for(self._done.wait(), timeout=remaining)
+                return True
+            except asyncio.TimeoutError:
+                continue
+
+    async def close(self):
+        self._closing = True
+        connected = getattr(self.sio, "connected", False)
+        if connected:
+            try:
+                await self.sio.disconnect()
+            except Exception:
+                pass

--- a/plugins/discord/core/voice_handler.py
+++ b/plugins/discord/core/voice_handler.py
@@ -10,6 +10,8 @@ from typing import Optional
 import discord
 
 from core.api_client import GuaardvarkClient, APIError
+from core.approvals import make_approval_handler
+from core.chat_reply import files_from_generated, send_chunks
 
 try:
     from discord.ext import voice_recv
@@ -196,12 +198,45 @@ class VoiceHandler:
             stt_s = time.monotonic() - t0
             logger.info("Voice STT (%s, %.1fs audio, %.1fs stt): '%s'", display_name, utt_seconds, stt_s, text[:100])
             t0 = time.monotonic()
-            chat_result = await self.api.chat(f"{display_name} says: {text}" if display_name else text, self.session_id)
+            prompt = f"{display_name} says: {text}" if display_name else text
+
+            async def send_fn(content, *, files=None, view=None):
+                kwargs = {"content": content}
+                if files:
+                    kwargs["files"] = files
+                if view is not None:
+                    kwargs["view"] = view
+                return await self.text_channel.send(**kwargs)
+
+            approval_handler = None
+            if self.text_channel is not None:
+                approval_handler = make_approval_handler(
+                    send_fn,
+                    user_id,
+                    auto_approve=bool(self.config.get("tools", {}).get("auto_approve", False)),
+                )
+
+            chat_result = await self.api.unified_chat(
+                prompt,
+                session_id=self.session_id,
+                approval_handler=approval_handler,
+                is_voice_message=True,
+            )
             response = chat_result.get("response", "")
-            if not response:
+            if not response and not chat_result.get("generated_images"):
                 return
-            logger.info("Voice LLM response (%.1fs): '%s'", time.monotonic() - t0, response[:100])
-            await self.speak(response)
+            logger.info("Voice LLM response (%.1fs): '%s'", time.monotonic() - t0, (response or "")[:100])
+            if response:
+                await self.speak(response)
+            images = chat_result.get("generated_images") or []
+            if images and self.text_channel is not None:
+                files = await files_from_generated(self.api, images)
+                if files:
+                    await send_chunks(
+                        send_fn,
+                        response or "Here's what Guaardvark made.",
+                        files=files,
+                    )
         except APIError as e:
             logger.error("Voice pipeline API error: %s", e)
             if self.text_channel:

--- a/plugins/discord/requirements.txt
+++ b/plugins/discord/requirements.txt
@@ -3,6 +3,7 @@ discord.py[voice]>=2.3.0
 # voice maintainer) provides VoiceRecvClient + sinks. Pre-release — exact pin required.
 discord-ext-voice-recv==0.5.2a179
 aiohttp>=3.9.0
+python-socketio>=5.10.0
 PyYAML>=6.0
 PyNaCl>=1.5.0
 pytest-asyncio>=0.23.0

--- a/plugins/discord/tests/conftest.py
+++ b/plugins/discord/tests/conftest.py
@@ -38,6 +38,15 @@ def mock_api_client():
         "model_used": "llama3",
         "response_time": 1.2,
     })
+    client.unified_chat = AsyncMock(return_value={
+        "response": "Hello! I'm Guaardvark.",
+        "session_id": "discord_user_123456789",
+        "generated_images": [],
+    })
+    client.chat_claude = AsyncMock(return_value={
+        "response": "Claude says hello.",
+    })
+    client.fetch_by_url = AsyncMock(return_value=b"\x89PNG\r\n" + b"\x00" * 100)
     client.generate_image = AsyncMock(return_value={
         "batch_id": "test-batch-123",
         "message": "Batch generation started",
@@ -128,7 +137,9 @@ def sample_config():
             "max_prompt_length": 2000,
             "max_image_prompt_length": 2000,
         },
-        "rate_limits": {"ask": 10, "imagine": 3, "generate_csv": 2, "search": 15, "enhance_prompt": 10},
+        "rate_limits": {"ask": 10, "imagine": 3, "generate_csv": 2, "search": 15, "enhance_prompt": 10, "claude": 5},
+        "tools": {"auto_approve": False},
+        "channel_chat": {"channel_ids": [], "respond_to_mentions": True},
         "voice": {
             "enabled": True, "silence_threshold_ms": 1500,
             "max_listen_duration_s": 30, "tts_voice": "ryan", "interrupt_on_speech": True,

--- a/plugins/discord/tests/test_api_client.py
+++ b/plugins/discord/tests/test_api_client.py
@@ -97,3 +97,61 @@ class TestGuaardvarkClient:
         err = APIError("not found", 404)
         assert str(err) == "not found"
         assert err.status_code == 404
+
+    def test_origin_strips_api_suffix(self):
+        client = GuaardvarkClient("http://localhost:5002/api")
+        assert client.origin == "http://localhost:5002"
+
+    def test_resolve_fetch_url_allows_relative_and_loopback(self):
+        client = GuaardvarkClient("http://localhost:5002/api")
+        assert client._resolve_fetch_url("/api/x.png") == "http://localhost:5002/api/x.png"
+        assert client._resolve_fetch_url("http://127.0.0.1:5002/api/x.png")
+        assert client._resolve_fetch_url("https://evil.example/steal") is None
+
+    @pytest.mark.asyncio
+    async def test_unified_chat_posts_unified_endpoint(self):
+        client = GuaardvarkClient("http://localhost:5002/api")
+        captured = {}
+
+        async def mock_post(path, **kwargs):
+            captured["path"] = path
+            captured["json"] = kwargs.get("json")
+            return {"success": True}
+
+        class FakeStreamer:
+            async def run(self, **kwargs):
+                await kwargs["post_fn"]({
+                    "session_id": kwargs["session_id"],
+                    "message": kwargs["message"],
+                    "options": kwargs["options"],
+                    "image": kwargs.get("image"),
+                })
+                return {
+                    "response": "hi",
+                    "session_id": kwargs["session_id"],
+                    "generated_images": [],
+                }
+
+        client._post = mock_post
+        result = await client.unified_chat(
+            "hello", session_id="discord_user_1", image="abc", streamer=FakeStreamer()
+        )
+        assert captured["path"] == "/chat/unified"
+        assert captured["json"]["message"] == "hello"
+        assert captured["json"]["session_id"] == "discord_user_1"
+        assert captured["json"]["image"] == "abc"
+        assert result["response"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_chat_claude_posts_escalate(self):
+        client = GuaardvarkClient()
+        captured_path = None
+
+        async def mock_post(path, **kwargs):
+            nonlocal captured_path
+            captured_path = path
+            return {"response": "hi"}
+
+        client._post = mock_post
+        await client.chat_claude("hello")
+        assert captured_path == "/claude/escalate"

--- a/plugins/discord/tests/test_approvals.py
+++ b/plugins/discord/tests/test_approvals.py
@@ -1,0 +1,30 @@
+"""Tests for Discord tool-approval views."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from core.approvals import ToolApprovalView, make_approval_handler
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_skips_view():
+    send_fn = AsyncMock()
+    handler = make_approval_handler(send_fn, user_id=1, auto_approve=True)
+    assert await handler({"tools": ["edit_image"]}) is True
+    send_fn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approval_view_only_requester_can_click():
+    view = ToolApprovalView(user_id=42)
+    other = MagicMock()
+    other.user = MagicMock()
+    other.user.id = 99
+    other.response = AsyncMock()
+    assert await view.interaction_check(other) is False
+    other.response.send_message.assert_awaited()
+
+    owner = MagicMock()
+    owner.user = MagicMock()
+    owner.user.id = 42
+    owner.response = AsyncMock()
+    assert await view.interaction_check(owner) is True

--- a/plugins/discord/tests/test_channel_chat.py
+++ b/plugins/discord/tests/test_channel_chat.py
@@ -1,0 +1,113 @@
+"""Tests for ChannelChatCog."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from commands.channel_chat import ChannelChatCog
+from core.api_client import APIError
+
+
+def _message(*, content, user_id=123456789, channel_id=111222333, attachments=None, mention=False, reply_to_bot=False, bot_user=None):
+    message = AsyncMock()
+    message.author = MagicMock()
+    message.author.bot = False
+    message.author.id = user_id
+    message.author.__str__ = lambda self: "testuser"
+    message.channel = MagicMock()
+    message.channel.id = channel_id
+    message.channel.typing = MagicMock()
+    message.channel.typing.return_value.__aenter__ = AsyncMock()
+    message.channel.typing.return_value.__aexit__ = AsyncMock()
+    message.channel.send = AsyncMock()
+    message.content = content
+    message.attachments = attachments or []
+    message.mentions = [bot_user] if mention and bot_user else []
+    message.reply = AsyncMock()
+    if reply_to_bot and bot_user:
+        resolved = MagicMock()
+        resolved.author = bot_user
+        resolved.attachments = []
+        message.reference = MagicMock()
+        message.reference.resolved = resolved
+    else:
+        message.reference = None
+    return message
+
+
+@pytest.fixture
+def channel_cog(mock_api_client, sample_config):
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 999
+    bot.user.__eq__ = lambda self, other: other is bot.user
+    return ChannelChatCog(bot=bot, api_client=mock_api_client, config=sample_config)
+
+
+@pytest.mark.asyncio
+async def test_mention_uses_unified_chat(channel_cog, mock_api_client):
+    msg = _message(
+        content="<@999> hello there",
+        mention=True,
+        bot_user=channel_cog.bot.user,
+    )
+    await channel_cog.on_message(msg)
+    mock_api_client.unified_chat.assert_awaited_once()
+    mock_api_client.chat_claude.assert_not_awaited()
+    kwargs = mock_api_client.unified_chat.call_args.kwargs
+    assert kwargs["session_id"] == "discord_user_123456789"
+
+
+@pytest.mark.asyncio
+async def test_listen_channel_uses_channel_session(mock_api_client, sample_config):
+    config = {
+        **sample_config,
+        "channel_chat": {"channel_ids": [111222333], "respond_to_mentions": True},
+    }
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 999
+    cog = ChannelChatCog(bot=bot, api_client=mock_api_client, config=config)
+    msg = _message(content="what can you do")
+    await cog.on_message(msg)
+    kwargs = mock_api_client.unified_chat.call_args.kwargs
+    assert kwargs["session_id"] == "discord_channel_111222333"
+
+
+@pytest.mark.asyncio
+async def test_forwards_image_attachment(channel_cog, mock_api_client):
+    att = AsyncMock()
+    att.read = AsyncMock(return_value=b"\x89PNG" + b"\x00" * 8)
+    att.size = 12
+    att.filename = "shot.png"
+    att.content_type = "image/png"
+    msg = _message(
+        content="<@999> edit this",
+        mention=True,
+        bot_user=channel_cog.bot.user,
+        attachments=[att],
+    )
+    await channel_cog.on_message(msg)
+    kwargs = mock_api_client.unified_chat.call_args.kwargs
+    assert kwargs["image"]
+
+
+@pytest.mark.asyncio
+async def test_ignores_unrelated_channel(channel_cog, mock_api_client):
+    msg = _message(content="hello")
+    await channel_cog.on_message(msg)
+    mock_api_client.unified_chat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reports_offline_on_api_error(channel_cog, mock_api_client):
+    mock_api_client.unified_chat.side_effect = APIError("backend down", 503)
+    msg = _message(
+        content="<@999> hello",
+        mention=True,
+        bot_user=channel_cog.bot.user,
+    )
+    await channel_cog.on_message(msg)
+    content = msg.reply.call_args.kwargs.get("content") or (
+        msg.reply.call_args.args[0] if msg.reply.call_args.args else ""
+    )
+    assert "offline" in content.lower() or "failed" in content.lower()
+    assert "claude" not in content.lower()

--- a/plugins/discord/tests/test_chat.py
+++ b/plugins/discord/tests/test_chat.py
@@ -1,9 +1,10 @@
 """Tests for the ChatCog (/ask command)."""
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, AsyncMock
 
-from commands.chat import ChatCog, split_message
+from commands.chat import ChatCog
 from core.api_client import APIError
+from core.chat_reply import split_message
 
 
 @pytest.fixture
@@ -48,14 +49,15 @@ class TestAskCommand:
         """Session ID should be discord_{user_id}."""
         await chat_cog._handle_ask(mock_interaction, "test prompt")
 
-        mock_api_client.chat.assert_awaited_once()
-        call_args = mock_api_client.chat.call_args
-        assert call_args.args[1] == "discord_123456789"
+        mock_api_client.unified_chat.assert_awaited_once()
+        mock_api_client.chat_claude.assert_not_awaited()
+        call_args = mock_api_client.unified_chat.call_args
+        assert call_args.kwargs["session_id"] == "discord_user_123456789"
 
     @pytest.mark.asyncio
     async def test_ask_handles_api_error(self, chat_cog, mock_interaction, mock_api_client):
         """API errors should be caught and reported to the user."""
-        mock_api_client.chat.side_effect = APIError("Backend offline", 503)
+        mock_api_client.unified_chat.side_effect = APIError("Backend offline", 503)
 
         await chat_cog._handle_ask(mock_interaction, "Hello")
 
@@ -69,7 +71,7 @@ class TestAskCommand:
         """Mentions and code blocks should be stripped before sending to API."""
         await chat_cog._handle_ask(mock_interaction, "<@!12345> tell me about ```code```")
 
-        call_args = mock_api_client.chat.call_args.args[0]
+        call_args = mock_api_client.unified_chat.call_args.args[0]
         assert "<@!12345>" not in call_args
         assert "```" not in call_args
 
@@ -77,7 +79,7 @@ class TestAskCommand:
     async def test_ask_splits_long_response(self, chat_cog, mock_interaction, mock_api_client):
         """Responses over 2000 chars should be split into multiple messages."""
         long_response = "word " * 600  # ~3000 chars, under 4000 so no file
-        mock_api_client.chat.return_value = {"response": long_response}
+        mock_api_client.unified_chat.return_value = {"response": long_response, "generated_images": []}
 
         await chat_cog._handle_ask(mock_interaction, "Give me a long answer")
 
@@ -87,12 +89,12 @@ class TestAskCommand:
     async def test_ask_very_long_response_as_file(self, chat_cog, mock_interaction, mock_api_client):
         """Responses over 4000 chars should be sent as a file attachment."""
         huge_response = "x" * 5000
-        mock_api_client.chat.return_value = {"response": huge_response}
+        mock_api_client.unified_chat.return_value = {"response": huge_response, "generated_images": []}
 
         await chat_cog._handle_ask(mock_interaction, "Give me a huge answer")
 
         call_kwargs = mock_interaction.followup.send.call_args.kwargs
-        assert call_kwargs.get("file") is not None
+        assert call_kwargs.get("files")
         assert "too long" in call_kwargs.get("content", "").lower()
 
     @pytest.mark.asyncio
@@ -118,3 +120,23 @@ class TestAskCommand:
         call_args = mock_interaction.response.send_message.call_args
         content = call_args.args[0] if call_args.args else call_args.kwargs.get("content", "")
         assert "not allowed" in content.lower()
+
+    @pytest.mark.asyncio
+    async def test_ask_does_not_call_claude(self, chat_cog, mock_interaction, mock_api_client):
+        await chat_cog._handle_ask(mock_interaction, "Hello AI")
+        mock_api_client.chat_claude.assert_not_awaited()
+        mock_api_client.unified_chat.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ask_forwards_image_attachment(self, chat_cog, mock_interaction, mock_api_client):
+        image = AsyncMock()
+        image.read = AsyncMock(return_value=b"\x89PNG" + b"\x00" * 16)
+        image.size = 20
+        image.filename = "photo.png"
+        image.content_type = "image/png"
+
+        await chat_cog._handle_ask(mock_interaction, "edit this", image=image)
+
+        kwargs = mock_api_client.unified_chat.call_args.kwargs
+        assert kwargs["image"]
+        assert kwargs["session_id"] == "discord_user_123456789"

--- a/plugins/discord/tests/test_chat_streamer.py
+++ b/plugins/discord/tests/test_chat_streamer.py
@@ -1,0 +1,118 @@
+"""Tests for UnifiedChatStreamer."""
+import pytest
+from unittest.mock import AsyncMock
+
+from core.chat_streamer import StreamError, UnifiedChatStreamer
+
+
+class FakeSio:
+    def __init__(self):
+        self.handlers = {}
+        self.connected = False
+        self.emitted = []
+
+    def on(self, event):
+        def deco(fn):
+            self.handlers[event] = fn
+            return fn
+        return deco
+
+    def event(self, fn):
+        self.handlers[fn.__name__] = fn
+        return fn
+
+    async def connect(self, *args, **kwargs):
+        self.connected = True
+
+    async def emit(self, event, data=None):
+        self.emitted.append((event, data))
+        if event == "chat:join":
+            handler = self.handlers.get("chat:joined")
+            if handler:
+                await handler({"session_id": (data or {}).get("session_id"), "status": "ok"})
+
+    async def disconnect(self):
+        self.connected = False
+
+
+@pytest.mark.asyncio
+async def test_joins_before_post():
+    sio = FakeSio()
+    streamer = UnifiedChatStreamer("http://localhost:5002", sio=sio)
+    order = []
+
+    async def post_fn(body):
+        order.append("post")
+        assert streamer._joined.is_set()
+        await sio.handlers["chat:complete"]({"response": "hi from gv"})
+
+    result = await streamer.run(
+        session_id="discord_user_1",
+        message="hello",
+        post_fn=post_fn,
+    )
+    assert order == ["post"]
+    assert sio.emitted[0][0] == "chat:join"
+    assert result["response"] == "hi from gv"
+    assert result["session_id"] == "discord_user_1"
+
+
+@pytest.mark.asyncio
+async def test_collects_generated_images():
+    sio = FakeSio()
+    streamer = UnifiedChatStreamer("http://localhost:5002", sio=sio)
+
+    async def post_fn(_body):
+        await sio.handlers["chat:image"]({"image_url": "/api/img/a.png"})
+        await sio.handlers["chat:complete"]({
+            "response": "here",
+            "generated_images": [{"url": "/api/img/b.png", "type": "image"}],
+        })
+
+    result = await streamer.run(
+        session_id="discord_user_1", message="draw", post_fn=post_fn
+    )
+    urls = [img["url"] for img in result["generated_images"]]
+    assert "/api/img/a.png" in urls
+    assert "/api/img/b.png" in urls
+
+
+@pytest.mark.asyncio
+async def test_approval_emits_response():
+    sio = FakeSio()
+    streamer = UnifiedChatStreamer("http://localhost:5002", sio=sio)
+    seen = {}
+
+    async def approval_handler(data):
+        seen["tools"] = data.get("tools")
+        await sio.handlers["chat:complete"]({"response": "ok"})
+        return True
+
+    async def post_fn(_body):
+        streamer._approval_queue.put_nowait({"tools": ["edit_image"]})
+
+    result = await streamer.run(
+        session_id="discord_user_1",
+        message="edit",
+        post_fn=post_fn,
+        approval_handler=approval_handler,
+    )
+    assert result["response"] == "ok"
+    assert seen["tools"] == ["edit_image"]
+    events = [e[0] for e in sio.emitted]
+    assert "chat:tool_approval_response" in events
+    approval = [d for e, d in sio.emitted if e == "chat:tool_approval_response"][0]
+    assert approval["approved"] is True
+
+
+@pytest.mark.asyncio
+async def test_error_event_raises():
+    sio = FakeSio()
+    streamer = UnifiedChatStreamer("http://localhost:5002", sio=sio)
+
+    async def post_fn(_body):
+        await sio.handlers["chat:error"]({"error": "LLM not available"})
+
+    with pytest.raises(StreamError) as exc:
+        await streamer.run(session_id="s", message="hi", post_fn=post_fn)
+    assert "LLM not available" in str(exc.value)


### PR DESCRIPTION
## Summary

The Discord bot's three conversational surfaces (`/ask`, listen-channel/mention chat, voice replies) called `/claude/escalate` or the plain `/chat` endpoint, so a Discord user got a different brain than the web UI — no tools, plugins, memory, or active-model selection. They now go through `POST /api/chat/unified` and listen on Socket.IO for the same event stream the browser uses.

- **`core/chat_streamer.py`** — one-shot Socket.IO client per turn. Joins the session room *before* the POST (the backend can emit before `join_room` returns); tool-approval requests are queued off the event handler so a button wait cannot stall the stream. Idle (300 s) and hard (30 min) timeouts, `chat:abort` on timeout.
- **`core/approvals.py`** — Approve/Deny button view. Only the requester may click; timeout counts as deny. `tools.auto_approve: true` in `config.yaml` skips the buttons (private servers).
- **`core/chat_reply.py`** — the message-splitting, attachment and media-download helpers that three cogs each carried a copy of (`claude_chat.py` now imports it too).
- **`api_client.py`** — `unified_chat()` with one retry after clearing a 409 (wedged session) via `/chat/unified/<sid>/abort`; `fetch_by_url()` refuses non-loopback hosts.
- `/ask` takes an optional `image:` attachment; channel chat forwards attachments and replied-to images; voice replies post generated images/videos to the text channel alongside the spoken answer.
- `/claude` keeps the explicit Uncle Claude path.
- New dependency: `python-socketio` (already present in the backend venv the bot runs from).

## Verification

- `plugins/discord/tests`: 84 passed (3 new test modules: streamer, approvals, channel chat).
- Streamer contract checked against `backend/socketio_events.py` / `unified_chat_engine.py` / `unified_chat_api.py`: `chat:join`→`chat:joined`, `image_url`/`video_url` payloads, `tools` on approval requests, `session_id`+`approved` on responses, `image`/`options`/`is_voice_message` on the POST, abort route.
- Live: the new client round-tripped a turn through the running backend (`PONG` in 19 s via AgentBrain); bot restarted on this code and loaded all cogs clean.
- `scripts/check_portable.sh --range origin/main..HEAD` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
