### PR TITLE
chore(frontend): react-grid-layout 2.2.4 through its legacy entry

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-grid-layout": "^1.4.4",
+        "react-grid-layout": "^2.2.4",
         "react-image-crop": "^11.1.2",
         "react-markdown": "^10.1.0",
         "react-router": "^7.18.3",
@@ -7839,16 +7839,15 @@
       }
     },
     "node_modules/react-grid-layout": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
-      "integrity": "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==",
-      "license": "MIT",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.4.tgz",
+      "integrity": "sha512-Eb57FsgOMYOfsUGrMI1ku/FFR+dPNPrE8qo+3hwZubpqVSy4GO9v52DeX50Tl3JDYAlCypP4rmw7Vrqk/zOIvA==",
       "dependencies": {
         "clsx": "^2.1.1",
         "fast-equals": "^4.0.3",
         "prop-types": "^15.8.1",
         "react-draggable": "^4.4.6",
-        "react-resizable": "^3.0.5",
+        "react-resizable": "^3.1.3",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-grid-layout": "^1.4.4",
+    "react-grid-layout": "^2.2.4",
     "react-image-crop": "^11.1.2",
     "react-markdown": "^10.1.0",
     "react-router": "^7.18.3",

--- a/frontend/src/components/documents/DesktopItemsGrid.jsx
+++ b/frontend/src/components/documents/DesktopItemsGrid.jsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Box, Card, CardActionArea, CardContent, Typography, useTheme, alpha } from '@mui/material';
 import { Folder as FolderIcon } from '@mui/icons-material';
-import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout';
+import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout/legacy';
 import { useLayout } from '../../contexts/LayoutContext';
 import { getFileIcon, getItemKey } from './fileUtils.jsx';
 import 'react-grid-layout/css/styles.css';

--- a/frontend/src/components/filesystem/FileManager.jsx
+++ b/frontend/src/components/filesystem/FileManager.jsx
@@ -67,7 +67,7 @@ import {
   Archive as ArchiveIcon,
   DataObject as JsonIcon,
 } from '@mui/icons-material';
-import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout';
+import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout/legacy';
 import axios from 'axios';
 import FilePropertiesModal from '../modals/FilePropertiesModal';
 import FolderPropertiesModal from '../modals/FolderPropertiesModal';

--- a/frontend/src/pages/CodeEditorPage.jsx
+++ b/frontend/src/pages/CodeEditorPage.jsx
@@ -24,7 +24,7 @@ import {
   ListItemText,
   CircularProgress,
 } from "@mui/material";
-import ReactGridLayout, { WidthProvider } from "react-grid-layout";
+import ReactGridLayout, { WidthProvider } from "react-grid-layout/legacy";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 
 import "react-grid-layout/css/styles.css";

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -18,7 +18,7 @@ import {
   useTheme,
   IconButton,
 } from "@mui/material";
-import ReactGridLayout from "react-grid-layout";
+import ReactGridLayout from "react-grid-layout/legacy";
 
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";

--- a/frontend/src/pages/DocumentsPage.jsx
+++ b/frontend/src/pages/DocumentsPage.jsx
@@ -18,7 +18,7 @@ import PdfViewerModal from "../components/documents/PdfViewerModal";
 import DocxViewerModal from "../components/documents/DocxViewerModal";
 import AudioPlayerModal from "../components/documents/AudioPlayerModal";
 import MediaPreviewOverlay from "../components/documents/MediaPreviewOverlay";
-import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout';
+import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout/legacy';
 import FolderWindow from "../components/documents/FolderWindow";
 import DocumentsContextMenu from "../components/documents/DocumentsContextMenu";
 import FilePropertiesModal from "../components/modals/FilePropertiesModal";

--- a/frontend/src/pages/ImagesPage.jsx
+++ b/frontend/src/pages/ImagesPage.jsx
@@ -48,7 +48,7 @@ import {
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
 import { BrandLogo } from "../components/branding";
-import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout';
+import ReactGridLayoutLib, { WidthProvider } from 'react-grid-layout/legacy';
 import BatchImageGeneratorPage from './BatchImageGeneratorPage';
 import VideoGeneratorPage from './VideoGeneratorPage';
 import UpscalingPage from './UpscalingPage';

--- a/frontend/src/pages/StickyNotesPage.jsx
+++ b/frontend/src/pages/StickyNotesPage.jsx
@@ -26,7 +26,7 @@ import {
   DialogActions,
   Button,
 } from "@mui/material";
-import ReactGridLayout from "react-grid-layout";
+import ReactGridLayout from "react-grid-layout/legacy";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 

--- a/frontend/src/pages/VideoEditorPage.jsx
+++ b/frontend/src/pages/VideoEditorPage.jsx
@@ -54,7 +54,7 @@ import {
   saveProjectAs,
   renameProject,
 } from "../api/videoEditorService";
-import ReactGridLayout, { WidthProvider } from "react-grid-layout";
+import ReactGridLayout, { WidthProvider } from "react-grid-layout/legacy";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 import DashboardCardWrapper from "../components/dashboard/DashboardCardWrapper";


### PR DESCRIPTION
Supersedes #123, which fails the Vite build because v2's root entry no longer exports `WidthProvider`.

react-grid-layout 2 is a TypeScript rewrite: the root entry drops `WidthProvider` and `data-grid`, requires an explicit `width`, and fires `onDragStart` only after 3 px of movement. The package ships `react-grid-layout/legacy` with the v1 flat-props API (`WidthProvider` included, drag threshold 0), so the eight grids in the app keep their behaviour by importing from that entry. The `css/styles.css` path is unchanged.

Verified locally: `npm run lint` clean, `npm run build` succeeds. Runtime dependencies of the package are unchanged apart from a minor `react-resizable` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)