### PR TITLE
fix(cli/chat): add missing `import os` so headless project-dir switch works

### DIFF
--- a/cli/llx/commands/chat.py
+++ b/cli/llx/commands/chat.py
@@ -1,5 +1,6 @@
 """Chat command — conversation with the LLM."""
 
+import os
 import sys
 import uuid
 import time


### PR DESCRIPTION
### Problem

`cli/llx/commands/chat.py` calls `os.chdir(...)` when the chat command is
invoked with a leading absolute path (the headless project-analysis entry
point, e.g. `guaardvark --non-interactive chat '/path/to/project' analyze this`):

```python
if Path(candidate).is_dir():
    try:
        os.chdir(Path(candidate).expanduser().resolve())
    except:
        pass
```

But the module never imports `os` — its imports are only `sys`, `uuid`,
`time` and `pathlib.Path`. So `os.chdir` raises
`NameError: name 'os' is not defined`.

### Impact

Because the call sits inside a bare `try/except: pass`, the `NameError` is
**silently swallowed**. The working directory is never changed, so the
headless project-analysis path keeps running against the original cwd
instead of the requested project directory — a silent behavioral failure
rather than a visible crash.

### Fix

Add `import os` to the module imports so `os.chdir` actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
