### PR TITLE
chore(dependabot): hold librosa at 0.x until the numpy 2 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # librosa 1.x requires numpy>=2.1; the backend pins numpy<2.0 (see
+      # backend/requirements.txt), so the resolver falls back to building an
+      # old scipy from source and fails. Lift this with the numpy 2 migration.
+      - dependency-name: librosa
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: pip
     directory: /cli
     schedule:


### PR DESCRIPTION
librosa 1.0.0 (released 2026-08-11) requires `numpy>=2.1`. The backend pins `numpy<2.0` for the CV stack, so Dependabot's #118 sends pip backtracking into a source build of an old scipy, which dies in pythran (`KeyError: 'sep'`) on Backend Validation, Backend Tests and the macOS job. The failure is deterministic; nothing to re-run.

This adds a Dependabot `ignore` for major librosa updates on the backend manifest so the same red PR is not reopened every week. The floor `librosa>=0.10.2` stays; 0.11.0 is what installs today. The ignore is meant to be removed with the numpy 2 migration, which is the real change behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)