### PR TITLE
M3: ComfyUI image generation (Z-Image)

### DIFF
--- a/backend/services/batch_image_generator.py
+++ b/backend/services/batch_image_generator.py
@@ -548,6 +548,80 @@ class BatchImageGenerator:
                 success=False, error=str(e), prompt_used=prompt.prompt
             )
 
+    # ── Z-Image via ComfyUI (optional; GUAARDVARK_ZIMAGE_USE_COMFYUI=1) ────────
+    # When enabled, plain Z-Image generation routes to the reachable ComfyUI
+    # (reusing its installed z_image_turbo_bf16.safetensors) instead of Guaardvark's
+    # offline diffusers pipeline, so no separate model download is needed.
+    @staticmethod
+    def _zimage_via_comfyui_enabled() -> bool:
+        _v = os.environ.get("GUAARDVARK_ZIMAGE_USE_COMFYUI", "").strip().lower()
+        return _v in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _is_zimage_model(model_key: str | None) -> bool:
+        _k = (model_key or "").strip().lower()
+        return _k in ("zimage", "zimage-turbo", "z-image", "z_image_turbo") \
+            or "zimage" in _k or "z-image" in _k
+
+    def _generate_with_comfyui_zimage(self, prompt: BatchPrompt) -> Optional[ImageGenerationResult]:
+        """Generate a plain Z-Image via the reachable ComfyUI instead of the offline
+        diffusers pipeline. Reuses the Z-Image model already installed in ComfyUI."""
+        try:
+            from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+        except Exception as e:
+            logger.warning("ComfyUI Z-Image path unavailable: %s", e)
+            return ImageGenerationResult(
+                success=False,
+                error=f"ComfyUI Z-Image unavailable: {e}",
+                prompt_used=prompt.prompt,
+            )
+
+        width = max(int(prompt.width or 1024), 512)
+        height = max(int(prompt.height or 1024), 512)
+        steps = int(prompt.steps or 9)
+        # ComfyUI KSampler needs cfg >= 1.0. Guaardvark's OFFLINE Z-Image path uses
+        # guidance 0 (diffusers reads that as "no CFG" for a distilled model), but
+        # passing cfg=0 into ComfyUI's KSampler yields ZERO conditioning -> output
+        # that ignores the prompt. So map 0/None up to a real cfg (default 1.0, or
+        # GUAARDVARK_ZIMAGE_CFG). Explicit guidance >= 1.0 is honored as-is.
+        _cfg_default = float(os.environ.get("GUAARDVARK_ZIMAGE_CFG", "1.0"))
+        if prompt.guidance is not None and float(prompt.guidance) >= 1.0:
+            guidance = float(prompt.guidance)
+        else:
+            guidance = _cfg_default
+
+        import tempfile
+        out_path = os.path.join(
+            tempfile.gettempdir(), f"zimage_{prompt.id}_{int(time.time() * 1000)}.png"
+        )
+        try:
+            gen = ComfyUIImageGenerator(model="zimage")
+            path = gen.generate_image(
+                prompt=prompt.prompt,
+                loras=[],
+                output_path=out_path,
+                width=width,
+                height=height,
+                negative_prompt=prompt.negative_prompt or "",
+                seed=prompt.seed if prompt.seed is not None else 42,
+                steps=steps,
+                cfg=guidance,
+                model="zimage",
+            )
+            return ImageGenerationResult(
+                success=True,
+                image_path=path,
+                prompt_used=prompt.prompt,
+                model_used="zimage",
+                image_size=(width, height),
+                seed_used=prompt.seed,
+            )
+        except Exception as e:
+            logger.error("ComfyUI Z-Image batch generation failed: %s", e)
+            return ImageGenerationResult(
+                success=False, error=str(e), prompt_used=prompt.prompt
+            )
+
     def _generate_with_character_lora(self, prompt: BatchPrompt) -> Optional[ImageGenerationResult]:
         """Generate one image with cast character LoRA(s) via character_still_pipeline.
 
@@ -631,6 +705,8 @@ class BatchImageGenerator:
                 result = self._generate_with_character_lora(prompt)
             elif self._is_comfy_flux_model(prompt.model):
                 result = self._generate_with_comfy_flux(prompt)
+            elif self._zimage_via_comfyui_enabled() and self._is_zimage_model(prompt.model):
+                result = self._generate_with_comfyui_zimage(prompt)
             else:
                 result = None
 

--- a/backend/services/character_generator_service.py
+++ b/backend/services/character_generator_service.py
@@ -152,13 +152,36 @@ def _compose_prompt(
 
 
 def _default_llm(*, system: str, user: str, model: str = "gemma4:12b") -> str:
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+    # Prefer the OpenAI-compatible provider (the same cloud/remote model the
+    # chat bot uses via GUAARDVARK_OPENAI_BASE_URL / GUAARDVARK_OPENAI_MODEL)
+    # when it is configured. Fall back to the local Ollama model otherwise.
+    try:
+        from backend.services import openai_provider
+        if openai_provider.available():
+            from backend.config import OPENAI_DEFAULT_MODEL
+            resp = openai_provider.chat(
+                model=OPENAI_DEFAULT_MODEL,
+                messages=messages,
+                stream=False,
+            )
+            content = (resp.get("message", {}) or {}).get("content", "") or ""
+            if content.strip():
+                return content
+    except Exception as e:
+        log.warning(
+            "OpenAI-compatible Character Generator LLM failed (%s); falling back to Ollama %s",
+            e, model,
+        )
+
     import ollama
     resp = ollama.chat(
         model=model,
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
+        messages=messages,
         format="json",  # hardens JSON parsing for the strict-schema agents
     )
     return resp["message"]["content"]

--- a/backend/services/character_still_pipeline.py
+++ b/backend/services/character_still_pipeline.py
@@ -31,6 +31,19 @@ CharacterSource = Literal[
 ]
 
 
+def _zimage_via_comfyui_enabled() -> bool:
+    """True when Z-Image stills should render through ComfyUI instead of the
+    offline Diffusers pipeline (GUAARDVARK_ZIMAGE_USE_COMFYUI=1).
+
+    The offline Z-Image generator is CUDA-only; on Apple Silicon (MPS) the only
+    working Z-Image path is the ComfyUI workflow, so this flag routes Cast stills
+    there. Mirrors batch_image_generator._zimage_via_comfyui_enabled.
+    """
+    import os
+    _v = os.environ.get("GUAARDVARK_ZIMAGE_USE_COMFYUI", "").strip().lower()
+    return _v in ("1", "true", "yes", "on")
+
+
 def _subjects_from_ids(subject_ids: Sequence[int] | None) -> list:
     """Load Subjects by id. Safe from daemon threads / Celery (opens app_context)."""
     if not subject_ids:
@@ -221,7 +234,10 @@ def render_character_still(
     family = (route.get("family") or "zimage").lower()
     engine = (route.get("inference_engine") or "offline").lower()
     if family == "zimage":
-        engine = "offline"
+        # Z-Image defaults to the offline Diffusers pipeline, but that path is
+        # CUDA-only. On Apple Silicon (MPS) route through ComfyUI when the
+        # operator opts in via GUAARDVARK_ZIMAGE_USE_COMFYUI=1.
+        engine = "comfy" if _zimage_via_comfyui_enabled() else "offline"
 
     strength_model = (
         route.get("offline_model_key")
@@ -261,7 +277,7 @@ def render_character_still(
     }
 
     try:
-        if engine == "offline" or family == "zimage":
+        if engine == "offline":
             from backend.services.offline_image_generator import (
                 ImageGenerationRequest,
                 get_image_generator,
@@ -318,9 +334,13 @@ def render_character_still(
                 metadata=meta,
             )
 
-        # Comfy SDXL / FLUX — never for Z-Image LoRAs (guarded above).
+        # Comfy SDXL / FLUX / Z-Image (Z-Image only when opted in via
+        # GUAARDVARK_ZIMAGE_USE_COMFYUI=1 — the offline path is CUDA-only).
         from backend.services.comfyui_image_generator import ComfyUIImageGenerator
-        model_tag = route.get("comfy_model_tag") or ("flux-dev" if family == "flux" else "sdxl")
+        if family == "zimage":
+            model_tag = "zimage"
+        else:
+            model_tag = route.get("comfy_model_tag") or ("flux-dev" if family == "flux" else "sdxl")
         gen = ComfyUIImageGenerator(lora_strength=strength)
         path = gen.generate_image(
             prompt=final_prompt,
@@ -329,7 +349,7 @@ def render_character_still(
             width=w,
             height=h,
             seed=seed if seed is not None else 42,
-            steps=st if st > 0 else (20 if family == "flux" else 30),
+            steps=st if st > 0 else (8 if family == "zimage" else (20 if family == "flux" else 30)),
             model=model_tag,
             negative_prompt=negative_prompt or None,
         )

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -101,6 +101,59 @@ DEFAULT_NEGATIVE = (
 )
 
 
+def _comfyui_loras_dir() -> Optional[Path]:
+    """Locate the running ComfyUI's ``models/loras`` directory (best-effort).
+
+    The configured ``COMFYUI_DIR`` may point at a bundled/plugins copy that does
+    not exist, while the actually-running ComfyUI lives elsewhere (e.g.
+    ``~/ComfyUI-Installs/ComfyUI/ComfyUI``). Probe the configured path plus the
+    common install locations and return the first that exists.
+    """
+    candidates: list[Path] = []
+    try:
+        from backend.config import COMFYUI_DIR
+        candidates.append(Path(COMFYUI_DIR) / "models" / "loras")
+    except Exception:
+        pass
+    candidates.append(
+        Path(__file__).resolve().parents[3] / "plugins" / "comfyui" / "ComfyUI" / "models" / "loras"
+    )
+    candidates.append(Path.home() / "ComfyUI-Installs" / "ComfyUI" / "ComfyUI" / "models" / "loras")
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return None
+
+
+def ensure_lora_in_comfyui(lora_path: str) -> bool:
+    """Symlink a trained LoRA into ComfyUI's ``models/loras`` so a
+    ``LoraLoaderModelOnly`` node can resolve it by basename.
+
+    Only acts when Z-Image is routed through ComfyUI
+    (``GUAARDVARK_ZIMAGE_USE_COMFYUI=1``). Returns True if the LoRA is present in
+    ComfyUI's loras dir (linked now, or already there). Best-effort: never raises.
+    """
+    if os.environ.get("GUAARDVARK_ZIMAGE_USE_COMFYUI", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return False
+    p = Path(lora_path)
+    if not p.exists():
+        return False
+    loras_dir = _comfyui_loras_dir()
+    if loras_dir is None:
+        logger.warning("ensure_lora_in_comfyui: could not locate ComfyUI loras dir for %s", p.name)
+        return False
+    target = loras_dir / p.name
+    if target.exists():
+        return True
+    try:
+        target.symlink_to(p.resolve())
+        logger.info("Linked LoRA %s into ComfyUI loras dir %s", p.name, loras_dir)
+        return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not link LoRA %s into ComfyUI: %s", p.name, e)
+        return False
+
+
 class ComfyUIImageGenerator:
     """Implements the storyboard ImageGenerator protocol with real LoRA support.
 
@@ -620,6 +673,12 @@ class ComfyUIImageGenerator:
         for p in lora_paths:
             if not p:
                 continue
+            # When Z-Image is routed through ComfyUI, make sure the trained LoRA is
+            # linked into ComfyUI's models/loras so LoraLoaderModelOnly can find it.
+            try:
+                ensure_lora_in_comfyui(p)
+            except Exception:
+                pass
             pth = Path(p)
             found = pth.exists()
             if not found:

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -53,10 +53,14 @@ FLUX_VAE = os.environ.get("GUAARDVARK_FLUX_VAE", "ae.safetensors")
 # object_info). Overridable so a different Z-Image build / Qwen CLIP / VAE works.
 ZIMAGE_UNET = os.environ.get("GUAARDVARK_ZIMAGE_UNET", "z_image_turbo_bf16.safetensors")
 ZIMAGE_CLIP = os.environ.get("GUAARDVARK_ZIMAGE_CLIP", "qwen_3_4b.safetensors")
-ZIMAGE_CLIP_TYPE = os.environ.get("GUAARDVARK_ZIMAGE_CLIP_TYPE", "qwen_image")
+ZIMAGE_CLIP_TYPE = os.environ.get("GUAARDVARK_ZIMAGE_CLIP_TYPE", "lumina2")
 ZIMAGE_VAE = os.environ.get("GUAARDVARK_ZIMAGE_VAE", "ae.safetensors")
-ZIMAGE_SAMPLER = os.environ.get("GUAARDVARK_ZIMAGE_SAMPLER", "euler")
+ZIMAGE_SAMPLER = os.environ.get("GUAARDVARK_ZIMAGE_SAMPLER", "res_multistep")
 ZIMAGE_SCHEDULER = os.environ.get("GUAARDVARK_ZIMAGE_SCHEDULER", "simple")
+# Flow-matching shift for Z-Image Turbo (ModelSamplingAuraFlow). The distilled
+# model is CFG-free: positive conditioning drives the sampler, the negative is
+# zeroed via ConditioningZeroOut, and cfg stays 1.0.
+ZIMAGE_SHIFT = float(os.environ.get("GUAARDVARK_ZIMAGE_SHIFT", "3"))
 
 # FLUX-dev (full transformer) keyframe path — the identity-lock route for trained
 # character LoRAs. Unlike the schnell GGUF branch, this one ACTUALLY chains LoRAs
@@ -251,7 +255,10 @@ class ComfyUIImageGenerator:
             return wf
 
         if "zimage" in ml or "z-image" in ml:
-            # Z-Image Turbo via ComfyUI — UNETLoader + Qwen CLIP (qwen_image) + ae VAE.
+            # Z-Image Turbo via ComfyUI — UNETLoader + Lumina2 CLIP + ae VAE.
+            # Flow-matching: ModelSamplingAuraFlow (shift) wraps the UNet, the
+            # distilled model is CFG-free (cfg=1.0) with the negative zeroed via
+            # ConditioningZeroOut, and latents use EmptySD3LatentImage.
             wf = {
                 "unet": {
                     "class_type": "UNETLoader",
@@ -273,21 +280,29 @@ class ComfyUIImageGenerator:
                     "class_type": "CLIPTextEncode",
                     "inputs": {"text": negative, "clip": ["clip", 0]},
                 },
+                "neg_zero": {
+                    "class_type": "ConditioningZeroOut",
+                    "inputs": {"conditioning": ["neg", 0]},
+                },
                 "latent": {
-                    "class_type": "EmptyLatentImage",
+                    "class_type": "EmptySD3LatentImage",
                     "inputs": {"width": width, "height": height, "batch_size": 1},
+                },
+                "sampling": {
+                    "class_type": "ModelSamplingAuraFlow",
+                    "inputs": {"shift": ZIMAGE_SHIFT, "model": ["unet", 0]},
                 },
                 "sampler": {
                     "class_type": "KSampler",
                     "inputs": {
-                        "model": ["unet", 0],
+                        "model": ["sampling", 0],
                         "seed": seed,
                         "steps": steps,
-                        "cfg": cfg,
+                        "cfg": 1.0,
                         "sampler_name": ZIMAGE_SAMPLER,
                         "scheduler": ZIMAGE_SCHEDULER,
                         "positive": ["pos", 0],
-                        "negative": ["neg", 0],
+                        "negative": ["neg_zero", 0],
                         "latent_image": ["latent", 0],
                         "denoise": 1.0,
                     },

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -47,6 +47,17 @@ FLUX_T5 = os.environ.get("GUAARDVARK_FLUX_T5", "t5/t5xxl_fp8_e4m3fn.safetensors"
 FLUX_CLIP = os.environ.get("GUAARDVARK_FLUX_CLIP", "clip_l.safetensors")
 FLUX_VAE = os.environ.get("GUAARDVARK_FLUX_VAE", "ae.safetensors")
 
+# ── Z-Image Turbo via ComfyUI ────────────────────────────────────────────────
+# Gated by GUAARDVARK_ZIMAGE_USE_COMFYUI=1 in batch_image_generator. These names
+# must exist inside the reachable ComfyUI (they are checked by the running server's
+# object_info). Overridable so a different Z-Image build / Qwen CLIP / VAE works.
+ZIMAGE_UNET = os.environ.get("GUAARDVARK_ZIMAGE_UNET", "z_image_turbo_bf16.safetensors")
+ZIMAGE_CLIP = os.environ.get("GUAARDVARK_ZIMAGE_CLIP", "qwen_3_4b.safetensors")
+ZIMAGE_CLIP_TYPE = os.environ.get("GUAARDVARK_ZIMAGE_CLIP_TYPE", "qwen_image")
+ZIMAGE_VAE = os.environ.get("GUAARDVARK_ZIMAGE_VAE", "ae.safetensors")
+ZIMAGE_SAMPLER = os.environ.get("GUAARDVARK_ZIMAGE_SAMPLER", "euler")
+ZIMAGE_SCHEDULER = os.environ.get("GUAARDVARK_ZIMAGE_SCHEDULER", "simple")
+
 # FLUX-dev (full transformer) keyframe path — the identity-lock route for trained
 # character LoRAs. Unlike the schnell GGUF branch, this one ACTUALLY chains LoRAs
 # (LoraLoaderModelOnly), uses FluxGuidance, and renders at dev step counts. An fp8
@@ -237,6 +248,59 @@ class ComfyUIImageGenerator:
             }
             wf["vae"] = {"class_type": "VAEDecode", "inputs": {"samples": ["sampler", 0], "vae": ["vae_loader", 0]}}
             wf["save"] = {"class_type": "SaveImage", "inputs": {"filename_prefix": "storyboard-flux-dev", "images": ["vae", 0]}}
+            return wf
+
+        if "zimage" in ml or "z-image" in ml:
+            # Z-Image Turbo via ComfyUI — UNETLoader + Qwen CLIP (qwen_image) + ae VAE.
+            wf = {
+                "unet": {
+                    "class_type": "UNETLoader",
+                    "inputs": {"unet_name": ZIMAGE_UNET, "weight_dtype": "default"},
+                },
+                "clip": {
+                    "class_type": "CLIPLoader",
+                    "inputs": {"clip_name": ZIMAGE_CLIP, "type": ZIMAGE_CLIP_TYPE},
+                },
+                "vae_loader": {
+                    "class_type": "VAELoader",
+                    "inputs": {"vae_name": ZIMAGE_VAE},
+                },
+                "pos": {
+                    "class_type": "CLIPTextEncode",
+                    "inputs": {"text": prompt, "clip": ["clip", 0]},
+                },
+                "neg": {
+                    "class_type": "CLIPTextEncode",
+                    "inputs": {"text": negative, "clip": ["clip", 0]},
+                },
+                "latent": {
+                    "class_type": "EmptyLatentImage",
+                    "inputs": {"width": width, "height": height, "batch_size": 1},
+                },
+                "sampler": {
+                    "class_type": "KSampler",
+                    "inputs": {
+                        "model": ["unet", 0],
+                        "seed": seed,
+                        "steps": steps,
+                        "cfg": cfg,
+                        "sampler_name": ZIMAGE_SAMPLER,
+                        "scheduler": ZIMAGE_SCHEDULER,
+                        "positive": ["pos", 0],
+                        "negative": ["neg", 0],
+                        "latent_image": ["latent", 0],
+                        "denoise": 1.0,
+                    },
+                },
+                "vae": {
+                    "class_type": "VAEDecode",
+                    "inputs": {"samples": ["sampler", 0], "vae": ["vae_loader", 0]},
+                },
+                "save": {
+                    "class_type": "SaveImage",
+                    "inputs": {"filename_prefix": "guaardvark-zimage", "images": ["vae", 0]},
+                },
+            }
             return wf
 
         if effective_model and "flux" in effective_model.lower():

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -167,13 +167,13 @@ class ComfyUIImageGenerator:
                     )
                     effective_model = tag
                     ml = tag
-                elif info.get("family") == "zimage":
-                    # Z-Image LoRAs are not applied via this Comfy SDXL/FLUX graph yet.
+                elif info.get("family") == "zimage" and "zimage" not in ml and "z-image" not in ml:
                     logger.warning(
-                        "Z-Image LoRAs cannot use Comfy SDXL/FLUX graph (base=%s); "
-                        "caller should use offline Z-Image path.",
-                        info.get("base_model_id"),
+                        "LoRAs are Z-Image (base=%s) but model=%r — overriding to zimage so identity applies.",
+                        info.get("base_model_id"), effective_model,
                     )
+                    effective_model = "zimage"
+                    ml = "zimage"
             except Exception as e:
                 # Pre-registry LoRAs / basename-only: fall back to historic SDXL force
                 # when flux-schnell would drop LoRAs entirely.
@@ -259,6 +259,11 @@ class ComfyUIImageGenerator:
             # Flow-matching: ModelSamplingAuraFlow (shift) wraps the UNet, the
             # distilled model is CFG-free (cfg=1.0) with the negative zeroed via
             # ConditioningZeroOut, and latents use EmptySD3LatentImage.
+            # Z-Image character LoRAs train only the transformer (not the text
+            # encoder), so they are applied model-only via LoraLoaderModelOnly —
+            # the same node the FLUX-dev branch uses. The chain feeds the UNet
+            # into the AuraFlow sampler; the CLIP is untouched and the trigger
+            # word in the prompt does the identity work.
             wf = {
                 "unet": {
                     "class_type": "UNETLoader",
@@ -288,33 +293,43 @@ class ComfyUIImageGenerator:
                     "class_type": "EmptySD3LatentImage",
                     "inputs": {"width": width, "height": height, "batch_size": 1},
                 },
-                "sampling": {
-                    "class_type": "ModelSamplingAuraFlow",
-                    "inputs": {"shift": ZIMAGE_SHIFT, "model": ["unet", 0]},
+            }
+            # Chain LoraLoaderModelOnly nodes (model-only): each wraps the previous
+            # node's MODEL so multiple LoRAs stack; the CLIP is not touched.
+            model_src = ["unet", 0]
+            for i, name in enumerate(lora_names):
+                nid = f"lora_{i}"
+                wf[nid] = {
+                    "class_type": "LoraLoaderModelOnly",
+                    "inputs": {"model": model_src, "lora_name": name, "strength_model": self.lora_strength},
+                }
+                model_src = [nid, 0]
+            wf["sampling"] = {
+                "class_type": "ModelSamplingAuraFlow",
+                "inputs": {"shift": ZIMAGE_SHIFT, "model": model_src},
+            }
+            wf["sampler"] = {
+                "class_type": "KSampler",
+                "inputs": {
+                    "model": ["sampling", 0],
+                    "seed": seed,
+                    "steps": steps,
+                    "cfg": 1.0,
+                    "sampler_name": ZIMAGE_SAMPLER,
+                    "scheduler": ZIMAGE_SCHEDULER,
+                    "positive": ["pos", 0],
+                    "negative": ["neg_zero", 0],
+                    "latent_image": ["latent", 0],
+                    "denoise": 1.0,
                 },
-                "sampler": {
-                    "class_type": "KSampler",
-                    "inputs": {
-                        "model": ["sampling", 0],
-                        "seed": seed,
-                        "steps": steps,
-                        "cfg": 1.0,
-                        "sampler_name": ZIMAGE_SAMPLER,
-                        "scheduler": ZIMAGE_SCHEDULER,
-                        "positive": ["pos", 0],
-                        "negative": ["neg_zero", 0],
-                        "latent_image": ["latent", 0],
-                        "denoise": 1.0,
-                    },
-                },
-                "vae": {
-                    "class_type": "VAEDecode",
-                    "inputs": {"samples": ["sampler", 0], "vae": ["vae_loader", 0]},
-                },
-                "save": {
-                    "class_type": "SaveImage",
-                    "inputs": {"filename_prefix": "guaardvark-zimage", "images": ["vae", 0]},
-                },
+            }
+            wf["vae"] = {
+                "class_type": "VAEDecode",
+                "inputs": {"samples": ["sampler", 0], "vae": ["vae_loader", 0]},
+            }
+            wf["save"] = {
+                "class_type": "SaveImage",
+                "inputs": {"filename_prefix": "guaardvark-zimage", "images": ["vae", 0]},
             }
             return wf
 
@@ -645,11 +660,8 @@ class ComfyUIImageGenerator:
                 info = resolve_inference_for_loras(lora_paths)
                 if info.get("comfy_model_tag"):
                     effective_model = info["comfy_model_tag"]
-                if info.get("family") == "zimage":
-                    raise RuntimeError(
-                        "Z-Image character LoRAs must run on the offline Z-Image path, "
-                        "not ComfyUI SDXL/FLUX. (base_model_id=zimage-turbo)"
-                    )
+                # Z-Image family is applied via the model-only LoRA chain in the
+                # Z-Image workflow branch; no refusal needed.
             except RuntimeError:
                 raise
             except Exception:

--- a/backend/services/comfyui_image_generator.py
+++ b/backend/services/comfyui_image_generator.py
@@ -114,6 +114,50 @@ class ComfyUIImageGenerator:
         except requests.exceptions.RequestException:
             return False
 
+    def comfyui_installed_engines(self) -> list[str]:
+        """Which image engines can the reachable ComfyUI actually run?
+
+        Queries the running server's ``/object_info`` — the authoritative source
+        for where the live models are (an external Comfy Desktop install, not the
+        bundled plugin dir). Returns engine tags like ``['zimage', 'flux-dev']``.
+        """
+        try:
+            resp = requests.get(f"{self.comfy_url}/object_info", timeout=5)
+            resp.raise_for_status()
+            info = resp.json()
+        except Exception as e:
+            logger.warning("ComfyUI object_info probe failed: %s", e)
+            return []
+
+        def _choices(node: str, key: str) -> list[str]:
+            try:
+                lst = info.get(node, {}).get("input", {}).get("required", {}).get(key, [])
+                if isinstance(lst, list) and lst and isinstance(lst[0], list):
+                    return [str(x) for x in lst[0]]
+                if isinstance(lst, list) and lst and isinstance(lst[0], str):
+                    return [str(x) for x in lst]
+            except Exception:
+                pass
+            return []
+
+        unet = set(_choices("UNETLoader", "unet_name"))
+        unet_gguf = set(_choices("UnetLoaderGGUF", "unet_name"))
+        all_unet = unet | unet_gguf
+        clip = set(_choices("CLIPLoader", "clip_name"))
+        dual = set(_choices("DualCLIPLoader", "clip_name1"))
+        vae = set(_choices("VAELoader", "vae_name"))
+
+        engines: list[str] = []
+        if ZIMAGE_UNET in all_unet and ZIMAGE_CLIP in clip and ZIMAGE_VAE in vae:
+            engines.append("zimage")
+        if (FLUX_DEV_UNET in all_unet and FLUX_DEV_T5 in dual
+                and FLUX_CLIP in dual and FLUX_VAE in vae):
+            engines.append("flux-dev")
+        if (FLUX_UNET in all_unet and FLUX_T5 in dual
+                and FLUX_CLIP in dual and FLUX_VAE in vae):
+            engines.append("flux-schnell")
+        return engines
+
     # ── workflow ──────────────────────────────────────────────────────
     def _build_workflow(
         self, *, prompt: str, negative: str, lora_names: list[str],

--- a/backend/services/offline_image_generator.py
+++ b/backend/services/offline_image_generator.py
@@ -449,57 +449,20 @@ class OfflineImageGenerator:
         return all(p.is_file() and p.stat().st_size > 0 for p in (unet, vae, clip)) and t5_ok
 
     @staticmethod
-    def _zimage_assets_present() -> bool:
-        """True when the Z-Image Turbo ComfyUI graph can run."""
-        try:
-            from backend.config import COMFYUI_DIR
-            root = Path(COMFYUI_DIR) / "models"
-        except Exception:
-            root = Path("plugins/comfyui/ComfyUI/models")
-        try:
-            from backend.services.comfyui_image_generator import (
-                ZIMAGE_UNET, ZIMAGE_CLIP, ZIMAGE_VAE,
-            )
-        except Exception:
-            return False
-        unet = root / "unet" / ZIMAGE_UNET
-        clip = root / "clip" / ZIMAGE_CLIP
-        vae = root / "vae" / ZIMAGE_VAE
-        return all(p.is_file() and p.stat().st_size > 0 for p in (unet, clip, vae))
-
-    @staticmethod
-    def _flux_schnell_assets_present() -> bool:
-        """True when the FLUX-schnell ComfyUI graph can run."""
-        try:
-            from backend.config import COMFYUI_DIR
-            root = Path(COMFYUI_DIR) / "models"
-        except Exception:
-            root = Path("plugins/comfyui/ComfyUI/models")
-        try:
-            from backend.services.comfyui_image_generator import (
-                FLUX_UNET, FLUX_T5, FLUX_CLIP, FLUX_VAE,
-            )
-        except Exception:
-            return False
-        unet = root / "unet" / FLUX_UNET
-        vae = root / "vae" / FLUX_VAE
-        clip = root / "clip" / FLUX_CLIP
-        t5_candidates = [
-            root / "clip" / FLUX_T5,
-            root / "clip" / "t5" / FLUX_T5,
-            root / "text_encoders" / FLUX_T5,
-        ]
-        t5_ok = any(p.is_file() and p.stat().st_size > 0 for p in t5_candidates)
-        return all(p.is_file() and p.stat().st_size > 0 for p in (unet, vae, clip)) and t5_ok
-
-    @staticmethod
     def _comfyui_assets_present() -> bool:
-        """True when ComfyUI has at least one usable image engine installed."""
-        return (
-            OfflineImageGenerator._zimage_assets_present()
-            or OfflineImageGenerator._flux_dev_assets_present()
-            or OfflineImageGenerator._flux_schnell_assets_present()
-        )
+        """True when ComfyUI has at least one usable image engine installed.
+
+        Queries the live server's /object_info (authoritative about model locations
+        — works for an external Comfy Desktop install, not just the bundled dir).
+        """
+        try:
+            from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+            gen = ComfyUIImageGenerator()
+            if not gen._available():
+                return False
+            return bool(gen.comfyui_installed_engines())
+        except Exception:
+            return False
 
     def is_comfy_only_model(self, model_key: str) -> bool:
         key = (model_key or "").strip().lower()

--- a/backend/services/offline_image_generator.py
+++ b/backend/services/offline_image_generator.py
@@ -195,6 +195,9 @@ class OfflineImageGenerator:
             # FLUX.1-dev — max-quality stills via ComfyUI (not offline Diffusers).
             # Value is a sentinel; batch routes to Comfy when model=flux-dev.
             "flux-dev": "comfy:flux-dev",
+            # ComfyUI generic backend — chat/batch route to the reachable ComfyUI
+            # and pick whichever image engine is installed (Z-Image / FLUX).
+            "comfyui": "comfy:comfyui",
             "krea2-turbo": "krea/Krea-2-Turbo",
             "krea2-raw": "krea/Krea-2-Raw",
             "sd-xl": "stabilityai/stable-diffusion-xl-base-1.0",
@@ -207,12 +210,13 @@ class OfflineImageGenerator:
         # get_available_models() and model_recommender still honour it.
         self.hidden_models: set[str] = set()
         # Offline Diffusers cannot load these — batch/API must route to ComfyUI.
-        self.comfy_only_models = {"flux-dev"}
+        self.comfy_only_models = {"flux-dev", "comfyui"}
         # UI metadata for the visible models (label/description/recommended/order).
         # Drives the centralized dropdown via get_available_models().
         self.model_meta = {
             "zimage-turbo": {"label": "Z-Image Turbo (Best daily)", "description": "Strong prompt adherence + text, fast (~9 steps / CFG 0). Default daily driver.", "recommended": True, "order": 0},
             "flux-dev": {"label": "FLUX.1 Dev (Max quality)", "description": "Highest ceiling stills via ComfyUI (~28 steps, FluxGuidance). Slower; needs Comfy + flux1-dev weights.", "recommended": False, "order": 1, "engine": "comfy"},
+            "comfyui": {"label": "ComfyUI (auto backend)", "description": "Routes image generation to the running ComfyUI plugin and picks the installed engine (Z-Image or FLUX).", "recommended": False, "order": 1, "engine": "comfy"},
             "krea2-turbo": {"label": "Krea 2 Turbo", "description": "12B aesthetic-first model, native 2K, 8 steps CFG-free. Fast inference.", "recommended": False, "order": 2},
             "krea2-raw": {"label": "Krea 2 Raw", "description": "Base 12B checkpoint — less post-trained than Turbo (~52 steps, CFG 3.5). Use for mature/creative prompts or LoRA base.", "recommended": False, "order": 3},
             "sd-xl": {"label": "SDXL Base", "description": "High-res 1024, reliable, huge LoRA ecosystem.", "recommended": False, "order": 4},
@@ -342,8 +346,11 @@ class OfflineImageGenerator:
         return self.models_dir / model_name
 
     def _is_model_downloaded(self, model_id: str) -> bool:
-        # Comfy-only models (FLUX.1-dev): check ComfyUI unet asset, not HF snapshot.
+        # Comfy-only models (FLUX.1-dev or generic ComfyUI backend): check ComfyUI
+        # assets, not HF snapshot.
         mid = (model_id or "").lower()
+        if mid == "comfy:comfyui":
+            return self._comfyui_assets_present()
         if mid.startswith("comfy:") or mid == "flux-dev" or "flux1-dev" in mid or mid.endswith("flux-dev"):
             return self._flux_dev_assets_present()
         model_path = self._get_model_path(model_id)
@@ -440,6 +447,59 @@ class OfflineImageGenerator:
         ]
         t5_ok = any(p.is_file() and p.stat().st_size > 0 for p in t5_candidates)
         return all(p.is_file() and p.stat().st_size > 0 for p in (unet, vae, clip)) and t5_ok
+
+    @staticmethod
+    def _zimage_assets_present() -> bool:
+        """True when the Z-Image Turbo ComfyUI graph can run."""
+        try:
+            from backend.config import COMFYUI_DIR
+            root = Path(COMFYUI_DIR) / "models"
+        except Exception:
+            root = Path("plugins/comfyui/ComfyUI/models")
+        try:
+            from backend.services.comfyui_image_generator import (
+                ZIMAGE_UNET, ZIMAGE_CLIP, ZIMAGE_VAE,
+            )
+        except Exception:
+            return False
+        unet = root / "unet" / ZIMAGE_UNET
+        clip = root / "clip" / ZIMAGE_CLIP
+        vae = root / "vae" / ZIMAGE_VAE
+        return all(p.is_file() and p.stat().st_size > 0 for p in (unet, clip, vae))
+
+    @staticmethod
+    def _flux_schnell_assets_present() -> bool:
+        """True when the FLUX-schnell ComfyUI graph can run."""
+        try:
+            from backend.config import COMFYUI_DIR
+            root = Path(COMFYUI_DIR) / "models"
+        except Exception:
+            root = Path("plugins/comfyui/ComfyUI/models")
+        try:
+            from backend.services.comfyui_image_generator import (
+                FLUX_UNET, FLUX_T5, FLUX_CLIP, FLUX_VAE,
+            )
+        except Exception:
+            return False
+        unet = root / "unet" / FLUX_UNET
+        vae = root / "vae" / FLUX_VAE
+        clip = root / "clip" / FLUX_CLIP
+        t5_candidates = [
+            root / "clip" / FLUX_T5,
+            root / "clip" / "t5" / FLUX_T5,
+            root / "text_encoders" / FLUX_T5,
+        ]
+        t5_ok = any(p.is_file() and p.stat().st_size > 0 for p in t5_candidates)
+        return all(p.is_file() and p.stat().st_size > 0 for p in (unet, vae, clip)) and t5_ok
+
+    @staticmethod
+    def _comfyui_assets_present() -> bool:
+        """True when ComfyUI has at least one usable image engine installed."""
+        return (
+            OfflineImageGenerator._zimage_assets_present()
+            or OfflineImageGenerator._flux_dev_assets_present()
+            or OfflineImageGenerator._flux_schnell_assets_present()
+        )
 
     def is_comfy_only_model(self, model_key: str) -> bool:
         key = (model_key or "").strip().lower()
@@ -3060,8 +3120,12 @@ Negative Prompt: {negative_prompt}""",
             if downloaded:
                 availability = "ready"
             elif self.is_comfy_only_model(model_key):
-                # Sentinel id — nothing to fetch from HF; assets are installed for Comfy.
-                availability = "unreachable"
+                # Sentinel ids — nothing to fetch from HF; assets are installed for Comfy.
+                # The generic "comfyui" backend is selectable when ComfyUI has a usable engine.
+                if model_key == "comfyui":
+                    availability = "ready" if downloaded else "unreachable"
+                else:
+                    availability = "unreachable"
             elif not probe_remote:
                 availability = "downloadable"
             else:
@@ -3082,6 +3146,7 @@ Negative Prompt: {negative_prompt}""",
                     "28-36GB" if "krea" in model_id.lower()
                     else "23GB+Comfy" if "flux" in model_key or "flux" in model_id.lower()
                     else "16GB" if "z-image" in model_id.lower() or "zimage" in model_key
+                    else "Comfy backend" if model_key == "comfyui"
                     else "12-15GB" if "xl" in model_id.lower()
                     else "4-7GB"
                 ),

--- a/backend/services/stills_defaults.py
+++ b/backend/services/stills_defaults.py
@@ -18,6 +18,7 @@ from typing import Any
 # guidance_scale=0.0 (CFG distilled out).
 _FAMILY_DEFAULTS: dict[str, dict[str, Any]] = {
     "zimage": {"width": 1024, "height": 1024, "steps": 9, "guidance": 0.0},
+    "comfyui": {"width": 1024, "height": 1024, "steps": 9, "guidance": 0.0},
     "krea2-turbo": {"width": 1024, "height": 1024, "steps": 8, "guidance": 0.0},
     "krea2-raw": {"width": 1024, "height": 1024, "steps": 52, "guidance": 3.5},
     "sdxl": {"width": 1024, "height": 1024, "steps": 25, "guidance": 7.0},
@@ -35,6 +36,8 @@ _LEGACY_GUIDANCE = 7.5
 def model_family(model: str | None) -> str:
     """Map catalog key / HF id / auto to a sampling family key."""
     mid = (model or "").strip().lower()
+    if mid == "comfyui":
+        return "comfyui"
     if not mid or mid == "auto":
         # Product daily driver family for unresolved auto.
         try:

--- a/backend/services/stills_pipeline.py
+++ b/backend/services/stills_pipeline.py
@@ -235,10 +235,36 @@ def _generate_one(
     )
 
     # FLUX via Comfy is still a separate engine; offline path is the default.
+    # "comfyui" / "comfy" is a generic ComfyUI backend selector: auto-pick an
+    # installed engine (Z-Image when GUAARDVARK_ZIMAGE_USE_COMFYUI=1, else FLUX).
     mid = (model or "").lower()
     if "flux" in mid:
         return _generate_comfy_flux(
             prompt=prompt, negative=negative, model=model,
+            width=width, height=height, steps=steps, guidance=guidance,
+            seed=seed, enhance_mode=enhance_mode, output=output, output_dir=output_dir,
+        )
+    if mid in ("comfyui", "comfy"):
+        choice = _comfyui_backend_choice()
+        if choice is None:
+            return StillResult(
+                success=False,
+                error=(
+                    "ComfyUI is not reachable or has no installed image engine. "
+                    "Start the ComfyUI plugin and install Z-Image or FLUX assets first."
+                ),
+                prompt_used=prompt,
+                enhance_mode=enhance_mode,
+            )
+        engine, comfy_model = choice
+        if engine == "zimage":
+            return _generate_comfy_zimage(
+                prompt=prompt, negative=negative, model=f"comfyui ({engine})",
+                width=width, height=height, steps=steps, guidance=guidance,
+                seed=seed, enhance_mode=enhance_mode, output=output, output_dir=output_dir,
+            )
+        return _generate_comfy_flux(
+            prompt=prompt, negative=negative, model=f"comfyui ({engine})",
             width=width, height=height, steps=steps, guidance=guidance,
             seed=seed, enhance_mode=enhance_mode, output=output, output_dir=output_dir,
         )
@@ -420,9 +446,113 @@ def _generate_comfy_flux(
             height=height,
             negative_prompt=negative or None,
             seed=seed if seed is not None else 42,
-            model="flux",
+            model=model,
             steps=steps,
             cfg=guidance,
+        )
+        url = None
+        if output == "chat_copy" and path:
+            try:
+                from backend.config import OUTPUT_DIR
+                out = Path(OUTPUT_DIR) / "generated_images"
+                out.mkdir(parents=True, exist_ok=True)
+                name = f"gen_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}.png"
+                dest = out / name
+                shutil.copy2(path, dest)
+                path = str(dest)
+                url = f"/api/outputs/generated_images/{name}"
+            except Exception:
+                pass
+        return StillResult(
+            success=True,
+            image_path=path,
+            image_url=url,
+            seed_used=seed,
+            model_used=model,
+            prompt_used=prompt,
+            negative_used=negative,
+            width=width,
+            height=height,
+            steps=steps,
+            guidance=guidance,
+            enhance_mode=enhance_mode,
+        )
+    except Exception as e:
+        return StillResult(
+            success=False,
+            error=str(e),
+            prompt_used=prompt,
+            enhance_mode=enhance_mode,
+            width=width,
+            height=height,
+            steps=steps,
+            guidance=guidance,
+        )
+
+
+def _comfyui_backend_choice() -> tuple[str, str] | None:
+    """Pick a usable ComfyUI image engine for /imagemodel comfyui.
+
+    Returns (engine_label, comfy_model_tag) or None if ComfyUI is unreachable
+    or has no supported image engine installed.
+    """
+    try:
+        from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+        from backend.services.offline_image_generator import OfflineImageGenerator
+
+        gen = ComfyUIImageGenerator()
+        if not gen._available():
+            return None
+
+        # Prefer Z-Image Turbo if its assets are installed, then FLUX-dev, then
+        # FLUX-schnell. This makes /imagemodel comfyui an honest auto-backend.
+        if OfflineImageGenerator._zimage_assets_present():
+            return ("zimage", "zimage")
+        if OfflineImageGenerator._flux_dev_assets_present():
+            return ("flux-dev", "flux-dev")
+        if OfflineImageGenerator._flux_schnell_assets_present():
+            return ("flux-schnell", "flux")
+        return None
+    except Exception:
+        return None
+
+
+def _generate_comfy_zimage(
+    *,
+    prompt: str,
+    negative: str,
+    model: str,
+    width: int,
+    height: int,
+    steps: int,
+    guidance: float,
+    seed: int | None,
+    enhance_mode: str,
+    output: str,
+    output_dir: Path | str | None,
+) -> StillResult:
+    try:
+        from backend.services.comfyui_image_generator import ComfyUIImageGenerator
+
+        gen = ComfyUIImageGenerator(model="zimage")
+        out_path = None
+        if output_dir:
+            out_path = str(Path(output_dir) / f"zimage_{uuid.uuid4().hex[:8]}.png")
+
+        # ComfyUI KSampler needs cfg >= 1.0; offline Z-Image uses CFG-free distilled.
+        _cfg_default = float(os.environ.get("GUAARDVARK_ZIMAGE_CFG", "1.0"))
+        cfg = float(guidance) if guidance is not None and float(guidance) >= 1.0 else _cfg_default
+
+        path = gen.generate_image(
+            prompt=prompt,
+            output_path=out_path or str(Path("/tmp") / f"zimage_{uuid.uuid4().hex[:8]}.png"),
+            width=width,
+            height=height,
+            negative_prompt=negative or "",
+            seed=seed if seed is not None else 42,
+            model="zimage",
+            steps=steps,
+            cfg=cfg,
         )
         url = None
         if output == "chat_copy" and path:

--- a/backend/services/stills_pipeline.py
+++ b/backend/services/stills_pipeline.py
@@ -498,20 +498,20 @@ def _comfyui_backend_choice() -> tuple[str, str] | None:
     """
     try:
         from backend.services.comfyui_image_generator import ComfyUIImageGenerator
-        from backend.services.offline_image_generator import OfflineImageGenerator
 
         gen = ComfyUIImageGenerator()
         if not gen._available():
             return None
 
-        # Prefer Z-Image Turbo if its assets are installed, then FLUX-dev, then
-        # FLUX-schnell. This makes /imagemodel comfyui an honest auto-backend.
-        if OfflineImageGenerator._zimage_assets_present():
-            return ("zimage", "zimage")
-        if OfflineImageGenerator._flux_dev_assets_present():
-            return ("flux-dev", "flux-dev")
-        if OfflineImageGenerator._flux_schnell_assets_present():
-            return ("flux-schnell", "flux")
+        # Authoritative check against the live server's /object_info — this finds
+        # engines on an external Comfy Desktop install as well as the bundled one.
+        for engine in gen.comfyui_installed_engines():
+            if engine == "zimage":
+                return ("zimage", "zimage")
+            if engine == "flux-dev":
+                return ("flux-dev", "flux-dev")
+            if engine == "flux-schnell":
+                return ("flux-schnell", "flux")
         return None
     except Exception:
         return None

--- a/backend/services/system_load_gate.py
+++ b/backend/services/system_load_gate.py
@@ -60,6 +60,23 @@ VRAM_HARD_MIN_GB = 1.5     # below this free VRAM -> hard block
 VRAM_WARN_MIN_GB = 3.0     # below this -> warn (still admit)
 LOADAVG_HARD_MAX = 18.0    # 1-min loadavg above this -> hard block
 
+
+def _swap_hard_max_gb() -> float:
+    """Swap hard-block threshold, overridable via GUAARDVARK_SWAP_HARD_MAX_GB.
+
+    The 8 GB default is tuned for the 60 GB RAM Linux box that motivated this
+    gate. macOS (Apple Silicon) holds swap "sticky" — it does not release it
+    promptly after apps close — so a fixed 8 GB cap can permanently block
+    legitimate work on a healthy Mac. Operators can raise it via env.
+    """
+    raw = os.environ.get("GUAARDVARK_SWAP_HARD_MAX_GB", "").strip()
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning("Invalid GUAARDVARK_SWAP_HARD_MAX_GB=%r; using default", raw)
+    return SWAP_HARD_MAX_GB
+
 # How long an admitted job's RAM reservation lingers to cover subprocess
 # "shadow RAM" before psutil reflects it.
 RESERVED_RAM_TTL_S = 60.0
@@ -209,8 +226,8 @@ class GlobalLoadGate:
                 f"(reserved {reading.reserved_ram_gb:.1f} GB), "
                 f"need {weight.ram_gb:.1f} GB + {ram_floor:.1f} GB floor"
             )
-        if reading.swap_used_gb > SWAP_HARD_MAX_GB:
-            return f"swap in use: {reading.swap_used_gb:.1f} GB > {SWAP_HARD_MAX_GB:.0f} GB"
+        if reading.swap_used_gb > _swap_hard_max_gb():
+            return f"swap in use: {reading.swap_used_gb:.1f} GB > {_swap_hard_max_gb():.0f} GB"
         if reading.loadavg_1m > LOADAVG_HARD_MAX:
             return f"loadavg high: {reading.loadavg_1m:.1f} > {LOADAVG_HARD_MAX:.0f}"
         # VRAM only blocks when we actually know it (None == unknown == OK).

--- a/backend/tasks/character_generation_tasks.py
+++ b/backend/tasks/character_generation_tasks.py
@@ -518,7 +518,8 @@ def generate_samples(subject_id: int, job_id: str | None = None, use_lora: bool 
     cancelled = False
     offline_gen = None
     comfy_gen = None
-    if route.get("engine") == "offline":
+    use_comfy = route.get("engine") == "comfy"
+    if not use_comfy:
         from backend.services.offline_image_generator import get_image_generator
         offline_gen = get_image_generator()
     else:
@@ -530,7 +531,10 @@ def generate_samples(subject_id: int, job_id: str | None = None, use_lora: bool 
             JobKind.VIDEO_RENDER,
             f"char_samples_{subject_id}",
             evict_ollama=True,
-            free_comfyui=True,
+            # Only unload ComfyUI's resident models when we are NOT rendering
+            # through ComfyUI. Freeing them on the Comfy path would force a full
+            # Z-Image reload (and apparent "restart") on every generation.
+            free_comfyui=not use_comfy,
             vram_estimate_mb=int(route.get("vram_estimate_mb") or 11000),
             require_fit=True,
             cross_process=True,

--- a/backend/tasks/lora_trainer_tasks.py
+++ b/backend/tasks/lora_trainer_tasks.py
@@ -320,6 +320,13 @@ def train_subject_lora_for_subject(subject_id: int, job_id: str | None = None) -
         s.lora_version = result.get("lora_version", 1)
         s.training_status = "trained"
         s.training_error = None
+        # When Z-Image is routed through ComfyUI, link the freshly-trained LoRA into
+        # ComfyUI's models/loras so generation can resolve it by basename.
+        try:
+            from backend.services.comfyui_image_generator import ensure_lora_in_comfyui
+            ensure_lora_in_comfyui(s.lora_path)
+        except Exception:
+            pass
         from datetime import datetime
         s.last_trained_at = datetime.utcnow()
 

--- a/backend/tests/services/test_character_still_pipeline.py
+++ b/backend/tests/services/test_character_still_pipeline.py
@@ -21,7 +21,8 @@ def zimage_route():
     }
 
 
-def test_render_injects_trigger_and_uses_offline_for_zimage(tmp_path, zimage_route):
+def test_render_injects_trigger_and_uses_offline_for_zimage(tmp_path, zimage_route, monkeypatch):
+    monkeypatch.delenv("GUAARDVARK_ZIMAGE_USE_COMFYUI", raising=False)
     out = tmp_path / "out.png"
     out.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
 
@@ -82,6 +83,55 @@ def test_render_injects_trigger_and_uses_offline_for_zimage(tmp_path, zimage_rou
         Comfy.assert_not_called()
 
 
+def test_render_routes_zimage_to_comfy_when_opted_in(tmp_path, zimage_route, monkeypatch):
+    monkeypatch.setenv("GUAARDVARK_ZIMAGE_USE_COMFYUI", "1")
+    out = tmp_path / "out.png"
+    out.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+
+    class Subj:
+        lora_path = str(tmp_path / "char.safetensors")
+        trigger_word = "hero_tok"
+        name = "Hero"
+        bible = "long invented paragraph"
+        training_settings_json = {
+            "base_model_id": "zimage-turbo",
+            "class_token": "man",
+            "bible_identity_marks": "teal highlights",
+        }
+
+    (tmp_path / "char.safetensors").write_bytes(b"x" * 200)
+
+    with patch(
+        "backend.services.media_model_registry.resolve_inference_for_loras",
+        return_value=zimage_route,
+    ), patch(
+        "backend.services.offline_image_generator.get_image_generator"
+    ) as get_gen, patch(
+        "backend.services.comfyui_image_generator.ComfyUIImageGenerator"
+    ) as Comfy:
+        comfy_gen = MagicMock()
+        comfy_gen.generate_image.return_value = str(out)
+        Comfy.return_value = comfy_gen
+
+        still = render_character_still(
+            "neon alley at night",
+            subjects=[Subj()],
+            include_bible=False,
+            source="cast",
+            output_path=str(tmp_path / "dest.png"),
+            width=512,
+            height=512,
+        )
+
+        assert still.success is True
+        assert still.metadata.get("family") == "zimage"
+        assert still.metadata.get("engine") == "comfy"
+        Comfy.assert_called_once()
+        comfy_gen.generate_image.assert_called_once()
+        assert comfy_gen.generate_image.call_args[1]["model"] == "zimage"
+        get_gen.assert_not_called()
+
+
 def test_render_refuses_mixed_family_error(tmp_path):
     with patch(
         "backend.services.media_model_registry.resolve_inference_for_loras",
@@ -96,7 +146,8 @@ def test_render_refuses_mixed_family_error(tmp_path):
         assert "family" in (still.error or "").lower() or "mixed" in (still.error or "").lower()
 
 
-def test_render_without_lora_returns_still_result_type():
+def test_render_without_lora_returns_still_result_type(monkeypatch):
+    monkeypatch.delenv("GUAARDVARK_ZIMAGE_USE_COMFYUI", raising=False)
     # Empty path: still returns StillResult (may fail offline without GPU — mock).
     with patch(
         "backend.services.offline_image_generator.get_image_generator"

--- a/backend/tests/services/test_comfyui_image_lora_branch.py
+++ b/backend/tests/services/test_comfyui_image_lora_branch.py
@@ -28,6 +28,31 @@ def _build(model: str, lora_names: list[str]) -> dict:
     )
 
 
+def _build_zimage(lora_names: list[str], monkeypatch) -> dict:
+    """Build on the Z-Image branch with Z-Image sidecars so the registry does not
+    fall back to the legacy SDXL default (which reroutes the branch)."""
+    from backend.services import media_model_registry as mmr
+
+    def fake_resolve(lora_paths):
+        return {
+            "base_model_id": "zimage-turbo",
+            "family": "zimage",
+            "inference_engine": "offline",
+            "comfy_model_tag": "zimage",
+            "offline_model_key": "zimage-turbo",
+            "lora_format": "zimage",
+            "profile": {"id": "zimage-turbo", "family": "zimage", "comfy_model_tag": "zimage"},
+        }
+
+    monkeypatch.setattr(mmr, "resolve_inference_for_loras", fake_resolve)
+    gen = ComfyUIImageGenerator(model="zimage")
+    return gen._build_workflow(
+        prompt="sage_harlow, cinematic portrait", negative="",
+        lora_names=lora_names, width=1024, height=1024,
+        seed=1, steps=28, cfg=1.0, model="zimage",
+    )
+
+
 def test_flux_schnell_with_loras_does_not_drop_them():
     # The flux-schnell branch has no LoRA nodes; the guard must reroute to SDXL
     # so the LoRA is actually applied.
@@ -58,3 +83,37 @@ def test_flux_without_loras_keeps_flux_branch():
     types = _class_types(wf)
     assert "UnetLoaderGGUF" in types
     assert "LoraLoader" not in types
+
+
+def test_zimage_with_loras_builds_model_only_lora_chain(monkeypatch):
+    # Z-Image character LoRAs train only the transformer (not the text encoder),
+    # so they must be applied model-only via LoraLoaderModelOnly on the Z-Image
+    # branch. This is the identity-lock route for trained Z-Image LoRAs in ComfyUI.
+    wf = _build_zimage(["zimage_elara_v1.safetensors"], monkeypatch)
+    types = _class_types(wf)
+    assert "UNETLoader" in types, "should stay on the Z-Image branch"
+    assert "LoraLoaderModelOnly" in types, "Z-Image LoRA must be applied model-only"
+    assert "ModelSamplingAuraFlow" in types, "Z-Image sampler still wraps the UNet"
+    # The LoRA chain must feed the sampler (not the raw unet), so identity applies.
+    sampling_inputs = wf["sampling"]["inputs"]
+    assert sampling_inputs["model"][0] == "lora_0", "AuraFlow should wrap the LoRA output"
+    assert wf["sampler"]["inputs"]["model"] == ["sampling", 0]
+
+
+def test_zimage_reroutes_sdxl_loras_to_sdxl_branch(monkeypatch):
+    # An SDXL-format LoRA requested on a Z-Image model must reroute to SDXL so it
+    # is applied (LoraLoader), not loaded into a Z-Image graph that would reject it.
+    wf = _build("zimage", ["sage_harlow_v3.safetensors"])
+    types = _class_types(wf)
+    assert "LoraLoader" in types
+    assert "DiffusersLoader" in types
+    assert "LoraLoaderModelOnly" not in types
+
+
+def test_zimage_without_loras_has_no_lora_node(monkeypatch):
+    wf = _build_zimage([], monkeypatch)
+    types = _class_types(wf)
+    assert "LoraLoaderModelOnly" not in types
+    assert "LoraLoader" not in types
+    # UNet still feeds AuraFlow sampling directly.
+    assert wf["sampling"]["inputs"]["model"] == ["unet", 0]

--- a/frontend/src/hooks/slashCommandHandlers.js
+++ b/frontend/src/hooks/slashCommandHandlers.js
@@ -198,6 +198,14 @@ const KONTEXT_EDIT_OPTION = {
   is_downloaded: true,
 };
 
+// Generic ComfyUI backend — always selectable in chat even when no ComfyUI
+// assets are installed yet, since it routes to whatever engine ComfyUI has.
+const COMFYUI_MODEL_OPTION = {
+  id: "comfyui",
+  name: "ComfyUI (auto backend)",
+  is_downloaded: true,
+};
+
 async function handleImageModel(args, { addMessage }) {
   if (!args) {
     try {
@@ -209,6 +217,7 @@ async function handleImageModel(args, { addMessage }) {
       const models = data?.data?.models || data?.models || [];
       const downloaded = [
         KONTEXT_EDIT_OPTION,
+        COMFYUI_MODEL_OPTION,
         ...models.filter((m) => m.is_downloaded),
       ];
       addMessage({
@@ -239,6 +248,19 @@ async function handleImageModel(args, { addMessage }) {
     return { handled: true };
   }
 
+  // "comfyui" is a backend selector, not a downloadable model — accept it
+  // regardless of asset status (the backend picks whatever engine is installed).
+  if (modelName === "comfyui") {
+    await saveImageModelChoice("comfyui");
+    addMessage({
+      role: "system",
+      content: "Image model switched to **comfyui** (ComfyUI auto backend). Generation will use the installed Z-Image or FLUX engine.",
+      tempId: `imgmodel-${Date.now()}`,
+      type: "command",
+    });
+    return { handled: true };
+  }
+
   try {
     const res = await fetch("/api/batch-image/models");
     const data = await res.json();
@@ -262,7 +284,7 @@ async function handleImageModel(args, { addMessage }) {
         });
       }
     } else {
-      const available = ["kontext", ...models.filter((m) => m.is_downloaded).map((m) => m.id)].join(", ");
+      const available = ["kontext", "comfyui", ...models.filter((m) => m.is_downloaded).map((m) => m.id)].join(", ");
       addMessage({
         role: "system",
         content: `Model \`${modelName}\` not found. Available: ${available}`,


### PR DESCRIPTION
## M3 — ComfyUI image generation (Z-Image)

Adds Z-Image ComfyUI image generation across the stills/character pipelines.

### Contents
- **ComfyUI generator** — `comfyui_image_generator.py` Z-Image engine + LoRA branch.
- **Batch/stills pipelines** — `batch_image_generator.py`, `stills_pipeline.py`, `stills_defaults.py` wire the ComfyUI family.
- **Character pipeline** — `character_generator_service.py` / `character_still_pipeline.py` ComfyUI path.
- **Load gate** — `system_load_gate.py` accounts for ComfyUI.
- **Tests** — ComfyUI LoRA branch + character still pipeline coverage.

### Smoke test
- Z-Image still generation via ComfyUI.