### PR TITLE
test(media): keep is_available metadata on the no-GPU stand-ins

### DIFF
--- a/backend/tests/test_media_import_no_cuda.py
+++ b/backend/tests/test_media_import_no_cuda.py
@@ -62,9 +62,15 @@ _PROBE = textwrap.dedent(
 
     grc.get_gpu_coordinator = lambda: _NoGpu()
 
+    import functools
     import torch
-    torch.cuda.is_available = lambda: False
-    torch.backends.mps.is_available = lambda: False
+
+    # The stand-ins keep the real probe's metadata: torch's dynamo reads
+    # ``is_available.__wrapped__`` while building its trace rules, and
+    # diffusers imports dynamo, so a bare lambda here would turn every media
+    # import into an AttributeError instead of exercising the no-GPU branch.
+    torch.cuda.is_available = functools.wraps(torch.cuda.is_available)(lambda: False)
+    torch.backends.mps.is_available = functools.wraps(torch.backends.mps.is_available)(lambda: False)
 
     import importlib
     importlib.import_module({module!r})

--- a/backend/tests/test_offline_video_mps.py
+++ b/backend/tests/test_offline_video_mps.py
@@ -9,6 +9,8 @@ MPS (that needs a Mac; tracked separately). They DO prove:
   - CPU-only and no-torch fall through correctly.
 """
 
+import functools
+
 import pytest
 
 import backend.services.offline_video_generator as ovg
@@ -23,9 +25,14 @@ def fake_torch(monkeypatch):
 
 
 def _set(monkeypatch, real_torch, *, cuda: bool, mps: bool):
-    monkeypatch.setattr(real_torch.cuda, "is_available", lambda: cuda)
+    # functools.wraps keeps ``__wrapped__`` on the stand-ins; torch's dynamo
+    # reads it off both probes when it builds its trace rules.
+    monkeypatch.setattr(real_torch.cuda, "is_available",
+                        functools.wraps(real_torch.cuda.is_available)(lambda: cuda))
     # _mps_available() reads torch.backends.mps.is_available — patch it there
-    monkeypatch.setattr(real_torch.backends.mps, "is_available", lambda: mps, raising=False)
+    monkeypatch.setattr(real_torch.backends.mps, "is_available",
+                        functools.wraps(real_torch.backends.mps.is_available)(lambda: mps),
+                        raising=False)
 
 
 def test_cuda_wins(monkeypatch, fake_torch):


### PR DESCRIPTION
torch 2.14.0 (released 2026-09-02) reads `torch.backends.mps.is_available.__wrapped__` while dynamo builds its trace rules, and diffusers imports dynamo. Two test files replaced the CUDA/MPS probes with bare lambdas, so on a runner that resolves torch 2.14 every media import fails with `AttributeError: 'function' object has no attribute '__wrapped__'` instead of exercising the no-GPU branch.

`functools.wraps` carries the real probe's metadata onto the stand-ins. No production code changes.

First seen on the macOS platform job of #130; the identical job passed on `main` the day before with torch 2.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)