### PR TITLE
fix(interconnector): ship backend/prompt_bundles to synced machines

### DIFF
--- a/backend/services/interconnector_file_sync_service.py
+++ b/backend/services/interconnector_file_sync_service.py
@@ -80,6 +80,10 @@ class InterconnectorFileSyncService:
             "backend/mcp/",
             "backend/rule_bundles/",
             "backend/lesson_bundles/",
+            # Prompt presets, gallery index and language table for the MiniMax
+            # H3 prompt compiler (backend/services/h3_prompt_compiler.py). Data,
+            # not a package, so it needs its own line like the bundles above.
+            "backend/prompt_bundles/",
             "backend/static/",
             "backend/oom_priority.py",
             "backend/schema.sql",


### PR DESCRIPTION
The H3 prompt compiler's data lives in `backend/prompt_bundles/` (presets, gallery index, language table). The Interconnector allowlist names backend directories one by one and had no line for it, so a synced machine got the H3 code and then failed with `No such file or directory: backend/prompt_bundles/minimax_h3/presets.json` when listing presets.

One line on the allowlist, next to `rule_bundles`/`lesson_bundles`. The master backend has to restart before a client's Update Now sees the new list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)