### PR TITLE
fix(self-improvement): UnboundLocalError on 'logger' in _propose_reflex_update

### DIFF
--- a/backend/services/self_improvement_service.py
+++ b/backend/services/self_improvement_service.py
@@ -791,7 +791,6 @@ class SelfImprovementService:
             try:
                 from backend.models import db, PendingFix
                 if not getattr(self, '_current_run_id', None):
-                    logger = logging.getLogger(__name__)
                     logger.info("PendingFix created without run_id (ad-hoc from _attempt_fix; per team audit)")
 
                 fix = PendingFix(


### PR DESCRIPTION
### Problem

`SelfImprovementService._propose_reflex_update` crashes with `UnboundLocalError`
whenever it reaches the review-logging step.

The module defines a global logger:

```python
logger = logging.getLogger(__name__)   # line 30
```

but inside `_propose_reflex_update` there is a second, local rebind:

```python
if not getattr(self, '_current_run_id', None):
    logger = logging.getLogger(__name__)
    logger.info("PendingFix created without run_id ...")
```

Because `logger` is assigned somewhere in the function body, Python treats it
as a **local** for the *entire* function. So the earlier call

```python
logger.info(f"Scale factor review: approved=...")   # line 786
```

runs *before* that assignment and raises `UnboundLocalError: local variable
'logger' referenced before assignment`. Worse, the outer
`except Exception as e: logger.error(...)` handler then tries to use the same
still-unbound `logger`, so the error is re-raised — the method always fails
once it gets past the advisor review call.

`python -m pyflakes` flags it directly:

```
self_improvement_service.py:786:13: local variable 'logger' defined in enclosing scope on line 30 referenced before assignment
```

### Fix

Drop the redundant local `logger = logging.getLogger(__name__)` so every
reference resolves to the module-level logger. One-line deletion; pyflakes is
clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
