### PR TITLE
fix(upload): master image forwarding always aborts on UnboundLocalError for project_id/tags_str

### DIFF
--- a/backend/api/upload_api.py
+++ b/backend/api/upload_api.py
@@ -345,6 +345,42 @@ def upload_file_endpoint():
         return jsonify({"error": "File content does not match file type or contains invalid data"}), 400
 
     if file and allowed_file(file.filename):
+        # --- Get project_id and tags from form data ---
+        project_id_str = request.form.get("project_id")
+        tags_str = request.form.get(
+            "tags"
+        )  # Expecting comma-separated string or similar
+        logger.debug(
+            f"Upload form data - project_id: {project_id_str}, tags: {tags_str}"
+        )
+
+        project_id = None
+        if project_id_str:
+            try:
+                project_id = int(project_id_str)
+                # SECURITY FIX: Add bounds checking for project_id
+                if project_id < 1 or project_id > 2147483647:  # 32-bit signed int max
+                    logger.warning(f"API Warning (POST /upload): Project ID out of valid range: {project_id}")
+                    project_id = None
+                # Optional: Validate if project_id actually exists in the Project table
+                elif Project and not db.session.get(Project, project_id):
+                    logger.warning(
+                        f"API Warning (POST /upload): Project ID {project_id} not found in database."
+                    )
+                    project_id = None  # Set back to None if validation fails
+            except ValueError:
+                logger.warning(
+                    f"API Warning (POST /upload): Invalid project_id '{project_id_str}'. Must be an integer."
+                )
+                project_id = None
+            except SQLAlchemyError as e:
+                logger.error(
+                    f"Database error validating project ID {project_id_str}: {e}",
+                    exc_info=True,
+                )
+                project_id = None
+        # --- End Get project_id and tags ---
+
         # Check if this is an image and should be forwarded to master
         file_ext = os.path.splitext(file.filename)[1].lower().lstrip(".")
         is_image = file_ext in ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']
@@ -423,42 +459,6 @@ def upload_file_endpoint():
         if _gitignore_filter.should_ignore(original_filename) or _gitignore_filter.should_ignore(filename):
             logger.info(f"Skipping ignored file: {original_filename}")
             return jsonify({"message": "File skipped (ignored by filter)", "skipped": True}), 200
-
-        # --- Get project_id and tags from form data ---
-        project_id_str = request.form.get("project_id")
-        tags_str = request.form.get(
-            "tags"
-        )  # Expecting comma-separated string or similar
-        logger.debug(
-            f"Upload form data - project_id: {project_id_str}, tags: {tags_str}"
-        )
-
-        project_id = None
-        if project_id_str:
-            try:
-                project_id = int(project_id_str)
-                # SECURITY FIX: Add bounds checking for project_id
-                if project_id < 1 or project_id > 2147483647:  # 32-bit signed int max
-                    logger.warning(f"API Warning (POST /upload): Project ID out of valid range: {project_id}")
-                    project_id = None
-                # Optional: Validate if project_id actually exists in the Project table
-                elif Project and not db.session.get(Project, project_id):
-                    logger.warning(
-                        f"API Warning (POST /upload): Project ID {project_id} not found in database."
-                    )
-                    project_id = None  # Set back to None if validation fails
-            except ValueError:
-                logger.warning(
-                    f"API Warning (POST /upload): Invalid project_id '{project_id_str}'. Must be an integer."
-                )
-                project_id = None
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"Database error validating project ID {project_id_str}: {e}",
-                    exc_info=True,
-                )
-                project_id = None
-        # --- End Get project_id and tags ---
 
         try:
             upload_folder_path = current_app.config.get("UPLOAD_FOLDER")


### PR DESCRIPTION
### Problem

`upload_file_endpoint()` in `backend/api/upload_api.py` has a variable-scope bug that
silently disables the master image-repository forwarding path.

The image-forwarding branch reads `project_id` and `tags_str`:

```python
# line 374 (current main)
if project_id:
    existing_doc.project_id = project_id
if tags_str:
    existing_doc.tags = tags_str
else:
    new_doc = DBDocument(..., project_id=project_id, tags=tags_str)
```

but both names are function-locals that are only **assigned further down in the same
function** (the `# --- Get project_id and tags from form data ---` block, lines 427-460).
Reading a function-local before its first assignment raises
`UnboundLocalError: cannot access local variable 'project_id' where it is not
associated with a value`.

The `except Exception` at line 401 catches it, logs
`Error checking master image repository: ...` and falls through to local storage — so
the failure is invisible except for a misleading log line. Note that
`forward_image_to_master()` has **already run and succeeded** by that point, so the
image is pushed to the master server and then *also* stored locally, and the DB record
points at the local path instead of `master_path`.

Net effect: whenever `should_use_master_image_repository()` is true, uploading an image
through `POST /api/upload` never takes the master path, no matter what.

### Reproduction (before / after)

Executing the real `backend/api/upload_api.py` with stubbed Flask/DB/interconnector
modules, `should_use_master_image_repository() -> True`,
`forward_image_to_master() -> (True, "master/pic.png", None)`, and form data
`project_id=7, tags="a,b"`:

**Before (current `main`)**

```
RESULT: 500 {'error': 'Failed to save file or create record.', ...}   # local-storage path
LOG[error]: Error checking master image repository: cannot access local variable
            'project_id' where it is not associated with a value
```

**After (this PR)**

```
RESULT: 201 {'success': True, 'message': 'File uploaded to master server',
             'data': {'filename': 'pic.png', 'path': 'master/pic.png',
                      'type': 'png', 'size': 72, 'project_id': 7, 'tags': 'a,b'}}
(no error logged)
```

### Fix

Move the existing `# --- Get project_id and tags from form data ---` block from below
the image branch to just above it, still inside `if file and allowed_file(...)`. It only
depends on `request.form`, `logger`, `Project` and `db`, all of which are available at
the earlier position, and the local-storage path below is unaffected because the names
are still bound before it runs.

Pure code move — no logic change. `pyflakes` reports no undefined names in the file
afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
