### PR TITLE
fix(devtools): migrations card reads the fields /api/health/db returns

### DIFF
--- a/frontend/src/pages/DevToolsPage.jsx
+++ b/frontend/src/pages/DevToolsPage.jsx
@@ -609,22 +609,22 @@ const DevToolsPage = () => {
               {dbHealth && !dbError ? (
                 <>
                   <Box display="flex" alignItems="center" mb={1}>
-                    {dbHealth.up_to_date ? (
+                    {dbHealth.status === "ok" ? (
                       <CheckCircle color="success" sx={{ mr: 1 }} />
                     ) : (
                       <Warning color="warning" sx={{ mr: 1 }} />
                     )}
                     <Chip
-                      label={dbHealth.up_to_date ? "Up to date" : "Needs update"}
-                      color={dbHealth.up_to_date ? "success" : "warning"}
+                      label={dbHealth.status === "ok" ? "Up to date" : "Needs update"}
+                      color={dbHealth.status === "ok" ? "success" : "warning"}
                       size="small"
                     />
                   </Box>
-                  <Typography variant="body2">Current: {dbHealth.current}</Typography>
+                  <Typography variant="body2">Current: {dbHealth.db_revision || "none"}</Typography>
                   <Typography variant="body2">
-                    Heads: {dbHealth.heads && dbHealth.heads.join(", ")}
+                    Heads: {(dbHealth.heads || [dbHealth.head]).filter(Boolean).join(", ")}
                   </Typography>
-                  {dbHealth.multiple_heads && (
+                  {dbHealth.status === "multiple_heads" && (
                     <Alert severity="error" sx={{ mt: 1 }}>
                       Multiple heads detected
                     </Alert>


### PR DESCRIPTION
The Database / Migrations card on the Dev Tools page tested `up_to_date`, `current` and `heads`. `/api/health/db` returns `status`, `head` and `db_revision` (see `backend/utils/migration_utils.get_health`). So every install showed "Needs update" with blank Current and Heads, even with the database exactly at head.

Reported in #114 against a clean v2.8.1 install where `scripts/check_migrations.py` reports `status: ok`.

The card now shows "Up to date" when status is `ok`, the database revision under Current, the head(s) under Heads, and the multiple-heads alert when status says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)