### PR TITLE
M2: LoRA trainer MPS support

### DIFF
--- a/backend/tasks/lora_trainer_tasks.py
+++ b/backend/tasks/lora_trainer_tasks.py
@@ -227,11 +227,13 @@ def _train_impl(subject_id: int, job_id: str | None = None) -> dict:
     # Reaching here means the real trainer was NOT selected. Outside of pytest that
     # is a hard failure — we do NOT silently produce a fake LoRA (NO-MOCKS policy).
     # The most common cause in 'auto' is that RealLoraTrainer.is_available() returned
-    # False: the venv-torch CUDA probe didn't see a GPU (or timed out under contention).
-    # Fail loud with guidance; the caller marks the Subject 'failed' with this message.
+    # False: the accelerator probe (CUDA or Apple MPS) didn't see a device (or timed
+    # out under contention). Fail loud with guidance; the caller marks the Subject
+    # 'failed' with this message.
     if not allow_mock:
-        msg = ("Real LoRA trainer unavailable (venv-torch/CUDA probe failed). "
-               "Verify the GPU is free (nvidia-smi) and the trainer venv exists "
+        msg = ("Real LoRA trainer unavailable (accelerator probe failed: no CUDA or "
+               "Apple MPS). Verify the GPU is free (nvidia-smi) or MPS is available "
+               "(Apple Silicon), and the trainer venv exists "
                "(plugins/lora_trainer/scripts/setup_venv.sh), then retry. To bypass "
                "the probe under contention, set GUAARDVARK_LORA_BACKEND=real. "
                "Mock training is disabled by policy.")

--- a/plugins/lora_trainer/README.md
+++ b/plugins/lora_trainer/README.md
@@ -28,7 +28,7 @@ Optional: set `ZIMAGE_TURBO_TRAIN_ADAPTER=/path/to/ostris_adapter.safetensors` t
 
 Selection priority:
   1. `GUAARDVARK_LORA_BACKEND=real|auto|mock` env var (default: `auto`)
-  2. `auto`: use **real** if `venv-torch/bin/python` exists and CUDA probe passes; otherwise **fail** with an error (no silent mock fallback)
+  2. `auto`: use **real** if a train Python sees an accelerator (CUDA **or Apple MPS**); otherwise **fail** with an error (no silent mock fallback)
   3. `mock`: allowed only when `PYTEST_CURRENT_TEST` is set (unit/integration tests)
 
 ### Setting up real training
@@ -38,9 +38,25 @@ Selection priority:
 
 This creates `venv-torch/`, installs torch+diffusers+peft (~7 GB once + ~5 GB cache for the SDXL base on first run), and verifies CUDA. Once it succeeds, the next training dispatch picks the real backend automatically.
 
+### Apple Silicon (MPS) training
+
+The default **Z-Image** backend runs in `backend/venv` and now supports Apple
+Silicon via the MPS backend (no CUDA required). The trainer scripts resolve the
+accelerator as CUDA > MPS > CPU, and `RealLoraTrainer.is_available()` accepts MPS
+as a valid accelerator. Requirements:
+
+  - `backend/venv` must have `torch` (MPS build), `diffusers>=0.38` with
+    `ZImagePipeline`, and `peft` installed:
+    `backend/venv/bin/pip install peft`
+  - `PYTORCH_ENABLE_MPS_FALLBACK=1` is set automatically by the trainer driver so
+    unsupported MPS ops degrade to CPU instead of hard-failing.
+
+The SDXL-legacy backend still requires `venv-torch/` (CUDA wheels); on Apple
+Silicon use the Z-Image default instead.
+
 ### When real training is unavailable
 
-If `auto` cannot reach the real trainer (missing venv, GPU busy, CUDA probe failed), the Celery task returns `status: failed` with guidance — it does **not** write a fake LoRA. Check `nvidia-smi`, run `setup_venv.sh`, or set `GUAARDVARK_LORA_BACKEND=real` to bypass the availability probe.
+If `auto` cannot reach the real trainer (missing venv, GPU busy, accelerator probe failed), the Celery task returns `status: failed` with guidance — it does **not** write a fake LoRA. Check `nvidia-smi` (or MPS availability on Mac), run `setup_venv.sh`, or set `GUAARDVARK_LORA_BACKEND=real` to bypass the availability probe.
 
 ### Mock backend (tests only)
 

--- a/plugins/lora_trainer/real_trainer.py
+++ b/plugins/lora_trainer/real_trainer.py
@@ -73,6 +73,10 @@ class RealLoraTrainer:
         "CUDA probe failed" that blocked subject 16's amend runs even on a free
         card. We force a real device for our GPU subprocess. An explicit non-empty
         value (a real multi-GPU pin) is respected; only ''/unset is repaired.
+
+        On Apple Silicon there is no CUDA; the trainer scripts fall back to the
+        MPS backend. Enable the MPS fallback env so unsupported ops degrade to
+        CPU instead of hard-failing mid-training.
         """
         import os
         env = dict(os.environ)
@@ -83,15 +87,20 @@ class RealLoraTrainer:
         env.setdefault(
             "PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"
         )
+        # Apple Silicon: let unsupported MPS ops fall back to CPU rather than
+        # raising, so LoRA training can proceed on unified memory.
+        env.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         return env
 
     @classmethod
     def is_available(cls) -> bool:
-        """True if any real train Python (venv-torch OR backend/venv) sees CUDA.
+        """True if any real train Python (venv-torch OR backend/venv) sees an
+        accelerator (CUDA or Apple MPS).
 
         Z-Image training uses backend/venv; SDXL uses venv-torch. Either is enough
         to pick the real backend (the per-base daemon will fail clearly if its own
-        python is missing).
+        python is missing). On Apple Silicon the backend/venv reports MPS (no CUDA),
+        which is sufficient for the Z-Image default path.
         """
         pythons = []
         if cls._VENV_PYTHON.exists():
@@ -111,9 +120,11 @@ class RealLoraTrainer:
                             str(py),
                             "-c",
                             "import torch, sys; "
-                            "ok = torch.cuda.is_available() and torch.cuda.device_count() > 0; "
+                            "cuda = torch.cuda.is_available() and torch.cuda.device_count() > 0; "
+                            "mps = hasattr(torch.backends, 'mps') and torch.backends.mps.is_available(); "
+                            "ok = cuda or mps; "
                             "print('OK' if ok else 'NO'); "
-                            "print(torch.cuda.get_device_name(0) if ok else '', file=sys.stderr)",
+                            "print((torch.cuda.get_device_name(0) if cuda else 'mps'), file=sys.stderr)",
                         ],
                         capture_output=True,
                         text=True,
@@ -123,7 +134,7 @@ class RealLoraTrainer:
                     if probe.returncode == 0 and "OK" in probe.stdout:
                         if i:
                             logger.info(
-                                "real_trainer: CUDA probe OK (%s) attempt %d/%d",
+                                "real_trainer: accelerator probe OK (%s) attempt %d/%d",
                                 py, i + 1, attempts,
                             )
                         return True
@@ -133,7 +144,7 @@ class RealLoraTrainer:
                 if i < attempts - 1:
                     time.sleep(2)
         logger.warning(
-            "real_trainer: CUDA probe failed for all train pythons after retries: %s",
+            "real_trainer: accelerator probe failed for all train pythons after retries: %s",
             last,
         )
         return False

--- a/plugins/lora_trainer/scripts/run_trainer.py
+++ b/plugins/lora_trainer/scripts/run_trainer.py
@@ -9,6 +9,16 @@ import traceback
 _pipeline = None
 _torch = None
 
+def _dev():
+    """Accelerator device: CUDA > MPS (Apple Silicon) > CPU."""
+    if _torch is None:
+        return "cpu"
+    if _torch.cuda.is_available():
+        return "cuda"
+    if hasattr(_torch.backends, "mps") and _torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
 def _eprint(msg):
     print(msg, file=sys.stderr, flush=True)
 
@@ -26,14 +36,16 @@ def _do_load(cmd):
     import torch
     _torch = torch
     
-    if not torch.cuda.is_available():
-        return {"ok": False, "error": "CUDA not available — LoRA training requires a GPU"}
+    if not torch.cuda.is_available() and not (
+        hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    ):
+        return {"ok": False, "error": "No accelerator available — LoRA training requires CUDA or Apple MPS"}
         
     try:
         from diffusers import StableDiffusionXLPipeline
         _pipeline = StableDiffusionXLPipeline.from_pretrained(
             model_id, torch_dtype=torch.bfloat16, use_safetensors=True,
-        ).to("cuda")
+        ).to(_dev())
         _eprint(f"[run_trainer] {model_id} loaded")
     except Exception as e:
         return {"ok": False, "error": f"failed to load {model_id}: {e}"}
@@ -91,7 +103,7 @@ def _do_train(cmd):
             img_tensor = transforms.Normalize([0.5], [0.5])(img_tensor)
             images.append(img_tensor)
             
-        images = _torch.stack(images).to("cuda", dtype=_torch.bfloat16)
+        images = _torch.stack(images).to(_dev(), dtype=_torch.bfloat16)
 
         instance_prompt = params.get("instance_prompt", "a photo")
         image_prompts = params.get("image_prompts") or []
@@ -106,7 +118,7 @@ def _do_train(cmd):
         for prompt in image_prompts[: len(image_paths)]:
             pe, _neg, pooled, _neg_pooled = _pipeline.encode_prompt(
                 prompt=prompt,
-                device=_torch.device("cuda"),
+                device=_torch.device(_dev()),
                 num_images_per_prompt=1,
                 do_classifier_free_guidance=False,
             )
@@ -128,7 +140,10 @@ def _do_train(cmd):
         vae.to("cpu")
         text_encoder.to("cpu")
         text_encoder_2.to("cpu")
-        _torch.cuda.empty_cache()
+        if _torch.cuda.is_available():
+            _torch.cuda.empty_cache()
+        elif _dev() == "mps":
+            _torch.mps.empty_cache()
 
         optimizer = _torch.optim.AdamW(
             filter(lambda p: p.requires_grad, unet.parameters()),
@@ -138,7 +153,10 @@ def _do_train(cmd):
         steps = params.get("steps", 400)
 
         from accelerate import Accelerator
-        accelerator = Accelerator(gradient_accumulation_steps=2, mixed_precision="bf16")
+        # bf16 mixed precision is CUDA-only; MPS falls back to no mixed precision
+        # (the UNet is already bf16). Accelerate's autocast device_type is inferred.
+        _mixed = "bf16" if _dev() == "cuda" else "no"
+        accelerator = Accelerator(gradient_accumulation_steps=2, mixed_precision=_mixed)
 
         unet, optimizer = accelerator.prepare(unet, optimizer)
 
@@ -162,7 +180,7 @@ def _do_train(cmd):
 
                 prompt_embeds = all_prompt_embeds[idx]
                 pooled_prompt_embeds = all_pooled_embeds[idx]
-                add_time_ids = _pipeline._get_add_time_ids((resolution, resolution), (0,0), (resolution, resolution), dtype=prompt_embeds.dtype, text_encoder_projection_dim=proj_dim).to("cuda")
+                add_time_ids = _pipeline._get_add_time_ids((resolution, resolution), (0,0), (resolution, resolution), dtype=prompt_embeds.dtype, text_encoder_projection_dim=proj_dim).to(_dev())
                 added_cond_kwargs = {"text_embeds": pooled_prompt_embeds, "time_ids": add_time_ids}
                 
                 model_pred = unet(noisy_latents, timesteps, prompt_embeds, added_cond_kwargs=added_cond_kwargs).sample
@@ -206,6 +224,10 @@ def _do_train(cmd):
         return {"ok": False, "error": f"OOM during training at step {cur_step}/{steps}: {e}"}
     except Exception as e:
         cur_step = step + 1 if 'step' in dir() else 'unknown'
+        # MPS raises a plain RuntimeError (not torch.cuda.OutOfMemoryError) on
+        # unified-memory exhaustion; surface it as an OOM-style failure.
+        if "out of memory" in str(e).lower():
+            return {"ok": False, "error": f"OOM during training at step {cur_step}/{steps}: {e}"}
         return {"ok": False, "error": f"training failed at step {cur_step}: {e}\n{traceback.format_exc()}"}
         
     return {"ok": True, "lora_path": output_path, "lora_version": 1}
@@ -216,7 +238,10 @@ def _do_unload(cmd):
         del _pipeline
         _pipeline = None
     if _torch is not None:
-        _torch.cuda.empty_cache()
+        if _torch.cuda.is_available():
+            _torch.cuda.empty_cache()
+        elif _dev() == "mps":
+            _torch.mps.empty_cache()
     return {"ok": True}
 
 def _do_shutdown(cmd):

--- a/plugins/lora_trainer/scripts/run_zimage_trainer.py
+++ b/plugins/lora_trainer/scripts/run_zimage_trainer.py
@@ -41,6 +41,31 @@ _torch = None
 _model_id = None
 
 
+def _dev() -> str:
+    """Accelerator device for training: CUDA > MPS (Apple Silicon) > CPU.
+
+    Apple Silicon has no CUDA; torch.backends.mps is the Metal backend. The
+    trainer stages one heavy module at a time, so the device is resolved lazily
+    per call (after _torch is set in _do_load).
+    """
+    if _torch is None:
+        return "cpu"
+    if _torch.cuda.is_available():
+        return "cuda"
+    if hasattr(_torch.backends, "mps") and _torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _is_bf16_supported() -> bool:
+    if _torch is None:
+        return False
+    if _torch.cuda.is_available():
+        return _torch.cuda.is_bf16_supported()
+    # MPS supports bfloat16 on Apple Silicon (M-series).
+    return _dev() == "mps"
+
+
 def _eprint(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
@@ -71,7 +96,7 @@ def _retag_peft_transformer_lora(state_dict: dict) -> dict:
 
 
 def _cuda_reclaim() -> None:
-    """Best-effort host + CUDA allocator reclaim between stages / after OOM."""
+    """Best-effort host + accelerator allocator reclaim between stages / after OOM."""
     gc.collect()
     if _torch is None:
         return
@@ -79,6 +104,8 @@ def _cuda_reclaim() -> None:
         if _torch.cuda.is_available():
             _torch.cuda.empty_cache()
             _torch.cuda.ipc_collect()
+        elif _dev() == "mps":
+            _torch.mps.empty_cache()
     except Exception:
         pass
 
@@ -125,12 +152,18 @@ def _move_pipeline_to_cpu() -> None:
 
 
 def _gpu_total_gb() -> float:
-    if _torch is None or not _torch.cuda.is_available():
+    if _torch is None:
         return 0.0
     try:
-        return float(_torch.cuda.get_device_properties(0).total_memory) / (1024**3)
+        if _torch.cuda.is_available():
+            return float(_torch.cuda.get_device_properties(0).total_memory) / (1024**3)
+        if _dev() == "mps":
+            # Apple Silicon unified memory: report the recommended max working set
+            # (defaults to ~2/3 of physical RAM) as the "VRAM" budget.
+            return float(_torch.mps.recommended_max_memory()) / (1024**3)
     except Exception:
-        return 0.0
+        pass
+    return 0.0
 
 
 def _resolve_model_path(model_id: str) -> str:
@@ -169,11 +202,16 @@ def _do_load(cmd: dict) -> dict:
         }
 
     _torch = torch
-    if not torch.cuda.is_available():
-        return {"ok": False, "error": "CUDA not available — Z-Image LoRA training requires a GPU"}
+    if not torch.cuda.is_available() and not (
+        hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+    ):
+        return {
+            "ok": False,
+            "error": "No accelerator available — Z-Image LoRA training requires CUDA or Apple MPS",
+        }
 
     path = _resolve_model_path(model_id)
-    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+    dtype = torch.bfloat16 if _is_bf16_supported() else torch.float16
     try:
         # Stay on CPU at load — full Z-Image (~20GB weights) cannot fit a 16GB card.
         # Train stages VAE → TE → transformer onto CUDA one at a time.
@@ -267,8 +305,9 @@ def _do_train(cmd: dict) -> dict:
 
     stage = "init"
     step = -1
+    dev = _dev()
     try:
-        # Prior failed train can leave a PeftModel + CUDA weights; unwrap first.
+        # Prior failed train can leave a PeftModel + accelerator weights; unwrap first.
         _unwrap_peft_transformer()
         _move_pipeline_to_cpu()
 
@@ -292,9 +331,7 @@ def _do_train(cmd: dict) -> dict:
         transformer = get_peft_model(transformer, lora_config)
         # PEFT initializes adapters in fp32; cast trainable to bf16 so they match
         # the base transformer and cut grad / optimizer footprint on 16GB.
-        train_dtype = (
-            _torch.bfloat16 if _torch.cuda.is_bf16_supported() else _torch.float16
-        )
+        train_dtype = _torch.bfloat16 if _is_bf16_supported() else _torch.float16
         for _n, _p in transformer.named_parameters():
             if _p.requires_grad and _p.is_floating_point():
                 _p.data = _p.data.to(train_dtype)
@@ -304,8 +341,8 @@ def _do_train(cmd: dict) -> dict:
 
         # ── stage VAE: encode latents, then free VRAM ───────────────────────
         stage = "VAE"
-        _eprint("[run_zimage_trainer] staging VAE on CUDA for latent cache...")
-        vae.to("cuda")
+        _eprint(f"[run_zimage_trainer] staging VAE on {dev} for latent cache...")
+        vae.to(dev)
         tensors = []
         for path in image_paths:
             img = Image.open(path).convert("RGB")
@@ -313,7 +350,7 @@ def _do_train(cmd: dict) -> dict:
             t = transforms.ToTensor()(img)
             t = transforms.Normalize([0.5], [0.5])(t)
             tensors.append(t)
-        images = _torch.stack(tensors).to("cuda", dtype=vae.dtype)
+        images = _torch.stack(tensors).to(dev, dtype=vae.dtype)
 
         all_latents = []
         with _torch.no_grad():
@@ -332,8 +369,8 @@ def _do_train(cmd: dict) -> dict:
 
         # ── stage TE: encode prompts, then free VRAM ────────────────────────
         stage = "TE"
-        _eprint("[run_zimage_trainer] staging text encoder on CUDA for prompt cache...")
-        text_encoder.to("cuda")
+        _eprint(f"[run_zimage_trainer] staging text encoder on {dev} for prompt cache...")
+        text_encoder.to(dev)
         all_prompt_embeds = []
         with _torch.no_grad():
             for prompt in image_prompts[: len(image_paths)]:
@@ -341,7 +378,7 @@ def _do_train(cmd: dict) -> dict:
                 # (unlike SDXL/FLUX); signature is prompt/device/CFG/neg/embeds.
                 pe, _neg = _pipeline.encode_prompt(
                     prompt=prompt,
-                    device=_torch.device("cuda"),
+                    device=_torch.device(dev),
                     do_classifier_free_guidance=False,
                 )
                 # Park embeds on CPU until transformer stage
@@ -357,31 +394,37 @@ def _do_train(cmd: dict) -> dict:
         _cuda_reclaim()
         _eprint(f"[run_zimage_trainer] cached {len(all_prompt_embeds)} prompts; TE off GPU")
 
-        # ── stage transformer: train on CUDA with cached latents/embeds ─────
+        # ── stage transformer: train on accelerator with cached latents/embeds ─
         stage = "transformer"
-        free_b, total_b = _torch.cuda.mem_get_info()
-        _eprint(
-            f"[run_zimage_trainer] staging transformer+LoRA on CUDA "
-            f"(free={free_b/1024**3:.2f}G / total={total_b/1024**3:.2f}G, "
-            f"res={resolution}, rank={rank}, dtype={train_dtype})..."
-        )
+        if dev == "cuda":
+            free_b, total_b = _torch.cuda.mem_get_info()
+            _eprint(
+                f"[run_zimage_trainer] staging transformer+LoRA on CUDA "
+                f"(free={free_b/1024**3:.2f}G / total={total_b/1024**3:.2f}G, "
+                f"res={resolution}, rank={rank}, dtype={train_dtype})..."
+            )
+        else:
+            _eprint(
+                f"[run_zimage_trainer] staging transformer+LoRA on {dev} "
+                f"(res={resolution}, rank={rank}, dtype={train_dtype})..."
+            )
         _cuda_reclaim()
-        transformer.to("cuda")
+        transformer.to(dev)
 
         # Keep latents and prompt embeds on CPU — move only the current sample
         # per step. On 16GB the transformer + LoRA grads + AdamW states already
         # consume most of the card.
         n_samples = len(all_latents)
 
-        def _embeds_to_cuda(pe):
+        def _embeds_to_dev(pe):
             if isinstance(pe, list):
-                return [t.to("cuda") if hasattr(t, "to") else t for t in pe]
+                return [t.to(dev) if hasattr(t, "to") else t for t in pe]
             if hasattr(pe, "to"):
-                return pe.to("cuda")
+                return pe.to(dev)
             return pe
 
         def _embeds_del(pe):
-            """Delete CUDA copies of prompt embeds to free VRAM."""
+            """Delete accelerator copies of prompt embeds to free memory."""
             if isinstance(pe, list):
                 for t in pe:
                     del t
@@ -400,13 +443,13 @@ def _do_train(cmd: dict) -> dict:
         stage = "train_loop"
         for step in range(steps):
             idx = step % n_samples
-            # Move only this sample's latent to CUDA (tiny: single image latent).
-            # Each element already has shape [1, C, H, W] from vae.encode(images[i:i+1]).
-            x0 = all_latents[idx].to("cuda", dtype=train_dtype)
+            # Move only this sample's latent to the accelerator (tiny: single image
+            # latent). Each element already has shape [1, C, H, W] from vae.encode.
+            x0 = all_latents[idx].to(dev, dtype=train_dtype)
             noise = _torch.randn_like(x0)
 
             # Continuous flow-matching time in [0, 1]
-            u = _torch.rand((1,), device="cuda", dtype=train_dtype).clamp(0.02, 0.98)
+            u = _torch.rand((1,), device=dev, dtype=train_dtype).clamp(0.02, 0.98)
             # xt = (1-u)*x0 + u*noise ; velocity target = noise - x0
             u_b = u.view(-1, 1, 1, 1)
             xt = (1.0 - u_b) * x0 + u_b * noise
@@ -418,12 +461,12 @@ def _do_train(cmd: dict) -> dict:
 
             latent_in = xt.unsqueeze(2)  # match pipeline unsqueeze
             latent_list = list(latent_in.unbind(dim=0))
-            # Move only this sample's prompt embed to CUDA
-            pe_cuda = _embeds_to_cuda(all_prompt_embeds[idx])
-            if not isinstance(pe_cuda, list):
-                pe_list = [pe_cuda]
+            # Move only this sample's prompt embed to the accelerator
+            pe_dev = _embeds_to_dev(all_prompt_embeds[idx])
+            if not isinstance(pe_dev, list):
+                pe_list = [pe_dev]
             else:
-                pe_list = pe_cuda
+                pe_list = pe_dev
 
             model_out = transformer(
                 latent_list,
@@ -442,10 +485,10 @@ def _do_train(cmd: dict) -> dict:
             opt.step()
             opt.zero_grad(set_to_none=True)
 
-            # Free per-step CUDA tensors explicitly
-            _embeds_del(pe_cuda)
+            # Free per-step accelerator tensors explicitly
+            _embeds_del(pe_dev)
             del x0, noise, u, u_b, xt, target, timestep, latent_in, latent_list
-            del pe_cuda, pe_list, model_out, pred
+            del pe_dev, pe_list, model_out, pred
 
             if step % 50 == 0 or step == steps - 1:
                 _eprint(f"[run_zimage_trainer] step {step+1}/{steps} loss={loss.item():.5f}")
@@ -453,7 +496,7 @@ def _do_train(cmd: dict) -> dict:
 
             # Allocator hygiene — without this, reserved-but-free holes OOM ~step 7 on 16GB.
             if (step + 1) % 25 == 0:
-                _torch.cuda.empty_cache()
+                _cuda_reclaim()
 
         # ── save diffusers-compatible LoRA ──────────────────────────────────
         stage = "save"
@@ -538,6 +581,15 @@ def _do_train(cmd: dict) -> dict:
             _move_pipeline_to_cpu()
         except Exception:
             pass
+        # MPS raises a plain RuntimeError (not torch.cuda.OutOfMemoryError) when
+        # unified memory is exhausted; surface it as an OOM-style failure.
+        if "out of memory" in str(e).lower():
+            return {
+                "ok": False,
+                "error": (
+                    f"OOM during Z-Image training (stage={stage}, step {cur}/{steps}): {e}"
+                ),
+            }
         return {
             "ok": False,
             "error": (
@@ -554,7 +606,7 @@ def _do_unload(cmd: dict) -> dict:
         _pipeline = None
         _model_id = None
     if _torch is not None:
-        _torch.cuda.empty_cache()
+        _cuda_reclaim()
     return {"ok": True}
 
 


### PR DESCRIPTION
## M2 — LoRA trainer MPS support

Runs the LoRA trainer on Apple Silicon (MPS) as well as CUDA.

### Contents
- **MPS training** — `real_trainer.py` / `run_trainer.py` detect MPS and use it when CUDA is unavailable.
- **Z-Image trainer** — `run_zimage_trainer.py` MPS path + device handling.
- **Docs** — LoRA trainer README notes MPS usage.

### Smoke test
- LoRA training on Apple Silicon (MPS).