### PR TITLE
fix: two NameErrors on live code paths

### DIFF
--- a/backend/api/voice_api.py
+++ b/backend/api/voice_api.py
@@ -17,7 +17,7 @@ import json
 import psutil
 import requests
 
-from flask import Blueprint, current_app, jsonify, request, send_file
+from flask import Blueprint, Response, current_app, jsonify, request, send_file
 from werkzeug.utils import secure_filename
 from backend.utils.response_utils import success_response, error_response
 from backend.utils.path_guard import PathEscapesRoot, contained, contained_path

--- a/backend/services/batch_video_generator.py
+++ b/backend/services/batch_video_generator.py
@@ -221,7 +221,7 @@ class BatchVideoGenerator:
         self._running_batch_id: Optional[str] = None
 
         self.video_generator = get_video_generator()
-        self.service_available = getattr(self.video_generator, 'service_available', True) and video_generator_available if 'video_generator_available' in dir() else self.video_generator.service_available
+        self.service_available = getattr(self.video_generator, 'service_available', True)
         # Edge graceful: on no-GPU, batch video (which uses offline or Comfy) will inherit unavailable with reason from underlying generator.
         _get_video_logger()  # Initialize dedicated log file
 


### PR DESCRIPTION
Both surfaced by pyflakes during the CodeQL sweep (#149).

- **voice_api**: `Response` was used for the streaming text-to-speech and narrate responses without being imported, so any streamed request raised `NameError`.
- **batch_video_generator**: `service_available` was set through a conditional that tested a name never defined in that scope; the branch that actually ran also bypassed the `getattr` default. It is now the underlying generator flag, defaulting to True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)