### PR TITLE
docs+mcp: official contact addresses (support@ / info@guaardvark.com)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,8 +52,9 @@ when an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainers through GitHub (a report on the repository, or the
-contact options at [guaardvark.com](https://guaardvark.com)). All complaints
+reported to the maintainers through GitHub (a report on the repository), by
+email to info@guaardvark.com, or via the contact options at
+[guaardvark.com](https://guaardvark.com). All complaints
 will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thanks for your interest in contributing to Guaardvark! Whether it's a bug repor
 - [Good First Issues](https://github.com/guaardvark/guaardvark/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Project Board](https://github.com/guaardvark/guaardvark/projects)
 - [README — Get Involved](README.md#get-involved)
+- Questions that do not fit an issue: info@guaardvark.com
 
 ### I want to help — 4 steps
 

--- a/README.md
+++ b/README.md
@@ -585,6 +585,8 @@ Guaardvark is built with love by a solo developer. If it's useful to you:
 
 Star the repo if you find it interesting — it helps with visibility.
 
+Questions, install trouble, or feedback: **support@guaardvark.com**. Press, partnerships, and business: **info@guaardvark.com**.
+
 ---
 
 ## Get Involved
@@ -641,7 +643,7 @@ Full setup, style, and PR expectations: **[CONTRIBUTING.md](CONTRIBUTING.md)**
 ### 5. Other ways to help (no code required)
 
 - Star the repo and share a short demo (screen agent, Film Crew, or Discord `/imagine`)
-- Report install friction with GPU model + logs from `logs/`
+- Report install friction with GPU model + logs from `logs/` (an issue, or email support@guaardvark.com)
 - Suggest recipes or workflows you wish worked out of the box
 - Support development: [Ko-fi](https://ko-fi.com/albenze) · [Sponsors](https://github.com/sponsors/guaardvark) · [PayPal](https://paypal.me/albenze)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,8 @@ reports about anything that could break those guarantees seriously.
 Please use **GitHub's private vulnerability reporting** (the "Report a
 vulnerability" button under the repository's Security tab). That opens a
 private thread with the maintainers — do **not** open a public issue for
-anything exploitable.
+anything exploitable. If you cannot use GitHub, email **support@guaardvark.com**
+with "SECURITY" in the subject line.
 
 You can expect an acknowledgement within a few days. Please include steps to
 reproduce and, when relevant, which surface is involved (backend API, agent

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -56,7 +56,8 @@ def build_server(config: MCPConfig | None = None) -> tuple[Server, dict[str, int
         version=version,
         instructions=(
             f"{MCP_TITLE} — local-first AI platform. Exposes generation, RAG, "
-            "memory, and web tools plus generated outputs as MCP resources."
+            "memory, and web tools plus generated outputs as MCP resources. "
+            "Docs: https://guaardvark.com/mcp/ · Support: support@guaardvark.com"
         ),
         website_url="https://guaardvark.com",
         on_list_tools=on_list_tools,

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -49,6 +49,7 @@ setup(
     long_description=_long_description,
     long_description_content_type="text/markdown",
     author="Guaardvark",
+    author_email="info@guaardvark.com",
     url="https://guaardvark.com",
     project_urls={
         "Source": "https://github.com/guaardvark/guaardvark",


### PR DESCRIPTION
Adds the official guaardvark.com contact addresses to the public-facing text:

- README: support@ for questions/install trouble, info@ for press/partnerships
- SECURITY.md: email fallback for people who cannot use GitHub private reporting
- CODE_OF_CONDUCT.md: enforcement contact
- CONTRIBUTING.md: questions line
- cli/setup.py: package author_email
- backend/mcp/server.py: MCP server instructions carry docs URL + support address

Branched from origin/main so it can merge independently of the in-progress local work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)